### PR TITLE
Add metrics interfaces and members, to demo a way to offer metrics wihout tying down to a specific implementation

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/metrics/Counter.java
+++ b/src/main/java/com/relayrides/pushy/apns/metrics/Counter.java
@@ -1,0 +1,11 @@
+package com.relayrides.pushy.apns.metrics;
+
+/**
+ * A Counter metric.
+ */
+public interface Counter {
+    /**
+     * Increment the counter.
+     */
+    void inc();
+}

--- a/src/main/java/com/relayrides/pushy/apns/metrics/NullMetrics.java
+++ b/src/main/java/com/relayrides/pushy/apns/metrics/NullMetrics.java
@@ -1,0 +1,34 @@
+package com.relayrides.pushy.apns.metrics;
+
+/**
+ * A null metrics sink implementation.
+ */
+public class NullMetrics implements PushyMetrics {
+    private static final Timer.Context nullTimerContext = new NullTimerContext();
+    private static final Counter nullCounter = new NullCounter();
+    private static final Timer nullTimer = new NullTimer();
+
+    @Override
+    public Counter counter(String name) {
+        return nullCounter;
+    }
+
+    @Override
+    public Timer timer(String name) {
+        return nullTimer;
+    }
+
+    private static class NullCounter implements Counter {
+        @Override
+        public void inc() {
+            // no-op
+        }
+    }
+
+    private static class NullTimer implements Timer {
+        @Override
+        public Context start() {
+            return nullTimerContext;
+        }
+    }
+}

--- a/src/main/java/com/relayrides/pushy/apns/metrics/NullTimerContext.java
+++ b/src/main/java/com/relayrides/pushy/apns/metrics/NullTimerContext.java
@@ -1,0 +1,11 @@
+package com.relayrides.pushy.apns.metrics;
+
+/**
+ * A no-op timer context, used for the case when there isn't currently a running timer.
+ */
+public class NullTimerContext implements Timer.Context {
+    @Override
+    public void stop() {
+        // no-op
+    }
+}

--- a/src/main/java/com/relayrides/pushy/apns/metrics/PushyMetrics.java
+++ b/src/main/java/com/relayrides/pushy/apns/metrics/PushyMetrics.java
@@ -1,0 +1,21 @@
+package com.relayrides.pushy.apns.metrics;
+
+/**
+ * Interface which metrics implementations need to implement.
+ *
+ * This is pretty simplistic; improvements could include enum keys instead of strings for the metric
+ * names, or pre-declared metric objects encapsulating the state for a Counter, a Timer, etc.
+ */
+public interface PushyMetrics {
+
+    /**
+     * Increment a counter metric named @param name.
+     */
+    Counter counter(String name);
+
+    /**
+     * @return a newly-started timer, named @param name. This should run until the first
+     * invocation of the TimerContext's stop() method.
+     */
+    Timer timer(String name);
+}

--- a/src/main/java/com/relayrides/pushy/apns/metrics/PushyMetrics.java
+++ b/src/main/java/com/relayrides/pushy/apns/metrics/PushyMetrics.java
@@ -5,6 +5,12 @@ package com.relayrides.pushy.apns.metrics;
  *
  * This is pretty simplistic; improvements could include enum keys instead of strings for the metric
  * names, or pre-declared metric objects encapsulating the state for a Counter, a Timer, etc.
