### PR TITLE
Expose the number of writable connections

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/PushManager.java
+++ b/src/main/java/com/relayrides/pushy/apns/PushManager.java
@@ -555,6 +555,15 @@ public class PushManager<T extends ApnsPushNotification> implements ApnsConnecti
 		return this.feedbackServiceClient.getExpiredTokens(timeout, timeoutUnit);
 	}
 
+    /**
+     * <p>Returns the number of writable connections. A connection is considered writable after the SSL handshake has succeeded. </p>
+     *
+     * @return the number of writable connections
+     */
+    public int getNumberOfWritableConnections() {
+        return writableConnectionPool.getAll().size();
+    }
+
 	/*
 	 * (non-Javadoc)
 	 * @see com.relayrides.pushy.apns.ApnsConnectionListener#handleConnectionSuccess(com.relayrides.pushy.apns.ApnsConnection)


### PR DESCRIPTION
This change would allow clients using the PushMonitor to ascertain whether there are currently any usable  connections to APNS. This information is useful for upstream service monitoring as it is not possible to reliably figure this out only by listening for failed connections.
