### PR TITLE
Expose writable connection count

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/PushManager.java
+++ b/src/main/java/com/relayrides/pushy/apns/PushManager.java
@@ -555,6 +555,15 @@ public class PushManager<T extends ApnsPushNotification> implements ApnsConnecti
 		return this.feedbackServiceClient.getExpiredTokens(timeout, timeoutUnit);
 	}
 
+    /**
+     * <p>Returns the number of writable connections. A connection is considered writable after the SSL handshake has succeeded. </p>
+     *
+     * @return the number of writable connections
+     */
+    public int getNumberOfWritableConnections() {
+        return writableConnectionPool.getAll().size();
+    }
+
 	/*
 	 * (non-Javadoc)
 	 * @see com.relayrides.pushy.apns.ApnsConnectionListener#handleConnectionSuccess(com.relayrides.pushy.apns.ApnsConnection)

--- a/src/test/java/com/relayrides/pushy/apns/PushManagerTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/PushManagerTest.java
@@ -497,12 +497,12 @@ public class PushManagerTest extends BasePushyTest {
 
     @Test
     public void testReturnsCorrectNumberOfWritableConnectionsWhenThereAreConcurrentConnections() throws Exception {
-        final PushManagerFactory<SimpleApnsPushNotification> factory =
-                new PushManagerFactory<SimpleApnsPushNotification>(TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient());
-        factory.setEventLoopGroup(this.getEventLoopGroup());
-        factory.setConcurrentConnectionCount(4);
+        final PushManagerConfiguration configuration = new PushManagerConfiguration();
+        		configuration.setConcurrentConnectionCount(4);
 
-        final PushManager<SimpleApnsPushNotification> parallelPushManager = factory.buildPushManager();
+        final PushManager<SimpleApnsPushNotification> parallelPushManager =
+                new PushManager<SimpleApnsPushNotification>(TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(), null, null, configuration);
+
         final int iterations = 10;
         final CountDownLatch latch = this.getApnsServer().getAcceptedNotificationCountDownLatch(iterations);
 
@@ -521,11 +521,10 @@ public class PushManagerTest extends BasePushyTest {
 
     @Test
     public void testWritableCountNotIncrementedForFailedConnection() throws Exception {
-        final PushManagerFactory<SimpleApnsPushNotification> factory =
-                new PushManagerFactory<SimpleApnsPushNotification>(
-                        TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient("/pushy-test-client-untrusted.jks"));
-
-        final PushManager<SimpleApnsPushNotification> badCredentialManager = factory.buildPushManager();
+        final PushManager<SimpleApnsPushNotification> badCredentialManager =
+        				new PushManager<SimpleApnsPushNotification>(TEST_ENVIRONMENT,
+        						SSLTestUtil.createSSLContextForTestClient("/pushy-test-client-untrusted.jks"), null,
+        						null, null, new PushManagerConfiguration());
 
         final Object monitor = new Object();
         final TestFailedConnectionListener listener = new TestFailedConnectionListener(monitor);


### PR DESCRIPTION
This change would allow clients using the PushMonitor to ascertain whether there are currently any usable connections to APNS. This information is useful for upstream service monitoring as it is not possible to reliably figure this out only by listening for failed connections.