### PR TITLE
Add socks proxy support without breaking netty 4.0.x compatibility.

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionConfiguration.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionConfiguration.java
@@ -21,6 +21,9 @@
 
 package com.relayrides.pushy.apns;
 
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelHandler;
+
 /**
  * A set of user-configurable options that affect the behavior of an {@link ApnsConnection}.
  *
@@ -28,6 +31,8 @@ package com.relayrides.pushy.apns;
  */
 public class ApnsConnectionConfiguration {
 
+	private ChannelHandler proxyHandler;
+	private CustomBootstrapConfiguration customBootstrapConfiguration;
 	private int sentNotificationBufferCapacity = ApnsConnection.DEFAULT_SENT_NOTIFICATION_BUFFER_CAPACITY;
 	private Integer closeAfterInactivityTime = null;
 	private Integer gracefulShutdownTimeout = null;
@@ -49,6 +54,8 @@ public class ApnsConnectionConfiguration {
 		this.closeAfterInactivityTime = configuration.closeAfterInactivityTime;
 		this.gracefulShutdownTimeout = configuration.gracefulShutdownTimeout;
 		this.sendAttemptLimit = configuration.sendAttemptLimit;
+		this.proxyHandler = configuration.proxyHandler;
+		this.customBootstrapConfiguration =configuration.customBootstrapConfiguration;
 	}
 
 	/**
@@ -145,6 +152,46 @@ public class ApnsConnectionConfiguration {
 		this.sendAttemptLimit = sendAttemptLimit;
 	}
 
+	/**
+	 * <p>Set a channel handler that will be used as proxy handler. It will be added at first position
+	 * in the channel pipeline.</p>
+	 * <p>
+	 *     Example:
+	 * <pre>
+	 *   config.setProxyHandler(new Socks5ProxyHandler(new InetSocketAddress(&lt;sock5.proxy.host&gt;, &lt;sock5.proxy.port&gt;)));
+	 * </pre>
+	 * </p>
+	 * @param proxyHandler The proxy handler to add to the pipeline.
+	 */
+	public void setProxyHandler(ChannelHandler proxyHandler) {
+		this.proxyHandler = proxyHandler;
+	}
+
+	/**
+	 * Returns the channel handler that must be used to connect to a proxy.
+	 * Returns {@code null} when no proxy are configured.
+	 * @return Returns the channel handler that must be used to connect to a proxy.
+	 */
+	public ChannelHandler getProxyHandler() {
+		return proxyHandler;
+	}
+
+	/**
+	 * Returns the custom bootstrap configuration callback.
+	 * @return Returns the custom bootstrap configuration callback.
+	 */
+	public CustomBootstrapConfiguration getCustomBootstrapConfiguration() {
+		return customBootstrapConfiguration;
+	}
+
+	/**
+	 * Set the custom bootstrap configuration callback.
+	 * @param customBootstrapConfiguration The custom bootstrap configuration callback to set.
+	 */
+	public void setCustomBootstrapConfiguration(CustomBootstrapConfiguration customBootstrapConfiguration) {
+		this.customBootstrapConfiguration = customBootstrapConfiguration;
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
@@ -160,6 +207,12 @@ public class ApnsConnectionConfiguration {
 		result = prime
 				* result
 				+ ((sendAttemptLimit == null) ? 0 : sendAttemptLimit.hashCode());
+		result = prime
+				* result
+				+ ((customBootstrapConfiguration == null) ? 0 : customBootstrapConfiguration.hashCode());
+		result = prime
+				* result
+				+ ((proxyHandler == null) ? 0 : proxyHandler.hashCode());
 		result = prime * result + sentNotificationBufferCapacity;
 		return result;
 	}
@@ -178,17 +231,27 @@ public class ApnsConnectionConfiguration {
 				return false;
 		} else if (!closeAfterInactivityTime
 				.equals(other.closeAfterInactivityTime))
-			return false;
+            return false;
 		if (gracefulShutdownTimeout == null) {
 			if (other.gracefulShutdownTimeout != null)
 				return false;
 		} else if (!gracefulShutdownTimeout
 				.equals(other.gracefulShutdownTimeout))
-			return false;
+            return false;
 		if (sendAttemptLimit == null) {
 			if (other.sendAttemptLimit != null)
 				return false;
 		} else if (!sendAttemptLimit.equals(other.sendAttemptLimit))
+			return false;
+		if (proxyHandler == null) {
+			if (other.proxyHandler != null)
+				return false;
+		} else if (!proxyHandler.equals(other.proxyHandler))
+			return false;
+		if (customBootstrapConfiguration == null) {
+			if (other.customBootstrapConfiguration != null)
+				return false;
+		} else if (!customBootstrapConfiguration.equals(other.customBootstrapConfiguration))
 			return false;
 		if (sentNotificationBufferCapacity != other.sentNotificationBufferCapacity)
 			return false;

--- a/src/main/java/com/relayrides/pushy/apns/CustomBootstrapConfiguration.java
+++ b/src/main/java/com/relayrides/pushy/apns/CustomBootstrapConfiguration.java
@@ -1,0 +1,37 @@
+package com.relayrides.pushy.apns;
+
+import io.netty.bootstrap.Bootstrap;
+
+/**
+ *  This interface aims at providing a callback so that a previously
+ *  instantiated bootstrap object can be configured prior to its use.
+ *  @author sylvere richard
+ */
+public interface CustomBootstrapConfiguration {
+	/**
+	 * <p>Put all your custom bootstrap configuration in this method.</p>
+	 * <p>Example to configure a NameResolver as of Netty 4.1:
+	 * <pre>{@code
+CustomBootstrapConfiguration customConfig = new CustomBootstrapConfiguration() {
+   @Override
+   public void customConfiguration(Bootstrap bootstrap) {
+     bootstrap.resolver(new NameResolverGroup<InetSocketAddress>() {
+	   @Override
+	   protected NameResolver<InetSocketAddress> newResolver(EventExecutor executor) throws Exception {
+	     return (NameResolver<InetSocketAddress>) new DefaultNameResolver(executor) {
+		    @Override
+		    public boolean isSupported(SocketAddress address) {
+		       InetSocketAddress add = (InetSocketAddress) address;
+		       return add.getHostName().contains("apple.com") == false;
+		    }
+	     };
+	   }
+     });
+   }
+}
+	}</pre>
+	 * </p>
+	 * @param bootstrap The bootstrap object to configure.
+	 */
+	public void customConfiguration(Bootstrap bootstrap);
+}

--- a/src/main/java/com/relayrides/pushy/apns/FeedbackConnectionConfiguration.java
+++ b/src/main/java/com/relayrides/pushy/apns/FeedbackConnectionConfiguration.java
@@ -21,6 +21,8 @@
 
 package com.relayrides.pushy.apns;
 
+import io.netty.channel.ChannelHandler;
+
 /**
  * A set of user-configurable options that affect the behavior of a {@link FeedbackServiceConnection}.
  *
@@ -28,6 +30,8 @@ package com.relayrides.pushy.apns;
  */
 public class FeedbackConnectionConfiguration {
 	private int readTimeout = 1;
+	private ChannelHandler proxyHandler;
+	private CustomBootstrapConfiguration customBootstrapConfiguration;
 
 	/**
 	 * Creates a new connection configuration object with all options set to their default values.
@@ -42,6 +46,8 @@ public class FeedbackConnectionConfiguration {
 	 */
 	public FeedbackConnectionConfiguration(final FeedbackConnectionConfiguration configuration) {
 		this.readTimeout = configuration.readTimeout;
+		this.proxyHandler = configuration.proxyHandler;
+		this.customBootstrapConfiguration = configuration.customBootstrapConfiguration;
 	}
 
 	/**
@@ -70,11 +76,57 @@ public class FeedbackConnectionConfiguration {
 		this.readTimeout = readTimeout;
 	}
 
+	/**
+	 * <p>Set a channel handler that will be used as proxy handler. It will be added at first position
+	 * in the channel pipeline.</p>
+	 * <p>
+	 *     Example:
+	 * <pre>
+	 *   config.setProxyHandler(new Socks5ProxyHandler(new InetSocketAddress(&lt;sock5.proxy.host&gt;, &lt;sock5.proxy.port&gt;)));
+	 * </pre>
+	 * </p>
+	 * @param proxyHandler The proxy handler to add to the pipeline.
+	 */
+	public void setProxyHandler(ChannelHandler proxyHandler) {
+		this.proxyHandler = proxyHandler;
+	}
+
+	/**
+	 * Returns the channel handler that must be used to connect to a proxy.
+	 * Returns {@code null} when no proxy are configured.
+	 * @return Returns the channel handler that must be used to connect to a proxy.
+	 */
+	public ChannelHandler getProxyHandler() {
+		return proxyHandler;
+	}
+
+	/**
+	 * Returns the custom bootstrap configuration callback.
+	 * @return Returns the custom bootstrap configuration callback.
+	 */
+	public CustomBootstrapConfiguration getCustomBootstrapConfiguration() {
+		return customBootstrapConfiguration;
+	}
+
+	/**
+	 * Set the custom bootstrap configuration callback.
+	 * @param customBootstrapConfiguration The custom bootstrap configuration callback to set.
+	 */
+	public void setCustomBootstrapConfiguration(CustomBootstrapConfiguration customBootstrapConfiguration) {
+		this.customBootstrapConfiguration = customBootstrapConfiguration;
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + readTimeout;
+		result = prime
+				* result
+				+ ((customBootstrapConfiguration == null) ? 0 : customBootstrapConfiguration.hashCode());
+		result = prime
+				* result
+				+ ((proxyHandler == null) ? 0 : proxyHandler.hashCode());
 		return result;
 	}
 
@@ -88,6 +140,16 @@ public class FeedbackConnectionConfiguration {
 			return false;
 		final FeedbackConnectionConfiguration other = (FeedbackConnectionConfiguration) obj;
 		if (readTimeout != other.readTimeout)
+			return false;
+		if (proxyHandler == null) {
+			if (other.proxyHandler != null)
+				return false;
+		} else if (!proxyHandler.equals(other.proxyHandler))
+			return false;
+		if (customBootstrapConfiguration == null) {
+			if (other.customBootstrapConfiguration != null)
+				return false;
+		} else if (!customBootstrapConfiguration.equals(other.customBootstrapConfiguration))
 			return false;
 		return true;
 	}

--- a/src/main/java/com/relayrides/pushy/apns/FeedbackServiceConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/FeedbackServiceConnection.java
@@ -255,12 +255,22 @@ public class FeedbackServiceConnection {
 				final SSLEngine sslEngine = feedbackConnection.sslContext.createSSLEngine();
 				sslEngine.setUseClientMode(true);
 
+				if(feedbackConnection.configuration.getProxyHandler() != null) {
+					log.debug("adding proxy to pipeline");
+					pipeline.addFirst("proxy", feedbackConnection.configuration.getProxyHandler());
+				}
+
 				pipeline.addLast("ssl", new SslHandler(sslEngine));
 				pipeline.addLast("readTimeoutHandler", new ReadTimeoutHandler(feedbackConnection.configuration.getReadTimeout()));
 				pipeline.addLast("decoder", new ExpiredTokenDecoder());
 				pipeline.addLast("handler", new FeedbackClientHandler(feedbackConnection));
 			}
 		});
+
+		if(feedbackConnection.configuration.getCustomBootstrapConfiguration() != null) {
+			log.debug("applying custom bootstrap configuration");
+			feedbackConnection.configuration.getCustomBootstrapConfiguration().customConfiguration(bootstrap);
+		}
 
 		this.connectFuture = bootstrap.connect(this.environment.getFeedbackHost(), this.environment.getFeedbackPort());
 		this.connectFuture.addListener(new GenericFutureListener<ChannelFuture>() {


### PR DESCRIPTION
Hi Jon,

here is a PR for the issue #99.
I use your great library to send notifications, but since I'm working for a large organization with strict security rules, I absolutely need to use a proxy.
My notification batch runs inside an internal network that is NOT allowed to directly reaches the internet. All connections to the outside world need to go through a proxy.
As you said previously, netty currently does NOT support proxy as of it's version 4.0. But since I can't wait until netty 4.1 is out, I tried to upgrade to netty-all-4.1.0.Beta4 and see what needs to be done.
In fact, it was really simple:
- first, I upgraded to netty-all-4.1.0.Beta4 and good news, pushy still works like a charm!
- next, in the pipeline, I added the socks5 proxy handler at the very first position;
- finally, since the domain name apple.com is not reachable from inside our internal network, I added a NameResolver strategy to tell netty not to resolve this specific domain name.
And it works!!!

But to do so, I had no choice but to redefine the ApnsConnection class with my custom socks5 configuration.
That's the reason why I submit this PR. The goal is to keep the compatibility to netty 4.0.x and providing some hooks so that pushy can be configured to be used behind a proxy with netty 4.1.

Please note this PR contains an update of the documentation to explain how to configure proxy settings.

Could you spend some time reviewing this PR and give me your feedback?
Thanks!
