### PR TITLE
Adding support for title and its localized version - new in iOS 8.2

### DIFF
--- a/src/test/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -68,6 +68,20 @@ public class ApnsPayloadBuilderTest {
 		}
 	}
 
+	@Test
+	public void testSetAlertTitle() throws ParseException {
+		final String alertTitle = "This is a test alert message.";
+
+		this.builder.setAlertTitle(alertTitle);
+
+		{
+			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+			final JSONObject alert = (JSONObject) aps.get("alert");
+
+			assertEquals(alertTitle, alert.get("title"));
+		}
+	}
+
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testSetLocalizedAlertMessage() throws ParseException {
@@ -107,6 +121,18 @@ public class ApnsPayloadBuilderTest {
 	public void testSetLocalizedAlertWithExistingAlertBody() {
 		this.builder.setAlertBody("Test");
 		this.builder.setLocalizedAlertMessage("Test", null);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testSetAlertTitleWithExistingLocalizedAlertTitle() {
+		this.builder.setLocalizedAlertTitle("Test", null);
+		this.builder.setAlertTitle("Test");
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testSetLocalizedAlertTitleWithExistingAlertTitle() {
+		this.builder.setAlertTitle("Test");
+		this.builder.setLocalizedAlertTitle("Test", null);
 	}
 
 	@Test


### PR DESCRIPTION
The new `title`, `title-loc-key` and `title-loc-args` are described in here:
https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html

Especially interesting for Apple Watch:

* _"On Apple Watch, the title key alerts the user to the new request."_
* _"Apple Watch displays this string as part of the notification interface. This string is displayed only briefly and should be crafted so that it can be understood quickly. This key was added in iOS 8.2."_