### PR TITLE
Wait for last write listeners to finish before handling closure

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -86,8 +86,8 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 	// having an expired token) is vanishingly small.
 	private int sequenceNumber = 1;
 
-	private ChannelFuture lastWriteFuture;
-	private boolean lastWriteFutureListenerFinished;
+	private volatile ChannelFuture lastWriteFuture;
+	private volatile boolean lastWriteFutureListenerFinished = false;
 
 	private int sendAttempts = 0;
 


### PR DESCRIPTION
In #166, we simplified the process by which we wait for things to finish before notifying listeners that a channel has closed. I believe there was a mistake in that approach; not only should we wait for the last write *future* to close, we should also wait for the *listener* attached to that future to finish up. This change makes sure the listener attached to the last write future has finished up before allowing channel closure. I'm pretty sure this will fix the sporadic build failures we're seeing in (for example) #169 and #174.

Additionally, this simplifies the "last write future" business further by not tracking shutdown notifications. We can get away with this because shutdown notifications are an internal detail that never get reported to listeners.