### PR TITLE
Make static inner classes of FeedbackServiceConnection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ doc
 .project
 .settings
 _site
+#ignore intellij files
+*.iml
+.idea/

--- a/src/main/java/com/relayrides/pushy/apns/FeedbackServiceConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/FeedbackServiceConnection.java
@@ -93,7 +93,7 @@ public class FeedbackServiceConnection {
 		TOKEN
 	}
 
-	private class ExpiredTokenDecoder extends ReplayingDecoder<ExpiredTokenDecoderState> {
+	private static class ExpiredTokenDecoder extends ReplayingDecoder<ExpiredTokenDecoderState> {
 
 		private Date expiration;
 		private byte[] token;
@@ -133,7 +133,7 @@ public class FeedbackServiceConnection {
 		}
 	}
 
-	private class FeedbackClientHandler extends SimpleChannelInboundHandler<ExpiredToken> {
+	private static class FeedbackClientHandler extends SimpleChannelInboundHandler<ExpiredToken> {
 
 		private final FeedbackServiceConnection feedbackClient;
 


### PR DESCRIPTION
Use of AtomicInteger for ApnsConnection.pendingWriteCount to ensure synchronization correctness.