### PR TITLE
Don't notify listeners of connection closure until all writes have finished

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -48,7 +48,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -87,7 +86,8 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 	// having an expired token) is vanishingly small.
 	private int sequenceNumber = 1;
 
-	private final AtomicInteger pendingWriteCount = new AtomicInteger(0);
+	private volatile ChannelFuture lastWriteFuture;
+
 	private int sendAttempts = 0;
 
 	private SendableApnsPushNotification<KnownBadPushNotification> disconnectNotification;
@@ -501,63 +501,44 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 	 * @see ApnsConnectionListener#handleRejectedNotification(ApnsConnection, ApnsPushNotification, RejectedNotificationReason)
 	 */
 	public synchronized void sendNotification(final T notification) {
-		final ApnsConnection<T> apnsConnection = this;
-
 		if (!this.handshakeCompleted) {
 			throw new IllegalStateException(String.format("%s has not completed handshake.", this.name));
 		}
 
 		if (this.disconnectNotification == null) {
-			this.connectFuture.channel().eventLoop().execute(new Runnable() {
+			final SendableApnsPushNotification<T> sendableNotification =
+					new SendableApnsPushNotification<T>(notification, this.sequenceNumber++);
+
+			log.trace("{} sending {}", this.name, sendableNotification);
+
+			this.lastWriteFuture = this.connectFuture.channel().writeAndFlush(sendableNotification).addListener(new GenericFutureListener<ChannelFuture>() {
 
 				@Override
-				public void run() {
-					final SendableApnsPushNotification<T> sendableNotification =
-							new SendableApnsPushNotification<T>(notification, apnsConnection.sequenceNumber++);
+				public void operationComplete(final ChannelFuture writeFuture) {
+					if (writeFuture.isSuccess()) {
+						log.trace("{} successfully wrote notification {}", ApnsConnection.this.name,
+								sendableNotification.getSequenceNumber());
 
-					log.trace("{} sending {}", apnsConnection.name, sendableNotification);
-
-					apnsConnection.pendingWriteCount.incrementAndGet();
-
-					apnsConnection.connectFuture.channel().writeAndFlush(sendableNotification).addListener(new GenericFutureListener<ChannelFuture>() {
-
-						@Override
-						public void operationComplete(final ChannelFuture writeFuture) {
-							if (writeFuture.isSuccess()) {
-								log.trace("{} successfully wrote notification {}", apnsConnection.name,
-										sendableNotification.getSequenceNumber());
-
-								if (apnsConnection.rejectionReceived) {
-									// Even though the write succeeded, we know for sure that this notification was never
-									// processed by the gateway because it had already rejected another notification from
-									// this connection.
-									if (apnsConnection.listener != null) {
-										apnsConnection.listener.handleUnprocessedNotifications(apnsConnection, java.util.Collections.singletonList(notification));
-									}
-								} else {
-									apnsConnection.sentNotificationBuffer.addSentNotification(sendableNotification);
-								}
-							} else {
-								log.trace("{} failed to write notification {}",
-										apnsConnection.name, sendableNotification, writeFuture.cause());
-
-								// Assume this is a temporary failure (we know it's not a permanent rejection because we didn't
-								// even manage to write the notification to the wire) and re-enqueue for another send attempt.
-								if (apnsConnection.listener != null) {
-									apnsConnection.listener.handleWriteFailure(apnsConnection, notification, writeFuture.cause());
-								}
+						if (ApnsConnection.this.rejectionReceived) {
+							// Even though the write succeeded, we know for sure that this notification was never
+							// processed by the gateway because it had already rejected another notification from
+							// this connection.
+							if (ApnsConnection.this.listener != null) {
+								ApnsConnection.this.listener.handleUnprocessedNotifications(ApnsConnection.this, java.util.Collections.singletonList(notification));
 							}
-
-							final int currentPendingWriteCount = apnsConnection.pendingWriteCount.decrementAndGet();
-							assert currentPendingWriteCount >= 0;
-
-							if (currentPendingWriteCount == 0) {
-								synchronized (apnsConnection.pendingWriteCount) {
-									apnsConnection.pendingWriteCount.notifyAll();
-								}
-							}
+						} else {
+							ApnsConnection.this.sentNotificationBuffer.addSentNotification(sendableNotification);
 						}
-					});
+					} else {
+						log.trace("{} failed to write notification {}",
+								ApnsConnection.this.name, sendableNotification, writeFuture.cause());
+
+						// Assume this is a temporary failure (we know it's not a permanent rejection because we didn't
+						// even manage to write the notification to the wire) and re-enqueue for another send attempt.
+						if (ApnsConnection.this.listener != null) {
+							ApnsConnection.this.listener.handleWriteFailure(ApnsConnection.this, notification, writeFuture.cause());
+						}
+					}
 				}
 			});
 		} else {
@@ -573,9 +554,9 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 	}
 
 	/**
-	 * <p>Waits for all pending write operations to finish. When this method exits normally (i.e. when it does
-	 * not throw an {@code InterruptedException}), all pending writes will have either finished successfully or failed
-	 * and passed to this connection's listener via the
+	 * <p>Waits for the most recent write operation to finish. When this method exits normally (i.e. when it does
+	 * not throw an {@code InterruptedException}), the most recent write operation will have either succeeded or failed
+	 * and triggered a call to this connection's listener's
 	 * {@link ApnsConnectionListener#handleWriteFailure(ApnsConnection, ApnsPushNotification, Throwable)} method.</p>
 	 *
 	 * <p>It is <em>not</em> guaranteed that all write operations will have finished by the time a connection has
@@ -585,11 +566,9 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 	 *
 	 * @throws InterruptedException if interrupted while waiting for pending read/write operations to finish
 	 */
-	public void waitForPendingWritesToFinish() throws InterruptedException {
-		synchronized (this.pendingWriteCount) {
-			while (this.pendingWriteCount.intValue() > 0) {
-				this.pendingWriteCount.wait();
-			}
+	public void waitForLastWriteToFinish() throws InterruptedException {
+		if (this.lastWriteFuture != null) {
+			this.lastWriteFuture.await();
 		}
 	}
 
@@ -614,64 +593,45 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 	 */
 	public synchronized boolean disconnectGracefully() {
 
-		final ApnsConnection<T> apnsConnection = this;
-
 		// We only need to send a known-bad notification if we were ever connected in the first place and if we're
 		// still connected.
 		if (this.handshakeCompleted && this.connectFuture.channel().isActive()) {
 
-			this.connectFuture.channel().eventLoop().execute(new Runnable() {
+			// Don't send a second disconnection notification if we've already started the graceful disconnection process.
+			if (this.disconnectNotification == null) {
 
-				@Override
-				public void run() {
-					// Don't send a second disconnection notification if we've already started the graceful disconnection process.
-					if (apnsConnection.disconnectNotification == null) {
+				log.debug("{} sending known-bad notification to disconnect.", this.name);
 
-						log.debug("{} sending known-bad notification to disconnect.", apnsConnection.name);
+				this.disconnectNotification = new SendableApnsPushNotification<KnownBadPushNotification>(
+						new KnownBadPushNotification(), this.sequenceNumber++);
 
-						apnsConnection.disconnectNotification = new SendableApnsPushNotification<KnownBadPushNotification>(
-								new KnownBadPushNotification(), apnsConnection.sequenceNumber++);
-
-						if (apnsConnection.configuration.getGracefulDisconnectionTimeout() != null) {
-							ApnsConnection.this.gracefulShutdownTimeoutFuture = ApnsConnection.this.connectFuture.channel().eventLoop().schedule(new Runnable() {
-								@Override
-								public void run() {
-									ApnsConnection.this.disconnectImmediately();
-								}
-							}, ApnsConnection.this.configuration.getGracefulDisconnectionTimeout(), TimeUnit.SECONDS);
+				if (this.configuration.getGracefulDisconnectionTimeout() != null) {
+					ApnsConnection.this.gracefulShutdownTimeoutFuture = ApnsConnection.this.connectFuture.channel().eventLoop().schedule(new Runnable() {
+						@Override
+						public void run() {
+							ApnsConnection.this.disconnectImmediately();
 						}
-
-						apnsConnection.pendingWriteCount.incrementAndGet();
-
-						apnsConnection.connectFuture.channel().writeAndFlush(apnsConnection.disconnectNotification).addListener(new GenericFutureListener<ChannelFuture>() {
-
-							@Override
-							public void operationComplete(final ChannelFuture future) {
-								if (future.isSuccess()) {
-									log.trace("{} successfully wrote known-bad notification {}",
-											apnsConnection.name, apnsConnection.disconnectNotification.getSequenceNumber());
-								} else {
-									log.trace("{} failed to write known-bad notification {}",
-											apnsConnection.name, apnsConnection.disconnectNotification, future.cause());
-
-									// Try again!
-									apnsConnection.disconnectNotification = null;
-									apnsConnection.disconnectGracefully();
-								}
-
-								final int currentPendingWriteCount = apnsConnection.pendingWriteCount.decrementAndGet();
-								assert currentPendingWriteCount >= 0;
-
-								if (currentPendingWriteCount == 0) {
-									synchronized (apnsConnection.pendingWriteCount) {
-										apnsConnection.pendingWriteCount.notifyAll();
-									}
-								}
-							}
-						});
-					}
+					}, ApnsConnection.this.configuration.getGracefulDisconnectionTimeout(), TimeUnit.SECONDS);
 				}
-			});
+
+				this.lastWriteFuture = this.connectFuture.channel().writeAndFlush(this.disconnectNotification).addListener(new GenericFutureListener<ChannelFuture>() {
+
+					@Override
+					public void operationComplete(final ChannelFuture future) {
+						if (future.isSuccess()) {
+							log.trace("{} successfully wrote known-bad notification {}",
+									ApnsConnection.this.name, ApnsConnection.this.disconnectNotification.getSequenceNumber());
+						} else {
+							log.trace("{} failed to write known-bad notification {}",
+									ApnsConnection.this.name, ApnsConnection.this.disconnectNotification, future.cause());
+
+							// Try again!
+							ApnsConnection.this.disconnectNotification = null;
+							ApnsConnection.this.disconnectGracefully();
+						}
+					}
+				});
+			}
 
 			return true;
 		} else {

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionListener.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionListener.java
@@ -61,7 +61,9 @@ public interface ApnsConnectionListener<T extends ApnsPushNotification> {
 	 * Indicates that the given connection has disconnected from the previously-connected APNs gateway and can no
 	 * longer send push notifications. This may happen either when the connection is closed locally or when the APNs
 	 * gateway closes the connection remotely. This method will only be called if the connection had previously
-	 * succeeded and completed a TLS handshake.
+	 * succeeded and completed a TLS handshake. By the time this method is called, all write operations for the given
+	 * channel are guaranteed to have succeed or failed and triggered a call to the listener's
+	 * {@link ApnsConnectionListener#handleWriteFailure(ApnsConnection, ApnsPushNotification, Throwable)} method.
 	 *
 	 * @param connection the connection that has been disconnected and is no longer active
 	 */

--- a/src/main/java/com/relayrides/pushy/apns/PushManager.java
+++ b/src/main/java/com/relayrides/pushy/apns/PushManager.java
@@ -766,25 +766,11 @@ public class PushManager<T extends ApnsPushNotification> implements ApnsConnecti
 		this.writableConnections.remove(connection);
 		this.dispatchThread.interrupt();
 
-		final PushManager<T> pushManager = this;
+		if (this.shouldReplaceClosedConnection()) {
+			this.startNewConnection();
+		}
 
-		this.listenerExecutorService.execute(new Runnable() {
-			@Override
-			public void run() {
-				try {
-					connection.waitForLastWriteToFinish();
-
-					if (pushManager.shouldReplaceClosedConnection()) {
-						pushManager.startNewConnection();
-					}
-
-					removeActiveConnection(connection);
-				} catch (InterruptedException e) {
-					log.warn("{} interrupted while waiting for closed connection's pending operations to finish.",
-							pushManager.name);
-				}
-			}
-		});
+		removeActiveConnection(connection);
 	}
 
 	/*

--- a/src/main/java/com/relayrides/pushy/apns/PushManager.java
+++ b/src/main/java/com/relayrides/pushy/apns/PushManager.java
@@ -772,7 +772,7 @@ public class PushManager<T extends ApnsPushNotification> implements ApnsConnecti
 			@Override
 			public void run() {
 				try {
-					connection.waitForPendingWritesToFinish();
+					connection.waitForLastWriteToFinish();
 
 					if (pushManager.shouldReplaceClosedConnection()) {
 						pushManager.startNewConnection();

--- a/src/test/java/com/relayrides/pushy/apns/ApnsConnectionTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/ApnsConnectionTest.java
@@ -88,7 +88,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 		@Override
 		public void handleConnectionClosure(final ApnsConnection<SimpleApnsPushNotification> connection) {
 			try {
-				connection.waitForPendingWritesToFinish();
+				connection.waitForLastWriteToFinish();
 			} catch (InterruptedException ignored) {
 			}
 
@@ -498,7 +498,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 							TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
 							new ApnsConnectionConfiguration(), listener, TEST_CONNECTION_NAME);
 
-			apnsConnection.waitForPendingWritesToFinish();
+			apnsConnection.waitForLastWriteToFinish();
 			apnsConnection.disconnectImmediately();
 		}
 
@@ -525,7 +525,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 				apnsConnection.sendNotification(this.createTestNotification());
 			}
 
-			apnsConnection.waitForPendingWritesToFinish();
+			apnsConnection.waitForLastWriteToFinish();
 			apnsConnection.disconnectGracefully();
 		}
 	}

--- a/src/test/java/com/relayrides/pushy/apns/ApnsConnectionTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/ApnsConnectionTest.java
@@ -87,11 +87,6 @@ public class ApnsConnectionTest extends BasePushyTest {
 
 		@Override
 		public void handleConnectionClosure(final ApnsConnection<SimpleApnsPushNotification> connection) {
-			try {
-				connection.waitForLastWriteToFinish();
-			} catch (InterruptedException ignored) {
-			}
-
 			synchronized (mutex) {
 				this.connectionClosed = true;
 				this.mutex.notifyAll();
@@ -483,51 +478,6 @@ public class ApnsConnectionTest extends BasePushyTest {
 						new ApnsConnectionConfiguration(), listener, TEST_CONNECTION_NAME);
 
 		apnsConnection.disconnectImmediately();
-	}
-
-	@Test
-	public void testWaitForPendingOperationsToFinish() throws Exception {
-		// For the purposes of this test, we're happy just as long as we don't time out waiting for writes to finish.
-
-		{
-			final Object mutex = new Object();
-
-			final TestListener listener = new TestListener(mutex);
-			final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
-					new ApnsConnection<SimpleApnsPushNotification>(
-							TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
-							new ApnsConnectionConfiguration(), listener, TEST_CONNECTION_NAME);
-
-			apnsConnection.waitForLastWriteToFinish();
-			apnsConnection.disconnectImmediately();
-		}
-
-		{
-			final Object mutex = new Object();
-
-			final TestListener listener = new TestListener(mutex);
-			final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
-					new ApnsConnection<SimpleApnsPushNotification>(
-							TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
-							new ApnsConnectionConfiguration(), listener, TEST_CONNECTION_NAME);
-
-			synchronized (mutex) {
-				apnsConnection.connect();
-
-				while (!listener.connectionSucceeded) {
-					mutex.wait();
-				}
-			}
-
-			assertTrue(listener.connectionSucceeded);
-
-			for (int i = 0; i < 1000; i++) {
-				apnsConnection.sendNotification(this.createTestNotification());
-			}
-
-			apnsConnection.waitForLastWriteToFinish();
-			apnsConnection.disconnectGracefully();
-		}
 	}
 
 	@Test


### PR DESCRIPTION
This gets rid of the terrible terrible `waitForPendingWritesToFinish` method and generally cuts down on blocky badness. I'm still a little disappointed at how much hoop-jumping needs to happen here, but I feel much better now that it's entirely hidden from listeners/callers.

~~Depends on #164 and #165; apologies for the diff noise until those are merged. The commits to look at now are dbc04ab (which gets rid of the internal pending write counter) and 620cc77 (which gets write of `waitForPendingWritesToFinish` and wraps that all into more sensible timing for the `handleConnectionClosure` listener method).~~

This is easier to read with [whitespace-only changes hidden](https://github.com/relayrides/pushy/pull/166/files?w=1). Because we're not dealing with counters, we don't have as many anonymous `Runnables` lying around (yay!) and some stuff got un-indented as a result.