### PR TITLE
Disable `SO_KEEPALIVE`

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -288,7 +288,6 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 		final Bootstrap bootstrap = new Bootstrap();
 		bootstrap.group(this.eventLoopGroup);
 		bootstrap.channel(NioSocketChannel.class);
-		bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
 		bootstrap.option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
 
 		// TODO Remove this when Netty 5 is available


### PR DESCRIPTION
I think it's a good idea to turn off the `SO_KEEPALIVE` option. It really only affects things on the time scale of hours (says the RFC), and even then isn't super reliable.
