### PR TITLE
Even simpler channel closure!

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -307,6 +307,8 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 				// At this point, there may still be some tasks in the event queue (i.e. write future listeners). We
 				// want to make sure those are all done before we notify listeners of connection closure, so we put the
 				// actual handler notification at the end of the queue.
+
+				// TODO Don't do this once Netty 5.0 is out (see http://netty.io/wiki/new-and-noteworthy-in-5.0.html)
 				context.channel().eventLoop().execute(new Runnable() {
 
 					@Override

--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -304,6 +304,9 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 			// listeners if the handshake has completed. Otherwise, we'll notify listeners of a connection failure (as
 			// opposed to closure) elsewhere.
 			if (this.apnsConnection.handshakeCompleted && this.apnsConnection.listener != null) {
+				// At this point, there may still be some tasks in the event queue (i.e. write future listeners). We
+				// want to make sure those are all done before we notify listeners of connection closure, so we put the
+				// actual handler notification at the end of the queue.
 				context.channel().eventLoop().execute(new Runnable() {
 
 					@Override


### PR DESCRIPTION
I'm 99% sure this will resolve a race condition we've seen causing intermittent failures test failures in #169 and #174. Basically, instead of checking to see whether an operation is the last thing in the queue (which led to potential double closure notifications), we just add the closure notification to the end of the queue and trust that it will be the last thing to happen.

Seems waaaaaaaaay simpler than what we were doing before and less error-prone. The thing I don't like is that there isn't a documented guarantee from Netty about the order of things in 4.0 (though there is in 4.1).

Thoughts? @sunng87, for what it's worth, I think we need to resolve this before we can put out a release with the fix for #168.