### PR TITLE
Fixed NullPtrException on channelRegistered in ApnsConnection

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -230,10 +230,12 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 		public void channelRegistered(final ChannelHandlerContext context) throws Exception {
 			super.channelRegistered(context);
 
-			synchronized (this.apnsConnection.connectFuture) {
-				if (this.apnsConnection.closeOnRegistration) {
-					log.debug("Channel registered for {}, but shutting down immediately.", this.apnsConnection.name);
-					context.channel().eventLoop().execute(this.apnsConnection.getImmediateShutdownRunnable());
+			if (this.apnsConnection.connectFuture != null) {
+				synchronized (this.apnsConnection.connectFuture) {
+					if (this.apnsConnection.closeOnRegistration) {
+						log.debug("Channel registered for {}, but shutting down immediately.", this.apnsConnection.name);
+						context.channel().eventLoop().execute(this.apnsConnection.getImmediateShutdownRunnable());
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixed possible NullPointerException on race condition, when channel is registered before field is set.
Not however, that using non-final field that is not even initialized in constructor is anti-pattern. There should be other object used for synchronize. If you wish to make this more correct fix, let me know. This fixes the problem thou. 
