### PR TITLE
Format ExpiredToken token to readable string

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ExpiredToken.java
+++ b/src/main/java/com/relayrides/pushy/apns/ExpiredToken.java
@@ -24,6 +24,8 @@ package com.relayrides.pushy.apns;
 import java.util.Arrays;
 import java.util.Date;
 
+import com.relayrides.pushy.apns.util.TokenUtil;
+
 /**
  * <p>Represents a device token that the APN Feedback Service has reported as expired. According to Apple's
  * documentation:</p>
@@ -110,7 +112,7 @@ public class ExpiredToken {
 	 */
 	@Override
 	public String toString() {
-		return "ExpiredToken [token=" + Arrays.toString(token)
+		return "ExpiredToken [token=" + TokenUtil.tokenBytesToString(token)
 				+ ", expiration=" + expiration + "]";
 	}
 }

--- a/src/test/java/com/relayrides/pushy/apns/ExpiredTokenTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/ExpiredTokenTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 public class ExpiredTokenTest {
 
     @Test(expected = NullPointerException.class)
-    public void ConstructorCantHandleNullToken() {
+    public void constructorCantHandleNullToken() {
         new ExpiredToken(null, new java.util.Date());
     }
 }

--- a/src/test/java/com/relayrides/pushy/apns/ExpiredTokenTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/ExpiredTokenTest.java
@@ -1,0 +1,11 @@
+package com.relayrides.pushy.apns;
+
+import org.junit.Test;
+
+public class ExpiredTokenTest {
+
+    @Test(expected = NullPointerException.class)
+    public void ConstructorCantHandleNullToken() {
+        new ExpiredToken(null, new java.util.Date());
+    }
+}


### PR DESCRIPTION
Hi,

The ExpiredToken class uses Arrays.toString(token) to create a String version of the token byte array. I suggest using the TokenUtil to format it to a more "readable" string, making it easier to map the output of the expired tokens to actual device IDs.

Before: 
ExpiredToken [token=[0, 69, -18, 29, -118, 4, 90, 108, -1, -117, -36, -35, -55, -77, 84, -118, -57, 63, -114, 4, 77, -13, -106, 54, 105, -94, 72, -116, 64, -107, 65, -33], expiration=Mon Mar 02 09:08:23 CET 2015]

After:
ExpiredToken [token=0289822941142798c701b5450d50f51275b20c55a03ad895aee9ef0b29e94612, expiration=Sun Mar 01 22:41:08 CET 2015]

Please consider adding this to the next version of Pushy. Thanks for an otherwise excellent library!