### PR TITLE
Update of used Netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   	<dependency>
   		<groupId>io.netty</groupId>
   		<artifactId>netty-all</artifactId>
-  		<version>4.0.25.Final</version>
+  		<version>4.0.26.Final</version>
   	</dependency>
   	<dependency>
   		<groupId>com.googlecode.json-simple</groupId>


### PR DESCRIPTION
As of March 2nd, there is a new Netty 4.0.x release 