### PR TITLE
Simplify immediate shutdown behavior

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -77,10 +77,8 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 
 	private final String name;
 
-	private final Object channelRegistrationMonitor = new Object();
 	private ChannelFuture connectFuture;
 	private volatile boolean handshakeCompleted = false;
-	private volatile boolean closeOnRegistration;
 
 	// We want to start the count at 1 here because the gateway will send back a sequence number of 0 if it doesn't know
 	// which notification failed. This isn't 100% bulletproof (we'll legitimately get back to 0 after 2^32
@@ -232,18 +230,6 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 
 		public ApnsConnectionHandler(final ApnsConnection<T> apnsConnection) {
 			this.apnsConnection = apnsConnection;
-		}
-
-		@Override
-		public void channelRegistered(final ChannelHandlerContext context) throws Exception {
-			super.channelRegistered(context);
-
-			synchronized (this.apnsConnection.channelRegistrationMonitor) {
-				if (this.apnsConnection.closeOnRegistration) {
-					log.debug("Channel registered for {}, but shutting down immediately.", this.apnsConnection.name);
-					context.channel().eventLoop().execute(this.apnsConnection.getImmediateShutdownRunnable());
-				}
-			}
 		}
 
 		@Override
@@ -721,33 +707,8 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 	 */
 	public synchronized void shutdownImmediately() {
 		if (this.connectFuture != null) {
-			synchronized (this.channelRegistrationMonitor) {
-				if (this.connectFuture.channel().isRegistered()) {
-					this.connectFuture.channel().eventLoop().execute(this.getImmediateShutdownRunnable());
-				} else {
-					this.closeOnRegistration = true;
-				}
-			}
+			this.connectFuture.channel().close();
 		}
-	}
-
-	private Runnable getImmediateShutdownRunnable() {
-		final ApnsConnection<T> apnsConnection = this;
-
-		return new Runnable() {
-			@Override
-			public void run() {
-				final SslHandler sslHandler = apnsConnection.connectFuture.channel().pipeline().get(SslHandler.class);
-
-				if (apnsConnection.connectFuture.isCancellable()) {
-					apnsConnection.connectFuture.cancel(true);
-				} else if (sslHandler != null && sslHandler.handshakeFuture().isCancellable()) {
-					sslHandler.handshakeFuture().cancel(true);
-				} else {
-					apnsConnection.connectFuture.channel().close();
-				}
-			}
-		};
 	}
 
 	@Override


### PR DESCRIPTION
We previously had a really complicated way of closing connections immediately. The idea was that we'd add a task to the connection's event loop that would check on the connection's state, then make the most appropriate call as to how to shut things down. The goal was to avoid a situation where calling `close` (which I believe still doesn't happen on the event loop) could interrupt a read that would have otherwise told us about a rejected notification.

I think this change *does* expose us to that potential race condition again, but it's of sufficiently low probability that I don't think it justifies the added shutdown complexity.

Thoughts?