### PR TITLE
Reduce NIO event loop group size (fixes #9)

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsClientThread.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsClientThread.java
@@ -180,7 +180,7 @@ class ApnsClientThread<T extends ApnsPushNotification> extends Thread {
 		this.sentNotificationBuffer = new SentNotificationBuffer<T>(SENT_NOTIFICATION_BUFFER_SIZE);
 		
 		this.bootstrap = new Bootstrap();
-		this.bootstrap.group(new NioEventLoopGroup());
+		this.bootstrap.group(new NioEventLoopGroup(1));
 		this.bootstrap.channel(NioSocketChannel.class);
 		this.bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
 		

--- a/src/main/java/com/relayrides/pushy/apns/FeedbackServiceClient.java
+++ b/src/main/java/com/relayrides/pushy/apns/FeedbackServiceClient.java
@@ -142,7 +142,7 @@ class FeedbackServiceClient {
 		this.environment = pushManager.getEnvironment();
 		
 		this.bootstrap = new Bootstrap();
-		this.bootstrap.group(new NioEventLoopGroup());
+		this.bootstrap.group(new NioEventLoopGroup(1));
 		this.bootstrap.channel(NioSocketChannel.class);
 		
 		final FeedbackServiceClient feedbackClient = this;


### PR DESCRIPTION
This reduces the size of the thread pools associated with each `ApnsClientThread` and `FeedbackServiceClient` to just a single thread. This covers most of #9.
