### PR TITLE
(feat) Do not retry when connection rejected by a fatal reason.

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/FailedConnectionListener.java
+++ b/src/main/java/com/relayrides/pushy/apns/FailedConnectionListener.java
@@ -47,5 +47,5 @@ public interface FailedConnectionListener<T extends ApnsPushNotification> {
 	 * @param pushManager the push manager that failed to open a connection
 	 * @param cause the cause for the connection failure
 	 */
-	void handleFailedConnection(PushManager<? extends T> pushManager, Throwable cause);
+	void handleFailedConnection(PushManager<? extends T> pushManager, Throwable cause, boolean fatal);
 }

--- a/src/main/java/com/relayrides/pushy/apns/util/ExceptionUtil.java
+++ b/src/main/java/com/relayrides/pushy/apns/util/ExceptionUtil.java
@@ -1,0 +1,28 @@
+package com.relayrides.pushy.apns.util;
+
+import javax.net.ssl.SSLException;
+
+/**
+ * Created by nsun on 15-6-1.
+ */
+public class ExceptionUtil {
+
+    /**
+     * Test if an exception is a fatal error, which reconnection doesn't solve the issue.
+     *
+     * Exceptions currently considered as FATAL:
+     * <ul>
+     *     <li>javax.net.ssl.SSLException: Received fatal alert: certificate_revoked</li>
+     *     <li>javax.net.ssl.SSLException: Received fatal alert: certificate_expired</li>
+     * </ul>
+     *
+     * @param e
+     * @return
+     */
+    public static boolean isFatal(Throwable e) {
+        if (e instanceof SSLException) {
+            return e.getMessage().contains("Received fatal alert");
+        }
+        return false;
+    }
+}

--- a/src/test/java/com/relayrides/pushy/apns/BenchmarkApp.java
+++ b/src/test/java/com/relayrides/pushy/apns/BenchmarkApp.java
@@ -52,7 +52,7 @@ public class BenchmarkApp {
 	private class BenchmarkErrorListener implements RejectedNotificationListener<SimpleApnsPushNotification>, FailedConnectionListener<SimpleApnsPushNotification> {
 
 		@Override
-		public void handleFailedConnection(final PushManager<? extends SimpleApnsPushNotification> pushManager, final Throwable cause) {
+		public void handleFailedConnection(final PushManager<? extends SimpleApnsPushNotification> pushManager, final Throwable cause, boolean fatal) {
 			System.err.println("Connection failed.");
 			cause.printStackTrace(System.err);
 		}

--- a/src/test/java/com/relayrides/pushy/apns/PushManagerTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/PushManagerTest.java
@@ -66,15 +66,17 @@ public class PushManagerTest extends BasePushyTest {
 
 		private PushManager<? extends SimpleApnsPushNotification> pushManager;
 		private Throwable cause;
+		private boolean fatal;
 
 		public TestFailedConnectionListener(final Object mutex) {
 			this.mutex = mutex;
 		}
 
 		@Override
-		public void handleFailedConnection(final PushManager<? extends SimpleApnsPushNotification> pushManager, final Throwable cause) {
+		public void handleFailedConnection(final PushManager<? extends SimpleApnsPushNotification> pushManager, final Throwable cause, boolean fatal) {
 			this.pushManager = pushManager;
 			this.cause = cause;
+			this.fatal = fatal;
 
 			synchronized (this.mutex) {
 				this.mutex.notifyAll();
@@ -195,6 +197,7 @@ public class PushManagerTest extends BasePushyTest {
 
 		assertEquals(badCredentialManager, listener.pushManager);
 		assertNotNull(listener.cause);
+		assertTrue(!listener.fatal);
 	}
 
 	@Test


### PR DESCRIPTION
This patch includes a breaking change to FailedConnectionListener.
Added a "fatal" argument indicates this exception is fatal and we
won't retry.

Some unrecoverable certificate issues are considered fatal for now, such as `certificate_revoked` or `certificate_expired`. These errors require users to recreate their PushManager with corrected SSLContext. Retrying just doesn't help.

One question left is do we need to shutdown PushManager for user in this situation or give it to user? WDYT?

edit: spelling and wording