### PR TITLE
(fix) check whether channel is writable before writeAndFlush

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -512,7 +512,7 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 			throw new IllegalStateException(String.format("%s has not completed handshake.", this.name));
 		}
 
-		if (this.disconnectNotification == null) {
+		if (this.disconnectNotification == null && this.connectFuture.channel().isWritable()) {
 			final SendableApnsPushNotification<T> sendableNotification =
 					new SendableApnsPushNotification<T>(notification, this.sequenceNumber++);
 
@@ -550,7 +550,8 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 			});
 		} else {
 			if (this.listener != null) {
-				this.listener.handleWriteFailure(this, notification, new IllegalStateException("Connection is disconnecting."));
+				this.listener.handleWriteFailure(this, notification,
+						new IllegalStateException(this.disconnectNotification == null ? "Connection is disconnecting." : "Channel is not writable."));
 			}
 		}
 


### PR DESCRIPTION
As we talked in this issue :https://github.com/relayrides/pushy/issues/142 that Pushy don't need to check whether the channel is writable before writeAndFlush to this channel because Pushy has writability listener which can do this job. I think it's very reasonable at that time. 

But I found a clue which may indicate that netty's writability listener can have a big lag behind the change time of the channel writability.  It means channel may already unwritable but the writability listener is not triggered for a long time. At that time, if we don't check the channel's writability we can write a lot of pending data far beyond the high water mark in netty. If the channel will recover eventually, that's all ok. But if the channel is broken, all the pending data wrote to this channel is wasted.

![image](https://cloud.githubusercontent.com/assets/1115061/11012946/a1b5a672-8537-11e5-8bd8-c34f7ab60ca6.png)

Please look at this picture. I got it from a heap dump opened by Eclipse Memory Analyzer. It's a detailed attributes information from a ChannelOutboundBuffer instance which belongs to an ApnsConnection. This ApnsConnection is unwritable and is removed from writableConnections queue in PushManager correctly. But in this picture you can see that unwritable is 1 but totalPendingSize is 1460866 (> 1MB). But the default value of the high water mark in netty is 64KB (we don't change it) which means (In my opinion) this channel has wrote a lot of data  to this channel before noticed that the channel is unwritable already.

By the way, I still think this issue has nothing to do with the memory leak mentioned in https://github.com/relayrides/pushy/issues/142