### PR TITLE
Always wait for remote closure

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsClientThread.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsClientThread.java
@@ -189,6 +189,7 @@ class ApnsClientThread<T extends ApnsPushNotification> extends Thread {
 
 		@Override
 		public void channelInactive(final ChannelHandlerContext context) {
+			log.debug(String.format("%s became inactive.", getName()));
 			this.clientThread.requestReconnection();
 		}
 	}


### PR DESCRIPTION
This fixes some wacky read issues and race conditions. Now, instead of closing the connection on our own if we suspect there was a problem, we'll always wait for the APNs gateway to close the connection on us. This should mean that we can always get rejected notification data without resorting to unsafe reads.

Although the Netty folks don't think it should be a problem, I'm most worried about cases where we somehow miss that the remote connection has closed and wind up with a zombie thread. I THINK that should be covered by the explicit (safe) read request in 417400a, though.
