### PR TITLE
(fix) donot retry gracefully disconnect on IOException

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsConnection.java
@@ -42,6 +42,7 @@ import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 
+import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Date;
@@ -613,9 +614,14 @@ public class ApnsConnection<T extends ApnsPushNotification> {
 							log.trace("{} failed to write known-bad notification {}",
 									ApnsConnection.this.name, ApnsConnection.this.disconnectNotification, writeFuture.cause());
 
-							// Try again!
-							ApnsConnection.this.disconnectNotification = null;
-							ApnsConnection.this.disconnectGracefully();
+							if (writeFuture.cause() instanceof IOException) {
+								// none recoverable exception
+								ApnsConnection.this.disconnectImmediately();
+							} else {
+								// Try again!
+								ApnsConnection.this.disconnectNotification = null;
+								ApnsConnection.this.disconnectGracefully();
+							}
 						}
 					}
 				});


### PR DESCRIPTION
In our production we saw lots of WriteAndFlushTask that blocks event thread and the whole system stops working. 

My colleague @ylgrgyq and I found if issue like "Broken pipe" or "Connection
reset by peer" happens on `ApnsConnection`, we will fall into an infinite retry of GracefullyShutdown until it meets timeout. This might produce a lot of `WriteAndFlushTask` and block event threads, stop it to register new channels, then the system stops working totally.

And these `IOException`s, there is no chance to recovery by retry so we better close the connection immediately.