### PR TITLE
Remove explicit hpack dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,6 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.6</version>
         </dependency>
-        <!-- TODO This should go away; needing it here at all appears to be a Netty bug. -->
-        <dependency>
-            <groupId>com.twitter</groupId>
-            <artifactId>hpack</artifactId>
-            <version>0.11.0</version>
-        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
It was added together with netty-all which is supposed to be used
when managing dependencies manually, so is not needed after
switching to netty-codec-http2