### PR TITLE
Known-bad rejection handling (fixes #149)

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -281,13 +281,17 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 
 			// Regardless of the cause, we ALWAYS want to notify listeners that some sent notifications were not
 			// processed by the gateway (assuming there are some such notifications).
-			final Collection<T> unprocessedNotifications =
-					this.apnsConnection.sentNotificationBuffer.getAllNotificationsAfterSequenceNumber(
-							rejectedNotification.getSequenceNumber());
+			// Unless the sequence number was erroneously reported as 0, in which case we don't know the actual
+			// sequence number, and can't determine what was sent after the bad notification.
+			if (rejectedNotification.getSequenceNumber() != 0) {
+				final Collection<T> unprocessedNotifications =
+						this.apnsConnection.sentNotificationBuffer.getAllNotificationsAfterSequenceNumber(
+								rejectedNotification.getSequenceNumber());
 
-			if (!unprocessedNotifications.isEmpty()) {
-				if (this.apnsConnection.listener != null) {
-					this.apnsConnection.listener.handleUnprocessedNotifications(this.apnsConnection, unprocessedNotifications);
+				if (!unprocessedNotifications.isEmpty()) {
+					if (this.apnsConnection.listener != null) {
+						this.apnsConnection.listener.handleUnprocessedNotifications(this.apnsConnection, unprocessedNotifications);
+					}
 				}
 			}
 

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -254,7 +254,8 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 			this.apnsConnection.sentNotificationBuffer.clearNotificationsBeforeSequenceNumber(rejectedNotification.getSequenceNumber());
 
 			final boolean isKnownBadRejection = this.apnsConnection.shutdownNotification != null &&
-					rejectedNotification.getSequenceNumber() == this.apnsConnection.shutdownNotification.getSequenceNumber();
+					(rejectedNotification.getSequenceNumber() == this.apnsConnection.shutdownNotification.getSequenceNumber()
+					|| rejectedNotification.getSequenceNumber() == 0);
 
 			// We only want to notify listeners of an actual rejection if something actually went wrong. We don't want
 			// to notify listeners if a known-bad notification was rejected because that's an expected case, and we

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -255,7 +255,7 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 
 			final boolean isKnownBadRejection = this.apnsConnection.shutdownNotification != null &&
 					(rejectedNotification.getSequenceNumber() == this.apnsConnection.shutdownNotification.getSequenceNumber()
-					|| rejectedNotification.getSequenceNumber() == 0);
+					|| (rejectedNotification.getSequenceNumber() == 0 && RejectedNotificationReason.MISSING_TOKEN.equals(rejectedNotification.getReason())));
 
 			// We only want to notify listeners of an actual rejection if something actually went wrong. We don't want
 			// to notify listeners if a known-bad notification was rejected because that's an expected case, and we


### PR DESCRIPTION
This is a bugfix for #149. If the PushManager has sent the known-bad packet, and we then get a rejection message regarding sequence number 0, we will assume it was the known-bad packet and handle it accordingly.

Given that the first message we send has sequence number 1, it is unlikely that a legitimate rejection message for sequence number 0 would ever be received, unless we had sent more than 2^32 messages (about 4 billion) in one session. Nonetheless, the behaviour of assuming that sequence number 0 is the known-bad packet only applies *after* the known-bad packet has been sent.