### PR TITLE
Schedule disconnection timeouts

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -91,7 +91,7 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 	private int sendAttempts = 0;
 
 	private SendableApnsPushNotification<KnownBadPushNotification> disconnectNotification;
-	private ScheduledFuture<?> gracefulShutdownTimeoutFuture;
+	private ScheduledFuture<?> gracefulDisconnectionTimeoutFuture;
 
 	private boolean rejectionReceived = false;
 	private final SentNotificationBuffer<T> sentNotificationBuffer;
@@ -311,8 +311,8 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 				}
 			}
 
-			if (this.apnsConnection.gracefulShutdownTimeoutFuture != null) {
-				this.apnsConnection.gracefulShutdownTimeoutFuture.cancel(false);
+			if (this.apnsConnection.gracefulDisconnectionTimeoutFuture != null) {
+				this.apnsConnection.gracefulDisconnectionTimeoutFuture.cancel(false);
 			}
 		}
 
@@ -633,7 +633,7 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 								new KnownBadPushNotification(), apnsConnection.sequenceNumber++);
 
 						if (apnsConnection.configuration.getGracefulDisconnectionTimeout() != null) {
-							ApnsConnection.this.gracefulShutdownTimeoutFuture = ApnsConnection.this.connectFuture.channel().eventLoop().schedule(new Runnable() {
+							ApnsConnection.this.gracefulDisconnectionTimeoutFuture = ApnsConnection.this.connectFuture.channel().eventLoop().schedule(new Runnable() {
 								@Override
 								public void run() {
 									ApnsConnection.this.disconnectImmediately();

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionConfiguration.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionConfiguration.java
@@ -95,25 +95,25 @@ public class ApnsConnectionConfiguration {
 	}
 
 	/**
-	 * Returns the time, in seconds, after which a graceful shutdown attempt should be abandoned and the connection
+	 * Returns the time, in seconds, after which a graceful disconnection attempt should be abandoned and the connection
 	 * should be closed immediately.
 	 *
-	 * @return the time, in seconds, after which a graceful shutdown attempt should be abandoned and the connection
+	 * @return the time, in seconds, after which a graceful disconnection attempt should be abandoned and the connection
 	 * should be closed immediately
 	 */
-	public Integer getGracefulShutdownTimeout() {
+	public Integer getGracefulDisconnectionTimeout() {
 		return this.gracefulShutdownTimeout;
 	}
 
 	/**
-	 * Sets the time, in seconds, after which a graceful shutdown attempt should be abandoned and the connection should
-	 * be closed immediately. If {@code null} (the default) graceful shutdown attempts will never time out. Note that,
-	 * if a graceful shutdown attempt times out, no guarantees are made as to the state of notifications sent by the
+	 * Sets the time, in seconds, after which a graceful disconnection attempt should be abandoned and the connection should
+	 * be closed immediately. If {@code null} (the default) graceful disconnection attempts will never time out. Note that,
+	 * if a graceful disconnection attempt times out, no guarantees are made as to the state of notifications sent by the
 	 * connection.
 	 *
-	 * @param gracefulShutdownTimeout the time, in seconds, after which a graceful shutdown attempt should be abandoned
+	 * @param gracefulShutdownTimeout the time, in seconds, after which a graceful disconnection attempt should be abandoned
 	 */
-	public void setGracefulShutdownTimeout(final Integer gracefulShutdownTimeout) {
+	public void setGracefulDisconnectionTimeout(final Integer gracefulShutdownTimeout) {
 		this.gracefulShutdownTimeout = gracefulShutdownTimeout;
 	}
 

--- a/src/main/java/com/relayrides/pushy/apns/PushManager.java
+++ b/src/main/java/com/relayrides/pushy/apns/PushManager.java
@@ -284,7 +284,7 @@ public class PushManager<T extends ApnsPushNotification> implements ApnsConnecti
 							if (shutDownStarted) {
 								// We're trying to drain the retry queue before shutting down, and the retry queue is
 								// now empty. Close the connection and see if it stays closed.
-								connection.shutdownGracefully();
+								connection.disconnectGracefully();
 								writableConnections.remove(connection);
 							} else {
 								// We'll park here either until a new notification is available from the outside or until
@@ -412,7 +412,7 @@ public class PushManager<T extends ApnsPushNotification> implements ApnsConnecti
 
 		synchronized (this.activeConnections) {
 			for (final ApnsConnection<T> connection : this.activeConnections) {
-				connection.shutdownImmediately();
+				connection.disconnectImmediately();
 			}
 		}
 
@@ -701,7 +701,7 @@ public class PushManager<T extends ApnsPushNotification> implements ApnsConnecti
 			this.writableConnections.add(connection);
 		} else {
 			// There's no dispatch thread to use this connection, so shut it down immediately
-			connection.shutdownImmediately();
+			connection.disconnectImmediately();
 		}
 	}
 

--- a/src/test/java/com/relayrides/pushy/apns/ApnsConnectionConfigurationTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/ApnsConnectionConfigurationTest.java
@@ -35,7 +35,7 @@ public class ApnsConnectionConfigurationTest {
 
 		assertTrue(configuration.getSentNotificationBufferCapacity() > 0);
 		assertNull(configuration.getCloseAfterInactivityTime());
-		assertNull(configuration.getGracefulShutdownTimeout());
+		assertNull(configuration.getGracefulDisconnectionTimeout());
 		assertNull(configuration.getSendAttemptLimit());
 	}
 
@@ -44,7 +44,7 @@ public class ApnsConnectionConfigurationTest {
 		final ApnsConnectionConfiguration configuration = new ApnsConnectionConfiguration();
 		configuration.setSentNotificationBufferCapacity(17);
 		configuration.setCloseAfterInactivityTime(19);
-		configuration.setGracefulShutdownTimeout(23);
+		configuration.setGracefulDisconnectionTimeout(23);
 		configuration.setSendAttemptLimit(29);
 
 		final ApnsConnectionConfiguration configurationCopy = new ApnsConnectionConfiguration(configuration);

--- a/src/test/java/com/relayrides/pushy/apns/ApnsConnectionTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/ApnsConnectionTest.java
@@ -380,7 +380,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 		assertTrue(listener.connectionSucceeded);
 
 		synchronized (mutex) {
-			apnsConnection.shutdownGracefully();
+			apnsConnection.disconnectGracefully();
 
 			while (!listener.connectionClosed) {
 				mutex.wait();
@@ -414,8 +414,8 @@ public class ApnsConnectionTest extends BasePushyTest {
 		assertTrue(listener.connectionSucceeded);
 
 		synchronized (mutex) {
-			apnsConnection.shutdownGracefully();
-			apnsConnection.shutdownGracefully();
+			apnsConnection.disconnectGracefully();
+			apnsConnection.disconnectGracefully();
 
 			while (!listener.connectionClosed) {
 				mutex.wait();
@@ -438,7 +438,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 						TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
 						new ApnsConnectionConfiguration(), listener, TEST_CONNECTION_NAME);
 
-		apnsConnection.shutdownGracefully();
+		apnsConnection.disconnectGracefully();
 	}
 
 	@Test
@@ -462,7 +462,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 		assertTrue(listener.connectionSucceeded);
 
 		synchronized (mutex) {
-			apnsConnection.shutdownImmediately();
+			apnsConnection.disconnectImmediately();
 
 			while (!listener.connectionClosed) {
 				mutex.wait();
@@ -482,7 +482,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 						TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
 						new ApnsConnectionConfiguration(), listener, TEST_CONNECTION_NAME);
 
-		apnsConnection.shutdownImmediately();
+		apnsConnection.disconnectImmediately();
 	}
 
 	@Test
@@ -499,7 +499,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 							new ApnsConnectionConfiguration(), listener, TEST_CONNECTION_NAME);
 
 			apnsConnection.waitForPendingWritesToFinish();
-			apnsConnection.shutdownImmediately();
+			apnsConnection.disconnectImmediately();
 		}
 
 		{
@@ -526,7 +526,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 			}
 
 			apnsConnection.waitForPendingWritesToFinish();
-			apnsConnection.shutdownGracefully();
+			apnsConnection.disconnectGracefully();
 		}
 	}
 
@@ -585,7 +585,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 		assertTrue(listener.connectionSucceeded);
 
 		synchronized (mutex) {
-			apnsConnection.shutdownGracefully();
+			apnsConnection.disconnectGracefully();
 
 			while (!listener.connectionClosed) {
 				mutex.wait();
@@ -667,7 +667,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 			this.waitForLatch(latch);
 
 			synchronized (mutex) {
-				apnsConnection.shutdownGracefully();
+				apnsConnection.disconnectGracefully();
 
 				while (!listener.connectionClosed) {
 					mutex.wait();

--- a/src/test/java/com/relayrides/pushy/apns/ApnsConnectionTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/ApnsConnectionTest.java
@@ -563,7 +563,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 		final TestListener listener = new TestListener(mutex);
 
 		final ApnsConnectionConfiguration gracefulShutdownTimeoutConfiguration = new ApnsConnectionConfiguration();
-		gracefulShutdownTimeoutConfiguration.setGracefulShutdownTimeout(1);
+		gracefulShutdownTimeoutConfiguration.setGracefulDisconnectionTimeout(1);
 
 		final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
 				new ApnsConnection<SimpleApnsPushNotification>(


### PR DESCRIPTION
Rather than adding a second idle state handler to the pipeline, we can just schedule an immediate disconnection after some delay. This seems a whole lot simpler to me.

Also, renamed "shutdown" to "disconnect" in the context of `ApnsConnections` for clarity.