### PR TITLE
Proxy support (closes #99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ Using Jetty's ALPN implementation is somewhat more complicated than using using 
 
 If you know exactly which version of Java you'll be running, you can just add that specific version of `alpn-boot` to your boot class path. If your project might run on a number of different systems and if you use Maven, you can use a `<profile>` section in your `pom.xml` to choose the correct version on the fly. Please see [Pushy's own `pom.xml`](https://github.com/relayrides/pushy/blob/http2/pom.xml#L189) for an example for Java 8. At the time of this writing, [Netty's `pom.xml`](https://github.com/netty/netty/blob/4.1/pom.xml) includes profiles for both Java 7 and Java 8.
 
+## Using a proxy
+
+If you need to use a proxy for outbound connections, you may specify a [`ProxyHandlerFactory`](http://relayrides.github.io/pushy/apidocs/0.6/com/relayrides/pushy/apns/proxy/ProxyHandlerFactory.html) before attempting to connect your `ApnsClient` instance. Concrete implementations of `ProxyHandlerFactory` are provided for HTTP, SOCKS4, and SOCKS5 proxies.
+
 ## Logging
 
 Pushy uses [SLF4J](http://www.slf4j.org/) for logging. If you're not already familiar with it, SLF4J is a facade that allows users to choose which logging library to use at deploy time by adding a specific "binding" to the classpath. To avoid making the choice for you, Pushy itself does *not* depend on any SLF4J bindings; you'll need to add one on your own (either by adding it as a dependency in your own project or by installing it directly). If you have no SLF4J bindings on your classpath, you'll probably see a warning that looks something like this:

--- a/README.md
+++ b/README.md
@@ -148,6 +148,21 @@ If you know exactly which version of Java you'll be running, you can just add th
 
 If you need to use a proxy for outbound connections, you may specify a [`ProxyHandlerFactory`](http://relayrides.github.io/pushy/apidocs/0.6/com/relayrides/pushy/apns/proxy/ProxyHandlerFactory.html) before attempting to connect your `ApnsClient` instance. Concrete implementations of `ProxyHandlerFactory` are provided for HTTP, SOCKS4, and SOCKS5 proxies.
 
+An example:
+
+```java
+final ApnsClient<SimpleApnsPushNotification> apnsClient =
+        new ApnsClient<SimpleApnsPushNotification>(
+                new File("/path/to/certificate.p12"), "p12-file-password");
+
+apnsClient.setProxyHandlerFactory(
+        new Socks5ProxyHandlerFactory(
+                new InetSocketAddress("my.proxy.com", 1080), "username", "password"));
+
+final Future<Void> connectFuture = apnsClient.connect(ApnsClient.DEVELOPMENT_APNS_HOST);
+connectFuture.await();
+```
+
 ## Logging
 
 Pushy uses [SLF4J](http://www.slf4j.org/) for logging. If you're not already familiar with it, SLF4J is a facade that allows users to choose which logging library to use at deploy time by adding a specific "binding" to the classpath. To avoid making the choice for you, Pushy itself does *not* depend on any SLF4J bindings; you'll need to add one on your own (either by adding it as a dependency in your own project or by installing it directly). If you have no SLF4J bindings on your classpath, you'll probably see a warning that looks something like this:

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
             <version>4.1.0.Beta8</version>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler-proxy</artifactId>
+            <version>4.1.0.Beta8</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.5</version>

--- a/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -37,6 +37,8 @@ import javax.net.ssl.SSLException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.relayrides.pushy.apns.proxy.ProxyHandlerFactory;
+
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;

--- a/src/main/java/com/relayrides/pushy/apns/ProxyHandlerFactory.java
+++ b/src/main/java/com/relayrides/pushy/apns/ProxyHandlerFactory.java
@@ -1,0 +1,37 @@
+/* Copyright (c) 2013-2016 RelayRides
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE. */
+
+package com.relayrides.pushy.apns;
+
+import io.netty.handler.proxy.ProxyHandler;
+
+/**
+ * A proxy handler factory creates proxy handlers for use in an {@link ApnsClient}'s pipeline.
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ */
+public interface ProxyHandlerFactory {
+    /**
+     * Constructs a new proxy handler.
+     *
+     * @return a new proxy handler; must not be {@code null}
+     */
+    ProxyHandler createProxyHandler();
+}

--- a/src/main/java/com/relayrides/pushy/apns/proxy/HttpProxyHandlerFactory.java
+++ b/src/main/java/com/relayrides/pushy/apns/proxy/HttpProxyHandlerFactory.java
@@ -1,0 +1,84 @@
+/* Copyright (c) 2013-2016 RelayRides
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE. */
+
+package com.relayrides.pushy.apns.proxy;
+
+import java.net.SocketAddress;
+
+import io.netty.handler.proxy.HttpProxyHandler;
+import io.netty.handler.proxy.ProxyHandler;
+
+/**
+ * A concrete {@link ProxyHandlerFactory} implementation that creates {@link HttpProxyHandler} instances.
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ */
+public class HttpProxyHandlerFactory implements ProxyHandlerFactory {
+
+    private final SocketAddress proxyAddress;
+
+    private final String username;
+    private final String password;
+
+    /**
+     * Creates a new proxy handler factory that will create HTTP proxy handlers that use the proxy at the given
+     * address and that will not perform authentication.
+     *
+     * @param proxyAddress the address of the HTTP proxy server
+     */
+    public HttpProxyHandlerFactory(final SocketAddress proxyAddress) {
+        this(proxyAddress, null, null);
+    }
+
+    /**
+     * Creates a new proxy handler factory that will create HTTP proxy handlers that use the proxy at the given
+     * address and that will authenticate with the given username and password.
+     *
+     * @param proxyAddress the address of the HTTP proxy server
+     * @param username the username to use when connecting to the given proxy server
+     * @param password the password to use when connecting to the given proxy server
+     */
+    public HttpProxyHandlerFactory(final SocketAddress proxyAddress, final String username, final String password) {
+        this.proxyAddress = proxyAddress;
+
+        this.username = username;
+        this.password = password;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see com.relayrides.pushy.apns.proxy.ProxyHandlerFactory#createProxyHandler()
+     */
+    @Override
+    public ProxyHandler createProxyHandler() {
+        final HttpProxyHandler handler;
+
+        // For reasons that are not immediately clear, HttpProxyHandler doesn't allow null usernames/passwords if
+        // specified. If we want them to be null, we have to use the constructor that doesn't take a username/password
+        // at all.
+        if (this.username != null && this.password != null) {
+            handler = new HttpProxyHandler(this.proxyAddress, this.username, this.password);
+        } else {
+            handler = new HttpProxyHandler(this.proxyAddress);
+        }
+
+        return handler;
+    }
+}

--- a/src/main/java/com/relayrides/pushy/apns/proxy/ProxyHandlerFactory.java
+++ b/src/main/java/com/relayrides/pushy/apns/proxy/ProxyHandlerFactory.java
@@ -18,7 +18,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE. */
 
-package com.relayrides.pushy.apns;
+package com.relayrides.pushy.apns.proxy;
+
+import com.relayrides.pushy.apns.ApnsClient;
 
 import io.netty.handler.proxy.ProxyHandler;
 

--- a/src/main/java/com/relayrides/pushy/apns/proxy/Socks4ProxyHandlerFactory.java
+++ b/src/main/java/com/relayrides/pushy/apns/proxy/Socks4ProxyHandlerFactory.java
@@ -1,0 +1,68 @@
+/* Copyright (c) 2013-2016 RelayRides
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE. */
+
+package com.relayrides.pushy.apns.proxy;
+
+import java.net.SocketAddress;
+
+import io.netty.handler.proxy.ProxyHandler;
+import io.netty.handler.proxy.Socks4ProxyHandler;
+
+/**
+ * A concrete {@link ProxyHandlerFactory} implementation that creates {@link Socks4ProxyHandler} instances.
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ */
+public class Socks4ProxyHandlerFactory implements ProxyHandlerFactory {
+
+    private final SocketAddress proxyAddress;
+    private final String username;
+
+    /**
+     * Creates a new proxy handler factory that will create SOCKS4 proxy handlers that use the proxy at the given
+     * address and that will not perform authentication.
+     *
+     * @param proxyAddress the address of the SOCKS4 proxy server
+     */
+    public Socks4ProxyHandlerFactory(final SocketAddress proxyAddress) {
+        this(proxyAddress, null);
+    }
+
+    /**
+     * Creates a new proxy handler factory that will create SOCKS4 proxy handlers that use the proxy at the given
+     * address and that will authenticate with the given username and password.
+     *
+     * @param proxyAddress the address of the SOCKS4 proxy server
+     * @param username the username to use when connecting to the given proxy server
+     */
+    public Socks4ProxyHandlerFactory(final SocketAddress proxyAddress, final String username) {
+        this.proxyAddress = proxyAddress;
+        this.username = username;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see com.relayrides.pushy.apns.proxy.ProxyHandlerFactory#createProxyHandler()
+     */
+    @Override
+    public ProxyHandler createProxyHandler() {
+        return new Socks4ProxyHandler(this.proxyAddress, this.username);
+    }
+}

--- a/src/main/java/com/relayrides/pushy/apns/proxy/Socks5ProxyHandlerFactory.java
+++ b/src/main/java/com/relayrides/pushy/apns/proxy/Socks5ProxyHandlerFactory.java
@@ -1,0 +1,73 @@
+/* Copyright (c) 2013-2016 RelayRides
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE. */
+
+package com.relayrides.pushy.apns.proxy;
+
+import java.net.SocketAddress;
+
+import io.netty.handler.proxy.ProxyHandler;
+import io.netty.handler.proxy.Socks5ProxyHandler;
+
+/**
+ * A concrete {@link ProxyHandlerFactory} implementation that creates {@link Socks5ProxyHandler} instances.
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ */
+public class Socks5ProxyHandlerFactory implements ProxyHandlerFactory {
+
+    private final SocketAddress proxyAddress;
+
+    private final String username;
+    private final String password;
+
+    /**
+     * Creates a new proxy handler factory that will create SOCKS5 proxy handlers that use the proxy at the given
+     * address and that will not perform authentication.
+     *
+     * @param proxyAddress the address of the SOCKS5 proxy server
+     */
+    public Socks5ProxyHandlerFactory(final SocketAddress proxyAddress) {
+        this(proxyAddress, null, null);
+    }
+
+    /**
+     * Creates a new proxy handler factory that will create SOCKS5 proxy handlers that use the proxy at the given
+     * address and that will authenticate with the given username and password.
+     *
+     * @param proxyAddress the address of the SOCKS5 proxy server
+     * @param username the username to use when connecting to the given proxy server
+     * @param password the password to use when connecting to the given proxy server
+     */
+    public Socks5ProxyHandlerFactory(final SocketAddress proxyAddress, final String username, final String password) {
+        this.proxyAddress = proxyAddress;
+
+        this.username = username;
+        this.password = password;
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see com.relayrides.pushy.apns.proxy.ProxyHandlerFactory#createProxyHandler()
+     */
+    @Override
+    public ProxyHandler createProxyHandler() {
+        return new Socks5ProxyHandler(this.proxyAddress, this.username, this.password);
+    }
+}

--- a/src/main/java/com/relayrides/pushy/apns/proxy/package-info.java
+++ b/src/main/java/com/relayrides/pushy/apns/proxy/package-info.java
@@ -1,0 +1,32 @@
+/* Copyright (c) 2013-2016 RelayRides
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE. */
+
+/**
+ * <p>Contains classes and interfaces for working with proxies.</p>
+ *
+ * <p>While {@link com.relayrides.pushy.apns.ApnsClient}s will connect to an APNs server directly by default, they may
+ * optionally be configured to connect through a proxy by setting a
+ * {@link com.relayrides.pushy.apns.proxy.ProxyHandlerFactory} via the
+ * {@link com.relayrides.pushy.apns.ApnsClient#setProxyHandlerFactory(ProxyHandlerFactory)} method. Proxy handler
+ * factory implementations are provided for HTTP, SOCKS4, and SOCKS5 proxies.</p>
+ *
+ * @author <a href="mailto:jon@relayrides.com">Jon Chambers</a>
+ */
+package com.relayrides.pushy.apns.proxy;

--- a/src/test/java/com/relayrides/pushy/apns/ExampleApp.java
+++ b/src/test/java/com/relayrides/pushy/apns/ExampleApp.java
@@ -1,12 +1,13 @@
 package com.relayrides.pushy.apns;
 
 import java.io.File;
+import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutionException;
 
+import com.relayrides.pushy.apns.proxy.Socks5ProxyHandlerFactory;
 import com.relayrides.pushy.apns.util.ApnsPayloadBuilder;
 import com.relayrides.pushy.apns.util.SimpleApnsPushNotification;
 import com.relayrides.pushy.apns.util.TokenUtil;
-
 import io.netty.util.concurrent.Future;
 
 /**
@@ -27,6 +28,11 @@ public class ExampleApp {
         final ApnsClient<SimpleApnsPushNotification> apnsClient =
                 new ApnsClient<SimpleApnsPushNotification>(
                         new File("/path/to/certificate.p12"), "p12-file-password");
+
+        // Optional: we can set a proxy handler factory if we must use a proxy.
+        apnsClient.setProxyHandlerFactory(
+                new Socks5ProxyHandlerFactory(
+                        new InetSocketAddress("my.proxy.com", 1080), "username", "password"));
 
         // Once we've created a client, we can connect it to the APNs gateway.
         // Note that this process is asynchronous; we'll get a Future right


### PR DESCRIPTION
This adds a `ProxyHandlerFactory` that callers may use to inject proxy handlers into an `ApnsClient`'s pipeline. This is very much inspired by #161, with thanks to @Nowheresly.