### PR TITLE
Expose RejectedNotification tuple instead of RejectedNotificationReason

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsClientThread.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsClientThread.java
@@ -536,7 +536,7 @@ class ApnsClientThread<T extends ApnsPushNotification> extends Thread {
 			if (rejectedNotification.getReason() != RejectedNotificationReason.SHUTDOWN) {
 				this.pushManager.notifyListenersOfRejectedNotification(
 						this.sentNotificationBuffer.getAndRemoveNotificationWithSequenceNumber(
-								rejectedNotification.getSequenceNumber()), rejectedNotification.getReason());
+								rejectedNotification.getSequenceNumber()), rejectedNotification);
 			}
 		}
 		

--- a/src/main/java/com/relayrides/pushy/apns/PushManager.java
+++ b/src/main/java/com/relayrides/pushy/apns/PushManager.java
@@ -349,7 +349,7 @@ public class PushManager<T extends ApnsPushNotification> {
 		this.rejectedNotificationListeners.add(new WeakReference<RejectedNotificationListener<T>>(listener));
 	}
 	
-	protected synchronized void notifyListenersOfRejectedNotification(final T notification, final RejectedNotificationReason reason) {
+	protected synchronized void notifyListenersOfRejectedNotification(final T notification, final RejectedNotification rejectedNotification) {
 
 		final ArrayList<RejectedNotificationListener<T>> listeners = new ArrayList<RejectedNotificationListener<T>>();
 		final ArrayList<Integer> expiredListenerIndices = new ArrayList<Integer>();
@@ -369,7 +369,7 @@ public class PushManager<T extends ApnsPushNotification> {
 
 			public void run() {
 				for (final RejectedNotificationListener<T> listener : listeners) {
-					listener.handleRejectedNotification(notification, reason);
+					listener.handleRejectedNotification(notification, rejectedNotification);
 				}
 			}
 			

--- a/src/main/java/com/relayrides/pushy/apns/RejectedNotification.java
+++ b/src/main/java/com/relayrides/pushy/apns/RejectedNotification.java
@@ -26,7 +26,7 @@ package com.relayrides.pushy.apns;
  *
  * @author <a href="mailto:jon@relayrides.com">Jon Chambers</a>
  */
-class RejectedNotification {
+public class RejectedNotification {
 	private final int sequenceNumber;
 	private final RejectedNotificationReason rejectionReason;
 	

--- a/src/main/java/com/relayrides/pushy/apns/RejectedNotificationListener.java
+++ b/src/main/java/com/relayrides/pushy/apns/RejectedNotificationListener.java
@@ -39,7 +39,7 @@ public interface RejectedNotificationListener<T extends ApnsPushNotification> {
 	 * Handles a permanent push notification rejection.
 	 *  
 	 * @param notification the notification rejected by the APNs server
-	 * @param rejectionReason the reason reported by APNs for the rejection
+	 * @param rejectedNotification the reason reported by APNs for the rejection
 	 */
-	void handleRejectedNotification(T notification, RejectedNotificationReason rejectionReason);
+	void handleRejectedNotification(T notification, RejectedNotification rejectedNotification);
 }

--- a/src/test/java/com/relayrides/pushy/apns/PushManagerTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/PushManagerTest.java
@@ -21,9 +21,7 @@
 
 package com.relayrides.pushy.apns;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import io.netty.channel.nio.NioEventLoopGroup;
 
 import java.util.concurrent.CountDownLatch;
@@ -39,7 +37,7 @@ public class PushManagerTest extends BasePushyTest {
 		
 		private final AtomicInteger rejectedNotificationCount = new AtomicInteger(0);
 
-		public void handleRejectedNotification(final SimpleApnsPushNotification notification, final RejectedNotificationReason reason) {
+		public void handleRejectedNotification(final SimpleApnsPushNotification notification, final RejectedNotification reason) {
 			this.rejectedNotificationCount.incrementAndGet();
 		}
 		


### PR DESCRIPTION
If not, sequenceNumber is not exposed. It's very useful for debugging.