+ *
+ * I would envisage a set of additional Maven modules for "pushy-dropwizard-metrics-publisher",
+ * "pushy-statsd-metrics-publisher" etc., which provide the necessary dependency declarations,
+ * and a factory to create PushyMetrics objects suitable to publish to whatever metrics system
+ * is in use.  (Regarding https://github.com/relayrides/pushy/issues/175#issuecomment-172857510 ,
+ * this would be the ideal place to specify the string prefix for the ApnsClient's metrics set.)
  */
 public interface PushyMetrics {
 

--- a/src/main/java/com/relayrides/pushy/apns/metrics/Timer.java
+++ b/src/main/java/com/relayrides/pushy/apns/metrics/Timer.java
@@ -1,0 +1,21 @@
+package com.relayrides.pushy.apns.metrics;
+
+/**
+ * A Timer metric.
+ */
+public interface Timer {
+
+    /**
+     * @return a newly-started timer context. This should run until the first
+     * invocation of the Context's stop() method.
+     */
+    Context start();
+
+    interface Context {
+        /**
+         * Stop this running timer and record its value.  Later invocations of this method
+         * on this object should be considered a no-op.
+         */
+        void stop();
+    }
+}

--- a/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
@@ -99,7 +99,7 @@ public class ApnsClientTest {
 
         this.client = new ApnsClient<SimpleApnsPushNotification>(
                 ApnsClientTest.getSslContextForTestClient(SINGLE_TOPIC_CLIENT_CERTIFICATE, SINGLE_TOPIC_CLIENT_PRIVATE_KEY),
-                EVENT_LOOP_GROUP);
+                EVENT_LOOP_GROUP, new NullMetrics());
 
         this.client.connect(HOST, PORT).await();
     }
@@ -126,7 +126,7 @@ public class ApnsClientTest {
     @Test
     public void testApnsClientWithManagedEventLoopGroup() throws Exception {
         final ApnsClient<SimpleApnsPushNotification> managedGroupClient = new ApnsClient<SimpleApnsPushNotification>(
-                ApnsClientTest.getSslContextForTestClient(SINGLE_TOPIC_CLIENT_CERTIFICATE, SINGLE_TOPIC_CLIENT_PRIVATE_KEY), null);
+                ApnsClientTest.getSslContextForTestClient(SINGLE_TOPIC_CLIENT_CERTIFICATE, SINGLE_TOPIC_CLIENT_PRIVATE_KEY), null, new NullMetrics());
 
         assertTrue(managedGroupClient.connect(HOST, PORT).await().isSuccess());
         assertTrue(managedGroupClient.disconnect().await().isSuccess());
@@ -135,7 +135,7 @@ public class ApnsClientTest {
     @Test
     public void testRestartApnsClientWithManagedEventLoopGroup() throws Exception {
         final ApnsClient<SimpleApnsPushNotification> managedGroupClient = new ApnsClient<SimpleApnsPushNotification>(
-                ApnsClientTest.getSslContextForTestClient(SINGLE_TOPIC_CLIENT_CERTIFICATE, SINGLE_TOPIC_CLIENT_PRIVATE_KEY), null);
+                ApnsClientTest.getSslContextForTestClient(SINGLE_TOPIC_CLIENT_CERTIFICATE, SINGLE_TOPIC_CLIENT_PRIVATE_KEY), null, new NullMetrics());
 
         assertTrue(managedGroupClient.connect(HOST, PORT).await().isSuccess());
         assertTrue(managedGroupClient.disconnect().await().isSuccess());
@@ -193,7 +193,7 @@ public class ApnsClientTest {
     public void testGetReconnectionFutureWhenNotConnected() throws Exception {
         final ApnsClient<SimpleApnsPushNotification> unconnectedClient = new ApnsClient<SimpleApnsPushNotification>(
                 ApnsClientTest.getSslContextForTestClient(SINGLE_TOPIC_CLIENT_CERTIFICATE, SINGLE_TOPIC_CLIENT_PRIVATE_KEY),
-                EVENT_LOOP_GROUP);
+                EVENT_LOOP_GROUP, new NullMetrics());
 
         final Future<Void> reconnectionFuture = unconnectedClient.getReconnectionFuture();
 
@@ -206,7 +206,7 @@ public class ApnsClientTest {
     public void testConnectWithUntrustedCertificate() throws Exception {
         final ApnsClient<SimpleApnsPushNotification> untrustedClient = new ApnsClient<SimpleApnsPushNotification>(
                 ApnsClientTest.getSslContextForTestClient(UNTRUSTED_CLIENT_CERTIFICATE, UNTRUSTED_CLIENT_PRIVATE_KEY),
-                EVENT_LOOP_GROUP);
+                EVENT_LOOP_GROUP, new NullMetrics());
 
         final Future<Void> connectFuture = untrustedClient.connect(HOST, PORT).await();
         assertFalse(connectFuture.isSuccess());
@@ -218,7 +218,7 @@ public class ApnsClientTest {
     public void testSendNotificationBeforeConnected() throws Exception {
         final ApnsClient<SimpleApnsPushNotification> unconnectedClient = new ApnsClient<SimpleApnsPushNotification>(
                 ApnsClientTest.getSslContextForTestClient(SINGLE_TOPIC_CLIENT_CERTIFICATE, SINGLE_TOPIC_CLIENT_PRIVATE_KEY),
-                EVENT_LOOP_GROUP);
+                EVENT_LOOP_GROUP, new NullMetrics());
 
         final String testToken = ApnsClientTest.generateRandomToken();
 
@@ -296,7 +296,7 @@ public class ApnsClientTest {
     public void testSendNotificationWithMissingTopic() throws Exception {
         final ApnsClient<SimpleApnsPushNotification> multiTopicClient = new ApnsClient<SimpleApnsPushNotification>(
                 ApnsClientTest.getSslContextForTestClient(MULTI_TOPIC_CLIENT_CERTIFICATE, MULTI_TOPIC_CLIENT_PRIVATE_KEY),
-                EVENT_LOOP_GROUP);
+                EVENT_LOOP_GROUP, new NullMetrics());
 
         multiTopicClient.connect(HOST, PORT).await();
 
@@ -320,7 +320,7 @@ public class ApnsClientTest {
     public void testSendNotificationWithSpecifiedTopic() throws Exception {
         final ApnsClient<SimpleApnsPushNotification> multiTopicClient = new ApnsClient<SimpleApnsPushNotification>(
                 ApnsClientTest.getSslContextForTestClient(MULTI_TOPIC_CLIENT_CERTIFICATE, MULTI_TOPIC_CLIENT_PRIVATE_KEY),
-                EVENT_LOOP_GROUP);
+                EVENT_LOOP_GROUP, new NullMetrics());
 
         multiTopicClient.connect(HOST, PORT).await();
 

--- a/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 
 import javax.net.ssl.SSLException;
 
+import com.relayrides.pushy.apns.metrics.NullMetrics;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;


### PR DESCRIPTION
I've spiked up a quick demo of what I would say is a reasonable way to offer metrics support in Pushy, without tying that down to a specific backend implementation too tightly.

This should allow implementation against:

* Dropwizard Metrics (v3),
* Yammer Metrics (v2),
* Datadog: https://github.com/indeedeng/java-dogstatsd-client
* and statsd using an interface similar to https://github.com/tim-group/java-statsd-client .

Essentially, the API used by Pushy internally is a simplified version of the Metrics API, but should be implementable for statsd and Datadog easily enough too.  I'd be curious if there are other metrics systems this approach would pose a problem for....
