### PR TITLE
Variable maximum payload lengths (fixes #151)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ final ApnsPayloadBuilder payloadBuilder = new ApnsPayloadBuilder();
 payloadBuilder.setAlertBody("Ring ring, Neo.");
 payloadBuilder.setSoundFileName("ring-ring.aiff");
 
-final String payload = payloadBuilder.buildWithDefaultMaximumLength();
+final String payload =
+    payloadBuilder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER);
 
 pushManager.getQueue().put(new SimpleApnsPushNotification(token, payload));
 ```

--- a/src/main/java/com/relayrides/pushy/apns/util/IOSVersion.java
+++ b/src/main/java/com/relayrides/pushy/apns/util/IOSVersion.java
@@ -1,0 +1,6 @@
+package com.relayrides.pushy.apns.util;
+
+public enum IOSVersion {
+	IOS_7_AND_OLDER,
+	IOS_8_AND_NEWER
+}

--- a/src/main/java/com/relayrides/pushy/apns/util/IOSVersion.java
+++ b/src/main/java/com/relayrides/pushy/apns/util/IOSVersion.java
@@ -1,5 +1,31 @@
+/* Copyright (c) 2015 RelayRides
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.relayrides.pushy.apns.util;
 
+/**
+ * An enumeration of ranges of iOS versions for the purpose of choosing a maximum notification payload length.
+ *
+ * @author <a href="mailto:jon@relayrides.com">Jon Chambers</a>
+ */
 public enum IOSVersion {
 	IOS_7_AND_OLDER,
 	IOS_8_AND_NEWER

--- a/src/test/java/com/relayrides/pushy/apns/BenchmarkApp.java
+++ b/src/test/java/com/relayrides/pushy/apns/BenchmarkApp.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import com.relayrides.pushy.apns.util.ApnsPayloadBuilder;
+import com.relayrides.pushy.apns.util.IOSVersion;
 import com.relayrides.pushy.apns.util.SimpleApnsPushNotification;
 
 public class BenchmarkApp {
@@ -73,7 +74,7 @@ public class BenchmarkApp {
 
 			builder.setAlertBody(new BigInteger(1024, new Random()).toString(16));
 
-			this.notifications.add(new SimpleApnsPushNotification(token, builder.buildWithDefaultMaximumLength()));
+			this.notifications.add(new SimpleApnsPushNotification(token, builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER)));
 		}
 	}
 

--- a/src/test/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -1,15 +1,15 @@
 /* Copyright (c) 2013 RelayRides
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -52,7 +52,7 @@ public class ApnsPayloadBuilderTest {
 		this.builder.setAlertBody(alertBody);
 
 		{
-			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 
 			// The alert property should be a string if all we're specifying is a literal alert message
 			assertEquals(alertBody, aps.get("alert"));
@@ -61,7 +61,7 @@ public class ApnsPayloadBuilderTest {
 		this.builder.setShowActionButton(false);
 
 		{
-			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 			final JSONObject alert = (JSONObject) aps.get("alert");
 
 			assertEquals(alertBody, alert.get("body"));
@@ -75,7 +75,7 @@ public class ApnsPayloadBuilderTest {
 		this.builder.setAlertTitle(alertTitle);
 
 		{
-			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 			final JSONObject alert = (JSONObject) aps.get("alert");
 
 			assertEquals(alertTitle, alert.get("title"));
@@ -91,7 +91,7 @@ public class ApnsPayloadBuilderTest {
 		this.builder.setAlertTitle(alertTitle);
 
 		{
-			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 			final JSONObject alert = (JSONObject) aps.get("alert");
 
 			assertEquals(alertTitle, alert.get("title"));
@@ -106,7 +106,7 @@ public class ApnsPayloadBuilderTest {
 		this.builder.setLocalizedAlertMessage(alertKey, null);
 
 		{
-			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 			final JSONObject alert = (JSONObject) aps.get("alert");
 
 			assertEquals(alertKey, alert.get("loc-key"));
@@ -117,7 +117,7 @@ public class ApnsPayloadBuilderTest {
 		this.builder.setLocalizedAlertMessage(alertKey, alertArgs);
 
 		{
-			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 			final JSONObject alert = (JSONObject) aps.get("alert");
 
 			assertEquals(alertKey, alert.get("loc-key"));
@@ -157,7 +157,7 @@ public class ApnsPayloadBuilderTest {
 		final String launchImageFilename = "launch.png";
 		this.builder.setLaunchImageFileName(launchImageFilename);
 
-		final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+		final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 		final JSONObject alert = (JSONObject) aps.get("alert");
 
 		assertEquals(launchImageFilename, alert.get("launch-image"));
@@ -168,7 +168,7 @@ public class ApnsPayloadBuilderTest {
 		this.builder.setShowActionButton(true);
 
 		{
-			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 
 			assertNull(aps.get("alert"));
 		}
@@ -176,7 +176,7 @@ public class ApnsPayloadBuilderTest {
 		this.builder.setShowActionButton(false);
 
 		{
-			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 			final JSONObject alert = (JSONObject) aps.get("alert");
 
 			assertTrue(alert.keySet().contains("action-loc-key"));
@@ -188,7 +188,7 @@ public class ApnsPayloadBuilderTest {
 		this.builder.setShowActionButton(true);
 
 		{
-			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 			final JSONObject alert = (JSONObject) aps.get("alert");
 
 			assertEquals(actionButtonKey, alert.get("action-loc-key"));
@@ -197,7 +197,7 @@ public class ApnsPayloadBuilderTest {
 		this.builder.setShowActionButton(false);
 
 		{
-			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 			final JSONObject alert = (JSONObject) aps.get("alert");
 
 			assertTrue(alert.keySet().contains("action-loc-key"));
@@ -210,7 +210,7 @@ public class ApnsPayloadBuilderTest {
 		final String actionButtonKey = "action.key";
 		this.builder.setLocalizedActionButtonKey(actionButtonKey);
 
-		final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+		final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 		final JSONObject alert = (JSONObject) aps.get("alert");
 
 		assertEquals(actionButtonKey, alert.get("action-loc-key"));
@@ -221,7 +221,7 @@ public class ApnsPayloadBuilderTest {
 		final int badgeNumber = 4;
 		this.builder.setBadgeNumber(badgeNumber);
 
-		final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+		final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 
 		assertEquals(badgeNumber, ((Number) aps.get("badge")).intValue());
 	}
@@ -231,7 +231,7 @@ public class ApnsPayloadBuilderTest {
 		final String soundFileName = "dying-giraffe.aiff";
 		this.builder.setSoundFileName(soundFileName);
 
-		final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+		final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 
 		assertEquals(soundFileName, aps.get("sound"));
 	}
@@ -241,7 +241,7 @@ public class ApnsPayloadBuilderTest {
 		final String categoryName = "INVITE";
 		this.builder.setCategoryName(categoryName);
 
-		final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+		final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 
 		assertEquals(categoryName, aps.get("category"));
 	}
@@ -249,14 +249,14 @@ public class ApnsPayloadBuilderTest {
 	@Test
 	public void testSetContentAvailable() throws ParseException {
 		{
-			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 			assertNull(aps.get("content-available"));
 		}
 
 		{
 			this.builder.setContentAvailable(true);
 
-			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+			final JSONObject aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 			assertEquals(1L, aps.get("content-available"));
 		}
 	}
@@ -268,7 +268,7 @@ public class ApnsPayloadBuilderTest {
 
 		this.builder.addCustomProperty(customKey, customValue);
 
-		final JSONObject payload = (JSONObject) this.parser.parse(this.builder.buildWithDefaultMaximumLength());
+		final JSONObject payload = (JSONObject) this.parser.parse(this.builder.buildWithMaximumLengthForIOSVersion(IOSVersion.IOS_8_AND_NEWER));
 
 		assertEquals(customValue, payload.get(customKey));
 	}


### PR DESCRIPTION
This change makes the maximum payload length for a push notification depend on the version of iOS running on the receiving device. Unfortunately, callers will need to keep track of the iOS version associated with APNs tokens on their own.