### PR TITLE
Automatic delay for replacing failed connections to avoid servers throttling

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -95,6 +95,7 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 	private static final Logger log = LoggerFactory.getLogger(ApnsConnection.class);
 
 	public static final int DEFAULT_SENT_NOTIFICATION_BUFFER_CAPACITY = 8192;
+	public static final long DEFAULT_MAX_RECONNECT_DELAY = 300000; // 5min
 
 	protected enum ApnsFrameItem {
 		DEVICE_TOKEN((byte)1),

--- a/src/test/java/com/relayrides/pushy/apns/PushManagerTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/PushManagerTest.java
@@ -161,7 +161,7 @@ public class PushManagerTest extends BasePushyTest {
 		{
 			final PushManager<ApnsPushNotification> defaultGroupPushManager =
 					new PushManager<ApnsPushNotification>(TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(),
-							1, null, null, null, ApnsConnection.DEFAULT_SENT_NOTIFICATION_BUFFER_CAPACITY);
+							1, null, null, null, ApnsConnection.DEFAULT_SENT_NOTIFICATION_BUFFER_CAPACITY, ApnsConnection.DEFAULT_MAX_RECONNECT_DELAY);
 
 			defaultGroupPushManager.start();
 			defaultGroupPushManager.shutdown();
@@ -174,7 +174,7 @@ public class PushManagerTest extends BasePushyTest {
 
 			final PushManager<ApnsPushNotification> providedGroupPushManager =
 					new PushManager<ApnsPushNotification>(TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(),
-							1, group, null, null, ApnsConnection.DEFAULT_SENT_NOTIFICATION_BUFFER_CAPACITY);
+							1, group, null, null, ApnsConnection.DEFAULT_SENT_NOTIFICATION_BUFFER_CAPACITY, ApnsConnection.DEFAULT_MAX_RECONNECT_DELAY);
 
 			providedGroupPushManager.start();
 			providedGroupPushManager.shutdown();
@@ -190,7 +190,7 @@ public class PushManagerTest extends BasePushyTest {
 
 			final PushManager<ApnsPushNotification> providedExecutorServicePushManager =
 					new PushManager<ApnsPushNotification>(TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(),
-							1, null, listenerExecutorService, null, ApnsConnection.DEFAULT_SENT_NOTIFICATION_BUFFER_CAPACITY);
+							1, null, listenerExecutorService, null, ApnsConnection.DEFAULT_SENT_NOTIFICATION_BUFFER_CAPACITY, ApnsConnection.DEFAULT_MAX_RECONNECT_DELAY);
 
 			providedExecutorServicePushManager.start();
 			providedExecutorServicePushManager.shutdown();
@@ -235,7 +235,7 @@ public class PushManagerTest extends BasePushyTest {
 	public void testDoubleStart() throws Exception {
 		final PushManager<ApnsPushNotification> doubleStartPushManager =
 				new PushManager<ApnsPushNotification>(TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), 1,
-						null, null, null, ApnsConnection.DEFAULT_SENT_NOTIFICATION_BUFFER_CAPACITY);
+						null, null, null, ApnsConnection.DEFAULT_SENT_NOTIFICATION_BUFFER_CAPACITY, ApnsConnection.DEFAULT_MAX_RECONNECT_DELAY);
 
 		doubleStartPushManager.start();
 		doubleStartPushManager.start();
@@ -245,7 +245,7 @@ public class PushManagerTest extends BasePushyTest {
 	public void testPrematureShutdown() throws Exception {
 		final PushManager<ApnsPushNotification> prematureShutdownPushManager =
 				new PushManager<ApnsPushNotification>(TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), 1,
-						null, null, null, ApnsConnection.DEFAULT_SENT_NOTIFICATION_BUFFER_CAPACITY);
+						null, null, null, ApnsConnection.DEFAULT_SENT_NOTIFICATION_BUFFER_CAPACITY, ApnsConnection.DEFAULT_MAX_RECONNECT_DELAY);
 
 		prematureShutdownPushManager.shutdown();
 	}
@@ -254,7 +254,7 @@ public class PushManagerTest extends BasePushyTest {
 	public void testRepeatedShutdown() throws Exception {
 		final PushManager<ApnsPushNotification> repeatedShutdownPushManager =
 				new PushManager<ApnsPushNotification>(TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), 1,
-						null, null, null, ApnsConnection.DEFAULT_SENT_NOTIFICATION_BUFFER_CAPACITY);
+						null, null, null, ApnsConnection.DEFAULT_SENT_NOTIFICATION_BUFFER_CAPACITY, ApnsConnection.DEFAULT_MAX_RECONNECT_DELAY);
 
 		repeatedShutdownPushManager.start();
 		repeatedShutdownPushManager.shutdown();
@@ -421,7 +421,7 @@ public class PushManagerTest extends BasePushyTest {
 					CountDownLatch latch) {
 
 				super(environment, sslContext, concurrentConnectionCount, eventLoopGroup, null, queue,
-						ApnsConnection.DEFAULT_SENT_NOTIFICATION_BUFFER_CAPACITY);
+						ApnsConnection.DEFAULT_SENT_NOTIFICATION_BUFFER_CAPACITY, ApnsConnection.DEFAULT_MAX_RECONNECT_DELAY);
 
 				this.latch = latch;
 			}


### PR DESCRIPTION
When there is a problem with connection, either wrong SSL certificate or any other reason connection is rejected, pushy ends up in infinite loop, causing hundreds connection attempts in second, eating up system resources but more can block server ip in firewall or Apple itself.

I've added automatic delaying of reopening failed connection, starting at 100ms and increasing up tu 5mins by default. Does not affect reopening of gracefully closed connection.
Can be disabled by setting maxReconnectDelay on PushManager to 0.

_It is missing proper unit tests, as I'm solving development issue and I don't have time to investigate how to write such complex test. Sorry about that, I like to have everything tested otherwise._

Any feedback is welcome. For me, this feature is must-have.
