### PR TITLE
Encapsulate connection groups, add exponential back-off

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -496,6 +496,21 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 	}
 
 	/**
+	 * Indicates whether this connection will write a push notification immediately. Any notifications sent when this
+	 * method returns {@code false} will be enqueued internally.
+	 *
+	 * @return {@code true} if this connection will write a push notification immediately or {@code false} if attempts
+	 * to send push notifications will be deferred
+	 */
+	public boolean isWritable() {
+		if (this.connectFuture == null || this.connectFuture.channel() == null) {
+			return false;
+		} else {
+			return this.connectFuture.channel().isWritable();
+		}
+	}
+
+	/**
 	 * Asynchronously sends a push notification to the connected APNs gateway. Successful notifications are
 	 * <strong>not</strong> acknowledged by the APNs gateway; failed attempts to write push notifications to the
 	 * outbound buffer and notification rejections are reported via this connection's listener.

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -30,8 +30,8 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.ByteToMessageDecoder;
@@ -72,7 +72,7 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 
 	private final ApnsEnvironment environment;
 	private final SSLContext sslContext;
-	private final NioEventLoopGroup eventLoopGroup;
+	private final EventLoopGroup eventLoopGroup;
 	private final ApnsConnectionConfiguration configuration;
 	private final ApnsConnectionListener<T> listener;
 
@@ -367,7 +367,7 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 	 * @param name a human-readable name for this connection; names must not be {@code null}
 	 */
 	public ApnsConnection(final ApnsEnvironment environment, final SSLContext sslContext,
-			final NioEventLoopGroup eventLoopGroup, final ApnsConnectionConfiguration configuration,
+			final EventLoopGroup eventLoopGroup, final ApnsConnectionConfiguration configuration,
 			final ApnsConnectionListener<T> listener, final String name) {
 
 		if (environment == null) {

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -658,6 +658,7 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 	 */
 	public synchronized void disconnectImmediately() {
 		if (this.connectFuture != null) {
+			this.connectFuture.cancel(false);
 			this.connectFuture.channel().close();
 		}
 	}

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
@@ -144,8 +144,7 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 	public ApnsConnection<T> getNextConnection(final long timeoutMillis) throws InterruptedException {
 		final ApnsConnection<T> connection = this.writableConnections.poll(timeoutMillis, TimeUnit.MILLISECONDS);
 
-		if (connection != null) {
-			// TODO Synchronize to avoid writability change goofiness
+		if (connection != null && connection.isWritable()) {
 			this.writableConnections.add(connection);
 		}
 

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
@@ -58,8 +58,10 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 		this.shouldMaintainConnections = true;
 
 		synchronized (this.connections) {
-			for (int i = this.connections.size(); i < this.connectionCount; i++) {
-				this.addConnectionWithDelay(0);
+			synchronized (this.connectionFutures) {
+				for (int i = this.connections.size() + this.connectionFutures.size(); i < this.connectionCount; i++) {
+					this.addConnectionWithDelay(0);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
@@ -137,27 +137,19 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 		}
 	}
 
-	public boolean sendNotification(final T notification) throws InterruptedException {
-		return this.sendNotification(notification, Long.MAX_VALUE);
+	public ApnsConnection<T> getNextConnection() throws InterruptedException {
+		return this.getNextConnection(Long.MAX_VALUE);
 	}
 
-	public boolean sendNotification(final T notification, final long timeoutMillis) throws InterruptedException {
-		final boolean notificationSent;
+	public ApnsConnection<T> getNextConnection(final long timeoutMillis) throws InterruptedException {
 		final ApnsConnection<T> connection = this.writableConnections.poll(timeoutMillis, TimeUnit.MILLISECONDS);
 
 		if (connection != null) {
-			// TODO Figure out what to do if the connection's writabiliy changes after we get it, but before we return it
-			// to the queue
+			// TODO Synchronize to avoid writability change goofiness
 			this.writableConnections.add(connection);
-
-			connection.sendNotification(notification);
-
-			notificationSent = true;
-		} else {
-			notificationSent = false;
 		}
 
-		return notificationSent;
+		return connection;
 	}
 
 	@Override

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
@@ -41,9 +41,19 @@ import org.slf4j.LoggerFactory;
 import com.relayrides.pushy.apns.util.DeadlineUtil;
 
 /**
- * A connection group maintains a pool of connections to the APNs gateway. Callers can retrieve connections from the
+ * <p>A connection group maintains a pool of connections to the APNs gateway. Callers can retrieve connections from the
  * group via the {@link ApnsConnectionGroup#getNextConnection()} method, and then use the returned connection to send
- * notifications.
+ * notifications.</p>
+ *
+ * <p>Connection groups also perform two secondary roles:</p>
+ *
+ * <ol>
+ * 	<li>They serve as a simple load balancer by rotating through connections; subsequent calls to the
+ * {@link ApnsConnectionGroup#getNextConnection()} method will return different connections if the group has more than
+ * one writable connection.</li>
+ * 	<li>They control the rate at which connections are replaced by implementing an exponential back-off strategy to
+ * avoid bombarding the APNs gateway (and local listeners) with connection attempts.</li>
+ * </ol>
  *
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
  */

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
@@ -13,6 +13,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.net.ssl.SSLContext;
 
+/**
+ * A connection group maintains a pool of connections to the APNs gateway. Callers can retrieve connections from the
+ * group via the {@link ApnsConnectionGroup#getNextConnection()} method, and then use the returned connection to send
+ * notifications.
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ */
 public class ApnsConnectionGroup<T extends ApnsPushNotification> implements ApnsConnectionListener<T> {
 	private final int connectionCount;
 
@@ -38,6 +45,22 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 	private static final long INITIAL_RECONNECT_DELAY = 100;
 	private static final long MAX_RECONNECT_DELAY = INITIAL_RECONNECT_DELAY * 512;
 
+	/**
+	 * Constructs a new connection group that will maintain connections to the APNs gateway in the given environment.
+	 *
+	 * @param environment the environment in which connections in this group will operate; must not be {@code null}
+	 * @param sslContext an SSL context with the keys/certificates and trust managers connection in this group should
+	 * use when communicating with the APNs gateway; must not be {@code null}
+	 * @param eventLoopGroup the event loop group connections in this group should use for asynchronous network
+	 * operations; must not be {@code null}
+	 * @param connectionConfiguration the set of configuration options to use for connections in this group. The
+	 * configuration object is copied and changes to the original object will not propagate to the connection after
+	 * creation. Must not be {@code null}.
+	 * @param listener the listener to which this group will report connection lifecycle events; may be {@code null}
+	 * @param name a human-readable name for this group; if {@code null}, a default name will be used. Individual
+	 * connection names are derived from the group's name.
+	 * @param connectionCount the number of concurrent connections to maintain to the APNs gateway
+	 */
 	public ApnsConnectionGroup(final ApnsEnvironment environment, final SSLContext sslContext, final EventLoopGroup eventLoopGroup, final ApnsConnectionConfiguration connectionConfiguration, final ApnsConnectionGroupListener<T> listener, final String name, final int connectionCount) {
 		this.environment = environment;
 		this.sslContext = sslContext;
@@ -54,6 +77,11 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 		this.connectionCount = connectionCount;
 	}
 
+	/**
+	 * Opens and begins maintaining connections to the APNs gateway. After this method has been called, connections in
+	 * this group will be replaced when they close until the {@link ApnsConnectionGroup#disconnectAllGracefuly()} method
+	 * is called.
+	 */
 	public void connectAll() {
 		this.shouldMaintainConnections = true;
 
@@ -66,6 +94,10 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 		}
 	}
 
+	/**
+	 * Gracefully disconnects all connections in this group. After this method is called, connections will not be
+	 * restored when they close.
+	 */
 	public void disconnectAllGracefuly() {
 		this.shouldMaintainConnections = false;
 
@@ -94,6 +126,11 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 		}
 	}
 
+	/**
+	 * Wait until all connections in this group have closed completely.
+	 *
+	 * @throws InterruptedException if interrupted while waiting for all connections to close
+	 */
 	public void waitForAllConnectionsToClose() throws InterruptedException {
 		synchronized (this.connections) {
 			while (!this.connections.isEmpty()) {
@@ -102,6 +139,11 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 		}
 	}
 
+	/**
+	 * Schedules a connection to open after the given delay.
+	 *
+	 * @param delayMillis the delay, in milliseconds, after which the connection should open
+	 */
 	private void addConnectionWithDelay(final long delayMillis) {
 		synchronized (this.connectionFutures) {
 			final ScheduledFuture<?> future = this.eventLoopGroup.schedule(new Runnable() {
@@ -129,6 +171,11 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 		}
 	}
 
+	/**
+	 * Removes a connection from this group and potentially alerts waiting threads that all connections have closed.
+	 *
+	 * @param connection the connection to remove from this group
+	 */
 	private void removeConnection(final ApnsConnection<T> connection) {
 		synchronized (this.connections) {
 			this.connections.remove(connection);
@@ -139,10 +186,26 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 		}
 	}
 
+	/**
+	 * Gets the next writable connection from this group, blocking indefinitely until a connection is available.
+	 *
+	 * @return the next writable connection from this group
+	 * @throws InterruptedException if interrupted while waiting for a connection to become available
+	 */
 	public ApnsConnection<T> getNextConnection() throws InterruptedException {
 		return this.getNextConnection(Long.MAX_VALUE);
 	}
 
+	/**
+	 * Gets the next writable connection from this group, blocking for up to the given period until a connection is
+	 * available.
+	 *
+	 * @param timeoutMillis the maximum time to wait for a connection
+	 *
+	 * @return the next writable connection from this group, or {@code null} if no connection is available before the
+	 * given timeout elapses
+	 * @throws InterruptedException if interrupted while waiting for a connection to become available
+	 */
 	public ApnsConnection<T> getNextConnection(final long timeoutMillis) throws InterruptedException {
 		final ApnsConnection<T> connection = this.writableConnections.poll(timeoutMillis, TimeUnit.MILLISECONDS);
 
@@ -153,12 +216,20 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 		return connection;
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see com.relayrides.pushy.apns.ApnsConnectionListener#handleConnectionSuccess(com.relayrides.pushy.apns.ApnsConnection)
+	 */
 	@Override
 	public void handleConnectionSuccess(final ApnsConnection<T> connection) {
 		this.writableConnections.add(connection);
 		this.reconnectDelay = 0;
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see com.relayrides.pushy.apns.ApnsConnectionListener#handleConnectionFailure(com.relayrides.pushy.apns.ApnsConnection, java.lang.Throwable)
+	 */
 	@Override
 	public void handleConnectionFailure(final ApnsConnection<T> connection, final Throwable cause) {
 		if (this.shouldMaintainConnections) {
@@ -174,6 +245,10 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 		this.listener.handleConnectionFailure(this, cause);
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see com.relayrides.pushy.apns.ApnsConnectionListener#handleConnectionWritabilityChange(com.relayrides.pushy.apns.ApnsConnection, boolean)
+	 */
 	@Override
 	public void handleConnectionWritabilityChange(final ApnsConnection<T> connection, final boolean writable) {
 		if (writable) {
@@ -183,6 +258,10 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 		}
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see com.relayrides.pushy.apns.ApnsConnectionListener#handleConnectionClosure(com.relayrides.pushy.apns.ApnsConnection)
+	 */
 	@Override
 	public void handleConnectionClosure(final ApnsConnection<T> connection) {
 		this.writableConnections.remove(connection);
@@ -194,6 +273,10 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 		this.removeConnection(connection);
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see com.relayrides.pushy.apns.ApnsConnectionListener#handleWriteFailure(com.relayrides.pushy.apns.ApnsConnection, com.relayrides.pushy.apns.ApnsPushNotification, java.lang.Throwable)
+	 */
 	@Override
 	public void handleWriteFailure(final ApnsConnection<T> connection, final T notification, final Throwable cause) {
 		if (this.listener != null) {
@@ -201,6 +284,10 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 		}
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see com.relayrides.pushy.apns.ApnsConnectionListener#handleRejectedNotification(com.relayrides.pushy.apns.ApnsConnection, com.relayrides.pushy.apns.ApnsPushNotification, com.relayrides.pushy.apns.RejectedNotificationReason)
+	 */
 	@Override
 	public void handleRejectedNotification(final ApnsConnection<T> connection, final T rejectedNotification, final RejectedNotificationReason reason) {
 		if (this.listener != null) {
@@ -208,6 +295,10 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 		}
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see com.relayrides.pushy.apns.ApnsConnectionListener#handleUnprocessedNotifications(com.relayrides.pushy.apns.ApnsConnection, java.util.Collection)
+	 */
 	@Override
 	public void handleUnprocessedNotifications(final ApnsConnection<T> connection, final Collection<T> unprocessedNotifications) {
 		if (this.listener != null) {

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
@@ -68,8 +68,6 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 
 	private long reconnectDelay = 0;
 
-	private static final AtomicInteger GROUP_COUNTER = new AtomicInteger(0);
-
 	public static final long INITIAL_RECONNECT_DELAY = 100;
 	public static final long MAX_RECONNECT_DELAY = INITIAL_RECONNECT_DELAY * 512;
 
@@ -87,21 +85,17 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 	 * configuration object is copied and changes to the original object will not propagate to the connection after
 	 * creation. Must not be {@code null}.
 	 * @param listener the listener to which this group will report connection lifecycle events; may be {@code null}
-	 * @param name a human-readable name for this group; if {@code null}, a default name will be used. Individual
-	 * connection names are derived from the group's name.
+	 * @param name a human-readable name for this group; must not be {@code null}
 	 * @param connectionCount the number of concurrent connections to maintain to the APNs gateway
 	 */
-	public ApnsConnectionGroup(final ApnsEnvironment environment, final SSLContext sslContext, final EventLoopGroup eventLoopGroup, final ApnsConnectionConfiguration connectionConfiguration, final ApnsConnectionGroupListener<T> listener, final String name, final int connectionCount) {
+	public ApnsConnectionGroup(final ApnsEnvironment environment, final SSLContext sslContext,
+			final EventLoopGroup eventLoopGroup, final ApnsConnectionConfiguration connectionConfiguration,
+			final ApnsConnectionGroupListener<T> listener, final String name, final int connectionCount) {
 		this.environment = environment;
 		this.sslContext = sslContext;
 		this.eventLoopGroup = eventLoopGroup;
 		this.connectionConfiguration = connectionConfiguration;
-
-		if (name != null) {
-			this.name = name;
-		} else {
-			this.name = String.format("ApnsConnectionGroup-%d", GROUP_COUNTER.getAndIncrement());
-		}
+		this.name = name;
 
 		this.listener = listener;
 		this.connectionCount = connectionCount;

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
@@ -107,8 +107,8 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 			final ScheduledFuture<?> future = this.eventLoopGroup.schedule(new Runnable() {
 				@Override
 				public void run() {
-					synchronized (ApnsConnectionGroup.this.connections) {
-						if (ApnsConnectionGroup.this.shouldMaintainConnections) {
+					if (ApnsConnectionGroup.this.shouldMaintainConnections) {
+						synchronized (ApnsConnectionGroup.this.connections) {
 							final String connectionName = String.format("%s-%d", ApnsConnectionGroup.this.name, ApnsConnectionGroup.this.connectionCounter.getAndIncrement());
 
 							final ApnsConnection<T> connection =

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
@@ -105,20 +105,20 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 			final ScheduledFuture<?> future = this.eventLoopGroup.schedule(new Runnable() {
 				@Override
 				public void run() {
-					synchronized (ApnsConnectionGroup.this.connectionFutures) {
-						synchronized (ApnsConnectionGroup.this.connections) {
-							if (ApnsConnectionGroup.this.shouldMaintainConnections) {
-								final String connectionName = String.format("%s-%d", ApnsConnectionGroup.this.name, ApnsConnectionGroup.this.connectionCounter.getAndIncrement());
+					synchronized (ApnsConnectionGroup.this.connections) {
+						if (ApnsConnectionGroup.this.shouldMaintainConnections) {
+							final String connectionName = String.format("%s-%d", ApnsConnectionGroup.this.name, ApnsConnectionGroup.this.connectionCounter.getAndIncrement());
 
-								final ApnsConnection<T> connection =
-										new ApnsConnection<T>(ApnsConnectionGroup.this.environment, ApnsConnectionGroup.this.sslContext, ApnsConnectionGroup.this.eventLoopGroup, ApnsConnectionGroup.this.connectionConfiguration, ApnsConnectionGroup.this, connectionName);
+							final ApnsConnection<T> connection =
+									new ApnsConnection<T>(ApnsConnectionGroup.this.environment, ApnsConnectionGroup.this.sslContext, ApnsConnectionGroup.this.eventLoopGroup, ApnsConnectionGroup.this.connectionConfiguration, ApnsConnectionGroup.this, connectionName);
 
-								ApnsConnectionGroup.this.connections.add(connection);
-								connection.connect();
-							}
-
-							ApnsConnectionGroup.this.connectionFutures.remove(this);
+							ApnsConnectionGroup.this.connections.add(connection);
+							connection.connect();
 						}
+					}
+
+					synchronized (ApnsConnectionGroup.this.connectionFutures) {
+						ApnsConnectionGroup.this.connectionFutures.remove(this);
 					}
 				}
 			}, delayMillis, TimeUnit.MILLISECONDS);

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
@@ -1,3 +1,24 @@
+/* Copyright (c) 2015 RelayRides
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.relayrides.pushy.apns;
 
 import io.netty.channel.EventLoopGroup;

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
@@ -1,0 +1,201 @@
+package com.relayrides.pushy.apns;
+
+import io.netty.channel.EventLoopGroup;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.net.ssl.SSLContext;
+
+public class ApnsConnectionGroup<T extends ApnsPushNotification> implements ApnsConnectionListener<T> {
+	private final int connectionCount;
+
+	private final ApnsEnvironment environment;
+	private final SSLContext sslContext;
+	private final EventLoopGroup eventLoopGroup;
+	private final ApnsConnectionConfiguration connectionConfiguration;
+
+	private final String name;
+	private final ApnsConnectionGroupListener<T> listener;
+
+	private volatile boolean shouldMaintainConnections = false;
+
+	private final List<ApnsConnection<T>> connections = new ArrayList<ApnsConnection<T>>();
+	private final Map<ApnsConnection<T>, ScheduledFuture<?>> connectionFutures = new HashMap<ApnsConnection<T>, ScheduledFuture<?>>();
+	private final BlockingQueue<ApnsConnection<T>> writableConnections = new LinkedBlockingQueue<ApnsConnection<T>>();
+
+	private long reconnectDelay = 0;
+
+	private static final AtomicInteger GROUP_COUNTER = new AtomicInteger(0);
+	private static final AtomicInteger CONNECTION_COUNTER = new AtomicInteger(0);
+
+	private static final long INITIAL_RECONNECT_DELAY = 100;
+	private static final long MAX_RECONNECT_DELAY = INITIAL_RECONNECT_DELAY * 512;
+
+	public ApnsConnectionGroup(final ApnsEnvironment environment, final SSLContext sslContext, final EventLoopGroup eventLoopGroup, final ApnsConnectionConfiguration connectionConfiguration, final ApnsConnectionGroupListener<T> listener, final String name, final int connectionCount) {
+		this.environment = environment;
+		this.sslContext = sslContext;
+		this.eventLoopGroup = eventLoopGroup;
+		this.connectionConfiguration = connectionConfiguration;
+
+		if (name != null) {
+			this.name = name;
+		} else {
+			this.name = String.format("ApnsConnectionGroup-%d", GROUP_COUNTER.getAndIncrement());
+		}
+
+		this.listener = listener;
+		this.connectionCount = connectionCount;
+	}
+
+	public void connectAll() {
+		this.shouldMaintainConnections = true;
+
+		synchronized (this.connections) {
+			for (int i = this.connections.size(); i < this.connectionCount; i++) {
+				this.addConnectionWithDelay(0);
+			}
+		}
+	}
+
+	public void disconnectAllGracefuly() {
+		this.shouldMaintainConnections = false;
+
+		synchronized (this.connectionFutures) {
+			for (final Map.Entry<ApnsConnection<T>, ScheduledFuture<?>> entry : this.connectionFutures.entrySet()) {
+				if (entry.getValue().cancel(false)) {
+					// If we successfully cancelled the connection future, we can just remove the connection immediately.
+					// Otherwise, we'll have to wait for it to fail/close on its own.
+					this.removeConnection(entry.getKey());
+				}
+			}
+
+			this.connectionFutures.clear();
+		}
+
+		synchronized (this.connections) {
+			for (final ApnsConnection<T> connection : this.connections) {
+				connection.disconnectGracefully();
+			}
+		}
+	}
+
+	public void waitForAllConnectionsToClose() throws InterruptedException {
+		synchronized (this.connections) {
+			while (!this.connections.isEmpty()) {
+				this.connections.wait();
+			}
+		}
+	}
+
+	private void addConnectionWithDelay(final long delayMillis) {
+		synchronized (this.connectionFutures) {
+			final String connectionName = String.format("%s-%d", this.name, CONNECTION_COUNTER.getAndIncrement());
+
+			final ApnsConnection<T> connection =
+					new ApnsConnection<T>(this.environment, this.sslContext, this.eventLoopGroup, this.connectionConfiguration, this, connectionName);
+
+			final ScheduledFuture<?> future = this.eventLoopGroup.schedule(new Runnable() {
+				@Override
+				public void run() {
+					synchronized (ApnsConnectionGroup.this.connectionFutures) {
+						connection.connect();
+						ApnsConnectionGroup.this.connectionFutures.remove(connection);
+					}
+				}
+			}, delayMillis, TimeUnit.MILLISECONDS);
+
+			this.connectionFutures.put(connection, future);
+		}
+	}
+
+	private void removeConnection(final ApnsConnection<T> connection) {
+		synchronized (this.connections) {
+			this.connections.remove(connection);
+
+			if (this.connections.isEmpty()) {
+				this.connections.notifyAll();
+			}
+		}
+	}
+
+	public void sendNotification(final T notification) throws InterruptedException {
+		// Get a connection, then immediately rotate it to the tail of the queue
+		final ApnsConnection<T> connection = this.writableConnections.take();
+
+		// TODO Figure out what to do if the connection's writabiliy changes after we get it, but before we return it
+		// to the queue
+		this.writableConnections.add(connection);
+
+		connection.sendNotification(notification);
+	}
+
+	@Override
+	public void handleConnectionSuccess(final ApnsConnection<T> connection) {
+		this.writableConnections.add(connection);
+		this.reconnectDelay = 0;
+	}
+
+	@Override
+	public void handleConnectionFailure(ApnsConnection<T> connection, Throwable cause) {
+		if (this.shouldMaintainConnections) {
+			addConnectionWithDelay(this.reconnectDelay);
+
+			// This isn't really thread-safe, but the consequences of a screw-up are pretty mild, so we don't worry about
+			// it too much.
+			this.reconnectDelay = this.reconnectDelay == 0 ? INITIAL_RECONNECT_DELAY :
+				Math.min(this.reconnectDelay * 2, MAX_RECONNECT_DELAY);
+		}
+
+		this.removeConnection(connection);
+	}
+
+	@Override
+	public void handleConnectionWritabilityChange(ApnsConnection<T> connection, boolean writable) {
+		if (writable) {
+			this.writableConnections.add(connection);
+		} else {
+			this.writableConnections.remove(connection);
+		}
+	}
+
+	@Override
+	public void handleConnectionClosure(ApnsConnection<T> connection) {
+		this.writableConnections.remove(connection);
+
+		if (this.shouldMaintainConnections) {
+			this.addConnectionWithDelay(0);
+		}
+
+		this.removeConnection(connection);
+	}
+
+	@Override
+	public void handleWriteFailure(final ApnsConnection<T> connection, final T notification, final Throwable cause) {
+		if (this.listener != null) {
+			this.listener.handleWriteFailure(this, notification, cause);
+		}
+	}
+
+	@Override
+	public void handleRejectedNotification(final ApnsConnection<T> connection, final T rejectedNotification, final RejectedNotificationReason reason) {
+		if (this.listener != null) {
+			this.listener.handleRejectedNotification(this, rejectedNotification, reason);
+		}
+	}
+
+	@Override
+	public void handleUnprocessedNotifications(final ApnsConnection<T> connection, final Collection<T> unprocessedNotifications) {
+		if (this.listener != null) {
+			this.listener.handleUnprocessedNotifications(this, unprocessedNotifications);
+		}
+	}
+}

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
@@ -32,10 +32,10 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 	private final Map<ApnsConnection<T>, ScheduledFuture<?>> connectionFutures = new HashMap<ApnsConnection<T>, ScheduledFuture<?>>();
 	private final BlockingQueue<ApnsConnection<T>> writableConnections = new LinkedBlockingQueue<ApnsConnection<T>>();
 
+	private final AtomicInteger connectionCounter = new AtomicInteger(0);
 	private long reconnectDelay = 0;
 
 	private static final AtomicInteger GROUP_COUNTER = new AtomicInteger(0);
-	private static final AtomicInteger CONNECTION_COUNTER = new AtomicInteger(0);
 
 	private static final long INITIAL_RECONNECT_DELAY = 100;
 	private static final long MAX_RECONNECT_DELAY = INITIAL_RECONNECT_DELAY * 512;
@@ -98,7 +98,7 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 
 	private void addConnectionWithDelay(final long delayMillis) {
 		synchronized (this.connectionFutures) {
-			final String connectionName = String.format("%s-%d", this.name, CONNECTION_COUNTER.getAndIncrement());
+			final String connectionName = String.format("%s-%d", this.name, this.connectionCounter.getAndIncrement());
 
 			final ApnsConnection<T> connection =
 					new ApnsConnection<T>(this.environment, this.sslContext, this.eventLoopGroup, this.connectionConfiguration, this, connectionName);

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroup.java
@@ -158,12 +158,12 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 	}
 
 	@Override
-	public void handleConnectionFailure(ApnsConnection<T> connection, Throwable cause) {
+	public void handleConnectionFailure(final ApnsConnection<T> connection, final Throwable cause) {
 		if (this.shouldMaintainConnections) {
 			addConnectionWithDelay(this.reconnectDelay);
 
-			// This isn't really thread-safe, but the consequences of a screw-up are pretty mild, so we don't worry about
-			// it too much.
+			// This isn't really thread-safe, but the consequences of a screw-up are pretty mild, so we don't worry
+			// about it too much.
 			this.reconnectDelay = this.reconnectDelay == 0 ? INITIAL_RECONNECT_DELAY :
 				Math.min(this.reconnectDelay * 2, MAX_RECONNECT_DELAY);
 		}
@@ -173,7 +173,7 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 	}
 
 	@Override
-	public void handleConnectionWritabilityChange(ApnsConnection<T> connection, boolean writable) {
+	public void handleConnectionWritabilityChange(final ApnsConnection<T> connection, final boolean writable) {
 		if (writable) {
 			this.writableConnections.add(connection);
 		} else {
@@ -182,7 +182,7 @@ public class ApnsConnectionGroup<T extends ApnsPushNotification> implements Apns
 	}
 
 	@Override
-	public void handleConnectionClosure(ApnsConnection<T> connection) {
+	public void handleConnectionClosure(final ApnsConnection<T> connection) {
 		this.writableConnections.remove(connection);
 
 		if (this.shouldMaintainConnections) {

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroupListener.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroupListener.java
@@ -1,0 +1,41 @@
+package com.relayrides.pushy.apns;
+
+import java.util.Collection;
+
+public interface ApnsConnectionGroupListener<T extends ApnsPushNotification> {
+	/**
+	 * Indicates that the given connection group failed to send a push notification to an APNs gateway. This indicates a
+	 * local failure; notifications passed to this method were never transmitted to the APNs gateway, and failures of
+	 * this kind generally represent temporary I/O problems (rather than permanent rejection by the gateway), and it is
+	 * generally safe to try to send the failed notifications again later.
+	 *
+	 * @param group the connection group that attempted to deliver the notification
+	 * @param notification the notification that could not be written
+	 * @param cause the cause of the write failure
+	 */
+	void handleWriteFailure(ApnsConnectionGroup<T> group, T notification, Throwable cause);
+
+	/**
+	 * Indicates that a notification sent via the given connection group was definitively rejected by the APNs gateway.
+	 * When an APNs gateway rejects a notification, the rejection should be considered a permanent failure and the
+	 * notification should not be sent again.
+	 *
+	 * @param group the connection group that sent the notification that was rejected
+	 * @param rejectedNotification the notification that was rejected
+	 * @param reason the reason for the rejection
+	 *
+	 * @see ApnsConnectionGroupListener#handleUnprocessedNotifications(ApnsConnectionGroup, Collection)
+	 */
+	void handleRejectedNotification(ApnsConnectionGroup<T> group, T rejectedNotification, RejectedNotificationReason reason);
+
+	/**
+	 * Indicates that notifications that had previously been sent to an APNs gateway by the given connection group were
+	 * not processed by the gateway and should be sent again later. This generally happens after a notification has been
+	 * rejected by the gateway, but may also happen when a connection is closed gracefully by Pushy or closed remotely
+	 * by the APNs gateway without a rejected notification.
+	 *
+	 * @param group the connection group that sent the notifications that were not processed
+	 * @param unprocessedNotifications the notifications known to have not been processed by the APNs gateway
+	 */
+	void handleUnprocessedNotifications(ApnsConnectionGroup<T> group, Collection<T> unprocessedNotifications);
+}

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroupListener.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroupListener.java
@@ -2,6 +2,14 @@ package com.relayrides.pushy.apns;
 
 import java.util.Collection;
 
+/**
+ * An {@code ApnsConnectionGroupListener} receives lifecycle events from {@link ApnsConnection} instances in an
+ * {@link ApnsConnectionGroup}. Handler methods are called from IO threads in the connection's event loop, and as such
+ * handler method implementations <em>must not</em> perform blocking operations. Blocking operations should be
+ * dispatched in separate threads.
+ *
+ * @author <a href="mailto:jon@relayrides.com">Jon Chambers</a>
+ */
 public interface ApnsConnectionGroupListener<T extends ApnsPushNotification> {
 	/**
 	 * Indicates that the given connection group attempted to open a connection to an APNs gateway, but failed.
@@ -12,10 +20,10 @@ public interface ApnsConnectionGroupListener<T extends ApnsPushNotification> {
 	void handleConnectionFailure(ApnsConnectionGroup<T> group, Throwable cause);
 
 	/**
-	 * Indicates that the given connection group failed to send a push notification to an APNs gateway. This indicates a
-	 * local failure; notifications passed to this method were never transmitted to the APNs gateway, and failures of
-	 * this kind generally represent temporary I/O problems (rather than permanent rejection by the gateway), and it is
-	 * generally safe to try to send the failed notifications again later.
+	 * Indicates that a connection in the given connection group failed to send a push notification to an APNs gateway.
+	 * This indicates a local failure; notifications passed to this method were never transmitted to the APNs gateway,
+	 * and failures of this kind generally represent temporary I/O problems (rather than permanent rejection by the
+	 * gateway), and it is generally safe to try to send the failed notifications again later.
 	 *
 	 * @param group the connection group that attempted to deliver the notification
 	 * @param notification the notification that could not be written

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroupListener.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroupListener.java
@@ -1,3 +1,24 @@
+/* Copyright (c) 2015 RelayRides
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.relayrides.pushy.apns;
 
 import java.util.Collection;

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroupListener.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnectionGroupListener.java
@@ -4,6 +4,14 @@ import java.util.Collection;
 
 public interface ApnsConnectionGroupListener<T extends ApnsPushNotification> {
 	/**
+	 * Indicates that the given connection group attempted to open a connection to an APNs gateway, but failed.
+	 *
+	 * @param group the connection group that failed to connect to an APNs gateway
+	 * @param cause the cause of the failure
+	 */
+	void handleConnectionFailure(ApnsConnectionGroup<T> group, Throwable cause);
+
+	/**
 	 * Indicates that the given connection group failed to send a push notification to an APNs gateway. This indicates a
 	 * local failure; notifications passed to this method were never transmitted to the APNs gateway, and failures of
 	 * this kind generally represent temporary I/O problems (rather than permanent rejection by the gateway), and it is

--- a/src/main/java/com/relayrides/pushy/apns/PushManager.java
+++ b/src/main/java/com/relayrides/pushy/apns/PushManager.java
@@ -231,7 +231,7 @@ public class PushManager<T extends ApnsPushNotification> implements ApnsConnecti
 		}
 
 		this.connectionGroup = new ApnsConnectionGroup<T>(this.environment, this.sslContext, this.eventLoopGroup,
-				this.configuration.getConnectionConfiguration(), this, this.name,
+				this.configuration.getConnectionConfiguration(), this, String.format("%s-ConnectionGroup", this.name),
 				this.configuration.getConcurrentConnectionCount());
 	}
 

--- a/src/main/java/com/relayrides/pushy/apns/PushManager.java
+++ b/src/main/java/com/relayrides/pushy/apns/PushManager.java
@@ -388,7 +388,7 @@ public class PushManager<T extends ApnsPushNotification> implements ApnsConnecti
 		this.dispatchThread.interrupt();
 		this.dispatchThread.join();
 
-		this.connectionGroup.disconnectAllGracefuly();
+		this.connectionGroup.disconnectAllGracefully();
 		this.connectionGroup.waitForAllConnectionsToClose();
 
 		while (!this.retryQueue.isEmpty() && !DeadlineUtil.hasDeadlineExpired(deadline)) {
@@ -406,7 +406,7 @@ public class PushManager<T extends ApnsPushNotification> implements ApnsConnecti
 				}
 			}
 
-			this.connectionGroup.disconnectAllGracefuly();
+			this.connectionGroup.disconnectAllGracefully();
 			this.connectionGroup.waitForAllConnectionsToClose(deadline);
 		}
 

--- a/src/main/java/com/relayrides/pushy/apns/util/DeadlineUtil.java
+++ b/src/main/java/com/relayrides/pushy/apns/util/DeadlineUtil.java
@@ -1,3 +1,24 @@
+/* Copyright (c) 2015 RelayRides
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.relayrides.pushy.apns.util;
 
 import java.util.Date;

--- a/src/main/java/com/relayrides/pushy/apns/util/DeadlineUtil.java
+++ b/src/main/java/com/relayrides/pushy/apns/util/DeadlineUtil.java
@@ -1,0 +1,51 @@
+package com.relayrides.pushy.apns.util;
+
+import java.util.Date;
+
+/**
+ * A utility class for working with deadlines and timeouts.
+ *
+ * @author <a href="mailto:jon@relayrides.com">Jon Chambers</a>
+ */
+public class DeadlineUtil {
+
+	/**
+	 * Returns the number of milliseconds between the current time and the given deadline. If the given deadline is
+	 * {@code null}, this method will return {@link java.lang.Long#MAX_VALUE}. Under no circumstances will this method
+	 * return a result less than 1 millisecond (since many methods interpret a timeout of zero as a signal to wait
+	 * indefinitely).
+	 *
+	 * @param deadline the deadline for which to calculate the number of milliseconds to wait
+	 *
+	 * @return the number of milliseconds to wait for the given deadline
+	 */
+	public static long getMillisToWaitForDeadline(final Date deadline) {
+		final long millisToWaitForDeadline;
+
+		if (deadline != null) {
+			millisToWaitForDeadline = Math.max(deadline.getTime() - System.currentTimeMillis(), 1);
+		} else {
+			millisToWaitForDeadline = Long.MAX_VALUE;
+		}
+
+		return millisToWaitForDeadline;
+	}
+
+	/**
+	 * Indicates whether the given deadline has passed. If the given deadline is {@code null}, this method will always
+	 * return {@code false}.
+	 *
+	 * @param deadline the deadline to check
+	 *
+	 * @return {@code true} if the given deadline is in the past or {@code false} if the deadline is {@code null} or not
+	 * in the past
+	 */
+	public static boolean hasDeadlineExpired(final Date deadline) {
+		if (deadline != null) {
+			return System.currentTimeMillis() > deadline.getTime();
+		} else {
+			return false;
+		}
+	}
+
+}

--- a/src/main/java/com/relayrides/pushy/apns/util/DeadlineUtil.java
+++ b/src/main/java/com/relayrides/pushy/apns/util/DeadlineUtil.java
@@ -3,7 +3,7 @@ package com.relayrides.pushy.apns.util;
 import java.util.Date;
 
 /**
- * A utility class for working with deadlines and timeouts.
+ * Contains utility methods for working with deadlines and timeouts.
  *
  * @author <a href="mailto:jon@relayrides.com">Jon Chambers</a>
  */

--- a/src/test/java/com/relayrides/pushy/apns/ApnsConnectionGroupTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/ApnsConnectionGroupTest.java
@@ -1,3 +1,24 @@
+/* Copyright (c) 2015 RelayRides
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.relayrides.pushy.apns;
 
 import static org.junit.Assert.*;

--- a/src/test/java/com/relayrides/pushy/apns/ApnsConnectionGroupTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/ApnsConnectionGroupTest.java
@@ -1,0 +1,163 @@
+package com.relayrides.pushy.apns;
+
+import static org.junit.Assert.*;
+
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.relayrides.pushy.apns.util.SimpleApnsPushNotification;
+
+public class ApnsConnectionGroupTest extends BasePushyTest {
+
+	@Override
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+	}
+
+	@Test
+	public void testConnectAllAndDisconnectAllGracefully() throws Exception {
+		final int connectionCount = 4;
+
+		final ApnsConnectionGroup<SimpleApnsPushNotification> testGroup =
+				new ApnsConnectionGroup<SimpleApnsPushNotification>(TEST_ENVIRONMENT,
+						SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
+						new ApnsConnectionConfiguration(), null, "TestGroup", 4);
+
+		final CountDownLatch connectionLatch = this.getApnsServer().getSuccessfulConnectionCountDownLatch(connectionCount);
+
+		testGroup.connectAll();
+		waitForLatch(connectionLatch);
+
+		testGroup.disconnectAllGracefully();
+		testGroup.waitForAllConnectionsToClose();
+	}
+
+	@Test
+	public void testConnectAllAndDisconnectAllImmediately() throws Exception {
+		final int connectionCount = 4;
+
+		final ApnsConnectionGroup<SimpleApnsPushNotification> testGroup =
+				new ApnsConnectionGroup<SimpleApnsPushNotification>(TEST_ENVIRONMENT,
+						SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
+						new ApnsConnectionConfiguration(), null, "TestGroup", 4);
+
+		final CountDownLatch connectionLatch = this.getApnsServer().getSuccessfulConnectionCountDownLatch(connectionCount);
+
+		testGroup.connectAll();
+		waitForLatch(connectionLatch);
+
+		testGroup.disconnectAllImmediately();
+		testGroup.waitForAllConnectionsToClose();
+	}
+
+	@Test
+	public void testIncreaseConnectionDelay() throws Exception {
+		final ApnsConnectionGroup<SimpleApnsPushNotification> testGroup =
+				new ApnsConnectionGroup<SimpleApnsPushNotification>(TEST_ENVIRONMENT,
+						SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
+						new ApnsConnectionConfiguration(), null, "TestGroup", 1);
+
+		assertEquals(0, testGroup.getConnectionDelay());
+
+		testGroup.increaseConnectionDelay();
+		assertEquals(ApnsConnectionGroup.INITIAL_RECONNECT_DELAY, testGroup.getConnectionDelay());
+
+		while (testGroup.getConnectionDelay() < ApnsConnectionGroup.MAX_RECONNECT_DELAY) {
+			testGroup.increaseConnectionDelay();
+		}
+
+		testGroup.increaseConnectionDelay();
+		assertEquals(ApnsConnectionGroup.MAX_RECONNECT_DELAY, testGroup.getConnectionDelay());
+	}
+
+	@Test
+	public void testResetConnectionDelay() throws Exception {
+		final ApnsConnectionGroup<SimpleApnsPushNotification> testGroup =
+				new ApnsConnectionGroup<SimpleApnsPushNotification>(TEST_ENVIRONMENT,
+						SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
+						new ApnsConnectionConfiguration(), null, "TestGroup", 1);
+
+		assertEquals(0, testGroup.getConnectionDelay());
+
+		testGroup.increaseConnectionDelay();
+		assertTrue(testGroup.getConnectionDelay() > 0);
+
+		testGroup.resetConnectionDelay();
+		assertEquals(0, testGroup.getConnectionDelay());
+	}
+
+	@Test
+	public void testWaitForAllConnectionsToCloseDate() throws Exception {
+		final int connectionCount = 4;
+
+		final ApnsConnectionGroup<SimpleApnsPushNotification> testGroup =
+				new ApnsConnectionGroup<SimpleApnsPushNotification>(TEST_ENVIRONMENT,
+						SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
+						new ApnsConnectionConfiguration(), null, "TestGroup", 4);
+
+		final CountDownLatch connectionLatch = this.getApnsServer().getSuccessfulConnectionCountDownLatch(connectionCount);
+
+		testGroup.connectAll();
+		waitForLatch(connectionLatch);
+
+		final Date deadline = new Date(System.currentTimeMillis() + 1000);
+
+		assertFalse("Waiting for connections to close should timeout if closure has not been requested.",
+				testGroup.waitForAllConnectionsToClose(deadline));
+
+		testGroup.disconnectAllGracefully();
+		testGroup.waitForAllConnectionsToClose(null);
+	}
+
+	@Test
+	public void testGetNextConnection() throws Exception {
+		final int connectionCount = 4;
+
+		final ApnsConnectionGroup<SimpleApnsPushNotification> testGroup =
+				new ApnsConnectionGroup<SimpleApnsPushNotification>(TEST_ENVIRONMENT,
+						SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
+						new ApnsConnectionConfiguration(), null, "TestGroup", 4);
+
+		final CountDownLatch connectionLatch = this.getApnsServer().getSuccessfulConnectionCountDownLatch(connectionCount);
+
+		testGroup.connectAll();
+		waitForLatch(connectionLatch);
+
+		final ApnsConnection<SimpleApnsPushNotification> firstConnection = testGroup.getNextConnection();
+		final ApnsConnection<SimpleApnsPushNotification> secondConnection = testGroup.getNextConnection();
+
+		assertNotNull(firstConnection);
+		assertNotNull(secondConnection);
+		assertNotEquals(firstConnection, secondConnection);
+
+		testGroup.disconnectAllGracefully();
+		testGroup.waitForAllConnectionsToClose(null);
+	}
+
+	@Test
+	public void testGetNextConnectionLong() throws Exception {
+		final int connectionCount = 4;
+
+		final ApnsConnectionGroup<SimpleApnsPushNotification> testGroup =
+				new ApnsConnectionGroup<SimpleApnsPushNotification>(TEST_ENVIRONMENT,
+						SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
+						new ApnsConnectionConfiguration(), null, "TestGroup", 4);
+
+		final long timeoutMillis = 1000;
+		assertNull(testGroup.getNextConnection(timeoutMillis));
+
+		final CountDownLatch connectionLatch = this.getApnsServer().getSuccessfulConnectionCountDownLatch(connectionCount);
+
+		testGroup.connectAll();
+		waitForLatch(connectionLatch);
+
+		assertNotNull(testGroup.getNextConnection(timeoutMillis));
+
+		testGroup.disconnectAllGracefully();
+		testGroup.waitForAllConnectionsToClose(null);
+	}
+}

--- a/src/test/java/com/relayrides/pushy/apns/ApnsConnectionTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/ApnsConnectionTest.java
@@ -46,7 +46,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 
 	private static final String TEST_CONNECTION_NAME = "Test connection";
 
-	private class TestListener implements ApnsConnectionListener<SimpleApnsPushNotification> {
+	private class TestConnectionListener implements ApnsConnectionListener<SimpleApnsPushNotification> {
 
 		private final Object mutex;
 
@@ -63,7 +63,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 
 		private final ArrayList<SimpleApnsPushNotification> unprocessedNotifications = new ArrayList<SimpleApnsPushNotification>();
 
-		public TestListener(final Object mutex) {
+		public TestConnectionListener(final Object mutex) {
 			this.mutex = mutex;
 		}
 
@@ -161,7 +161,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 		// For this test, we just want to make sure that connection succeeds and nothing explodes.
 		final Object mutex = new Object();
 
-		final TestListener listener = new TestListener(mutex);
+		final TestConnectionListener listener = new TestConnectionListener(mutex);
 		final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
 				new ApnsConnection<SimpleApnsPushNotification>(
 						TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
@@ -183,7 +183,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 		final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
 				new ApnsConnection<SimpleApnsPushNotification>(
 						TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
-						new ApnsConnectionConfiguration(), new TestListener(new Object()), TEST_CONNECTION_NAME);
+						new ApnsConnectionConfiguration(), new TestConnectionListener(new Object()), TEST_CONNECTION_NAME);
 
 		apnsConnection.connect();
 		apnsConnection.connect();
@@ -194,7 +194,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 
 		final Object mutex = new Object();
 
-		final TestListener listener = new TestListener(mutex);
+		final TestConnectionListener listener = new TestConnectionListener(mutex);
 
 		final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
 				new ApnsConnection<SimpleApnsPushNotification>(
@@ -218,7 +218,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 
 		final Object mutex = new Object();
 
-		final TestListener listener = new TestListener(mutex);
+		final TestConnectionListener listener = new TestConnectionListener(mutex);
 
 		final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
 				new ApnsConnection<SimpleApnsPushNotification>(
@@ -241,7 +241,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 	public void testConnectionRefusal() throws Exception {
 		final Object mutex = new Object();
 
-		final TestListener listener = new TestListener(mutex);
+		final TestConnectionListener listener = new TestConnectionListener(mutex);
 		final ApnsEnvironment connectionRefusedEnvironment = new ApnsEnvironment("localhost", 7876, "localhost", 7877);
 
 		final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
@@ -264,7 +264,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 	public void testSendNotification() throws UnrecoverableKeyException, KeyManagementException, KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException, InterruptedException {
 		final Object mutex = new Object();
 
-		final TestListener listener = new TestListener(mutex);
+		final TestConnectionListener listener = new TestConnectionListener(mutex);
 		final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
 				new ApnsConnection<SimpleApnsPushNotification>(
 						TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
@@ -290,7 +290,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 	public void testSendNotificationWithNullPriority() throws Exception {
 		final Object mutex = new Object();
 
-		final TestListener listener = new TestListener(mutex);
+		final TestConnectionListener listener = new TestConnectionListener(mutex);
 		final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
 				new ApnsConnection<SimpleApnsPushNotification>(
 						TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
@@ -322,7 +322,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 	public void testSendNotificationWithError() throws UnrecoverableKeyException, KeyManagementException, KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException, InterruptedException {
 		final Object mutex = new Object();
 
-		final TestListener listener = new TestListener(mutex);
+		final TestConnectionListener listener = new TestConnectionListener(mutex);
 		final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
 				new ApnsConnection<SimpleApnsPushNotification>(
 						TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
@@ -358,7 +358,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 	public void testShutdownGracefully() throws UnrecoverableKeyException, KeyManagementException, KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException, InterruptedException {
 		final Object mutex = new Object();
 
-		final TestListener listener = new TestListener(mutex);
+		final TestConnectionListener listener = new TestConnectionListener(mutex);
 		final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
 				new ApnsConnection<SimpleApnsPushNotification>(
 						TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
@@ -392,7 +392,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 	public void testDoubleShutdownGracefully() throws Exception {
 		final Object mutex = new Object();
 
-		final TestListener listener = new TestListener(mutex);
+		final TestConnectionListener listener = new TestConnectionListener(mutex);
 		final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
 				new ApnsConnection<SimpleApnsPushNotification>(
 						TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
@@ -427,7 +427,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 	public void testShutdownGracefullyBeforeConnect() throws Exception {
 		final Object mutex = new Object();
 
-		final TestListener listener = new TestListener(mutex);
+		final TestConnectionListener listener = new TestConnectionListener(mutex);
 		final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
 				new ApnsConnection<SimpleApnsPushNotification>(
 						TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
@@ -440,7 +440,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 	public void testShutdownImmediately() throws UnrecoverableKeyException, KeyManagementException, KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException, InterruptedException {
 		final Object mutex = new Object();
 
-		final TestListener listener = new TestListener(mutex);
+		final TestConnectionListener listener = new TestConnectionListener(mutex);
 		final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
 				new ApnsConnection<SimpleApnsPushNotification>(
 						TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
@@ -471,7 +471,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 	public void testShutdownImmediatelyBeforeConnect() throws Exception {
 		final Object mutex = new Object();
 
-		final TestListener listener = new TestListener(mutex);
+		final TestConnectionListener listener = new TestConnectionListener(mutex);
 		final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
 				new ApnsConnection<SimpleApnsPushNotification>(
 						TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),
@@ -484,7 +484,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 	public void testWriteTimeout() throws Exception {
 		final Object mutex = new Object();
 
-		final TestListener listener = new TestListener(mutex);
+		final TestConnectionListener listener = new TestConnectionListener(mutex);
 
 		final ApnsConnectionConfiguration writeTimeoutConfiguration = new ApnsConnectionConfiguration();
 		writeTimeoutConfiguration.setCloseAfterInactivityTime(1);
@@ -510,7 +510,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 	public void testGracefulShutdownTimeout() throws Exception {
 		final Object mutex = new Object();
 
-		final TestListener listener = new TestListener(mutex);
+		final TestConnectionListener listener = new TestConnectionListener(mutex);
 
 		final ApnsConnectionConfiguration gracefulShutdownTimeoutConfiguration = new ApnsConnectionConfiguration();
 		gracefulShutdownTimeoutConfiguration.setGracefulDisconnectionTimeout(1);
@@ -553,7 +553,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 
 		final Object mutex = new Object();
 
-		final TestListener listener = new TestListener(mutex);
+		final TestConnectionListener listener = new TestConnectionListener(mutex);
 
 		final ApnsConnectionConfiguration sendAttemptLimitConfiguration = new ApnsConnectionConfiguration();
 		sendAttemptLimitConfiguration.setSendAttemptLimit(100);
@@ -595,7 +595,7 @@ public class ApnsConnectionTest extends BasePushyTest {
 		try {
 			final Object mutex = new Object();
 
-			final TestListener listener = new TestListener(mutex);
+			final TestConnectionListener listener = new TestConnectionListener(mutex);
 			final ApnsConnection<SimpleApnsPushNotification> apnsConnection =
 					new ApnsConnection<SimpleApnsPushNotification>(
 							TEST_ENVIRONMENT, SSLTestUtil.createSSLContextForTestClient(), this.getEventLoopGroup(),


### PR DESCRIPTION
This does a few things:

1. Connection lifecycle management gets moved out of `PushManager` and into `ApnsConnectionGroup`.
2. `ApnsConnectionGroup` opens connections by scheduling tasks on its event loop, which gives us a way to do exponential back-off.
3. Greatly simplified and untangled drain-before-shutdown behavior (no more weird interactions between the dispatch thread and the `PushManager`).

----

TODO:

- [x] Document the `ApnsConnectionGroup` class (9aca76a)
- [x] Resolve shutdown/timeout TODOs (eb4cc29)
- [x] Figure out how to test exponential back-off (eb4cc29, a45a45d)
- [x] Add or migrate tests for `ApnsConnectionGroup` (a45a45d)