### PR TITLE
Fix passing not specified password for .p12 file

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -245,7 +245,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
         final PrivateKey privateKey;
 
         try {
-            final KeyStore.PasswordProtection keyStorePassword = (password != null) ? new KeyStore.PasswordProtection(password.toCharArray()) : null;
+            final KeyStore.PasswordProtection keyStorePassword = new KeyStore.PasswordProtection(password != null ? password.toCharArray() : null);
 
             final KeyStore keyStore = KeyStore.Builder.newInstance("PKCS12", null, p12File, keyStorePassword).getKeyStore();
 


### PR DESCRIPTION
KeyStore.PasswordProtection constructor accepts null,
but the next KeyStore.Builder.newInstance() call doesn't accept protection as null