### PR TITLE
Drop support for Java 6 (closes #224)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,8 @@ Before you can get started with Pushy, you'll need to do some provisioning work 
 Once you've registered your app and have the requisite certificates, the first thing you'll need to do to start sending push notifications with Pushy is to create an [`ApnsClient`](http://relayrides.github.io/pushy/apidocs/0.5/com/relayrides/pushy/apns/ApnsClient.html). Clients need a certificate and private key to authenticate with the APNs server. The most common way to store the certificate and key is in a password-protected PKCS#12 file (you'll wind up with a password-protected .p12 file if you follow Apple's instructions at the time of this writing):
 
 ```java
-final ApnsClient<SimpleApnsPushNotification> apnsClient =
-        new ApnsClient<SimpleApnsPushNotification>(
-                new File("/path/to/certificate.p12"), "p12-file-password");
+final ApnsClient<SimpleApnsPushNotification> apnsClient = new ApnsClient<>(
+        new File("/path/to/certificate.p12"), "p12-file-password");
 ```
 
 Once you've created a client, you can connect it to the APNs gateway. Note that this process is asynchronous; the client will return a Future right away, but you'll need to wait for it to complete before you can send any notifications. Note that this is a Netty [`Future`](http://netty.io/4.1/api/io/netty/util/concurrent/Future.html), which is an extension of the Java [`Future`](http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/Future.html) interface that allows callers to add listeners and adds methods for checking the status of the `Future`.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you don't use Maven (or something else that understands Maven dependencies, l
 - Either `netty-tcnative` or `alpn-boot`, as discussed in the [system requirements](#system-requirements) section below
   - [alpn-api](http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html) if you've opted not to use `alpn-boot` (`alpn-api` is included in `alpn-boot`); please see the [system requirements](#system-requirements) section for details)
 
-Pushy itself requires Java 6 or newer to build and run.
+Pushy itself requires Java 7 or newer to build and run.
 
 ## Sending push notifications
 
@@ -41,7 +41,7 @@ final ApnsClient<SimpleApnsPushNotification> apnsClient = new ApnsClient<>(
         new File("/path/to/certificate.p12"), "p12-file-password");
 ```
 
-Once you've created a client, you can connect it to the APNs gateway. Note that this process is asynchronous; the client will return a Future right away, but you'll need to wait for it to complete before you can send any notifications. Note that this is a Netty [`Future`](http://netty.io/4.1/api/io/netty/util/concurrent/Future.html), which is an extension of the Java [`Future`](http://docs.oracle.com/javase/6/docs/api/java/util/concurrent/Future.html) interface that allows callers to add listeners and adds methods for checking the status of the `Future`.
+Once you've created a client, you can connect it to the APNs gateway. Note that this process is asynchronous; the client will return a Future right away, but you'll need to wait for it to complete before you can send any notifications. Note that this is a Netty [`Future`](http://netty.io/4.1/api/io/netty/util/concurrent/Future.html), which is an extension of the Java [`Future`](http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Future.html) interface that allows callers to add listeners and adds methods for checking the status of the `Future`.
 
 ```java
 final Future<Void> connectFuture = apnsClient.connect(ApnsClient.DEVELOPMENT_APNS_HOST);
@@ -118,18 +118,18 @@ disconnectFuture.await();
 
 ## System requirements
 
-Pushy works with Java 6 and newer, but has some additional dependencies depending on the environment in which it is running.
+Pushy works with Java 7 and newer, but has some additional dependencies depending on the environment in which it is running.
 
 The APNs protocol is built on top of the [HTTP/2 protocol](https://http2.github.io/). HTTP/2 is a relatively new protocol, and relies on some new developments that aren't yet wide-spread in the Java world. In particular:
 
-1. HTTP/2 depends on [ALPN](https://tools.ietf.org/html/rfc7301), a TLS extension for protocol negotiation. No version of Java has native ALPN support at this time. The ALPN requirement may be met either by [using OpenSSL as an SSL provider](#using-native-openssl-as-an-ssl-provider) for Java 6, 7, and 8, or by [using Jetty's ALPN implementation](#using-jettys-alpn-implementation) under OpenJDK 7 or 8.
-2. The HTTP/2 specification requires the use of [ciphers](https://httpwg.github.io/specs/rfc7540.html#rfc.section.9.2.2) that weren't introduced in Java until Java 8. Using OpenSSL as an SSL provider is the best way to meet this requirement under Java 6 and 7. Using OpenSSL isn't a requirement under Java 8, but may still yield performance gains.
+1. HTTP/2 depends on [ALPN](https://tools.ietf.org/html/rfc7301), a TLS extension for protocol negotiation. No version of Java has native ALPN support at this time. The ALPN requirement may be met either by [using OpenSSL as an SSL provider](#using-native-openssl-as-an-ssl-provider) or by [using Jetty's ALPN implementation](#using-jettys-alpn-implementation) under OpenJDK 7 or 8.
+2. The HTTP/2 specification requires the use of [ciphers](https://httpwg.github.io/specs/rfc7540.html#rfc.section.9.2.2) that weren't introduced in Java until Java 8. Using OpenSSL as an SSL provider is the best way to meet this requirement under Java 7. Using OpenSSL isn't a requirement under Java 8, but may still yield performance gains.
 
-Generally speaking, using OpenSSL as your SSL provider is the best way to fulfill the system requirements imposed by HTTP/2 because installation is fairly straightforward, it works for Java 6 onward and generally offers better SSL performance than the JDK SSL provider.
+Generally speaking, using OpenSSL as your SSL provider is the best way to fulfill the system requirements imposed by HTTP/2 because installation is fairly straightforward, it works for Java 7 onward and generally offers better SSL performance than the JDK SSL provider.
 
 ### Using OpenSSL as an SSL provider
 
-Using OpenSSL as an SSL provider fulfills the ALPN and cipher suite requirements imposed by HTTP/2. To use OpenSSL as an SSL provider, you'll need OpenSSL 1.0.2 or newer installed. You'll also need to add `netty-tcnative` as a dependency to your project. The `netty-tcnative` wiki provides [detailed instructions](http://netty.io/wiki/forked-tomcat-native.html), but in short, you'll need to add one additional platform-specific dependency to your project. This approach will meet all requirements imposed by HTTP/2 for Java 6, 7, and 8.
+Using OpenSSL as an SSL provider fulfills the ALPN and cipher suite requirements imposed by HTTP/2. To use OpenSSL as an SSL provider, you'll need OpenSSL 1.0.2 or newer installed. You'll also need to add `netty-tcnative` as a dependency to your project. The `netty-tcnative` wiki provides [detailed instructions](http://netty.io/wiki/forked-tomcat-native.html), but in short, you'll need to add one additional platform-specific dependency to your project. This approach will meet all requirements imposed by HTTP/2 under Java 7 and 8.
 
 Additionally, you'll need [`alpn-api`](http://mvnrepository.com/artifact/org.eclipse.jetty.alpn/alpn-api) as a `runtime` dependency for your project. If you're managing dependencies manually, you'll just need to make sure the latest version of `alpn-api` is available on your classpath.
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -124,8 +124,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
     private volatile ChannelPromise reconnectionPromise;
     private long reconnectDelay = INITIAL_RECONNECT_DELAY;
 
-    private final Map<T, Promise<PushNotificationResponse<T>>> responsePromises =
-            new IdentityHashMap<T, Promise<PushNotificationResponse<T>>>();
+    private final Map<T, Promise<PushNotificationResponse<T>>> responsePromises = new IdentityHashMap<>();
 
     /**
      * The hostname for the production APNs gateway.
@@ -415,7 +414,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
         final Future<Void> connectionReadyFuture;
 
         if (this.bootstrap.group().isShuttingDown() || this.bootstrap.group().isShutdown()) {
-            connectionReadyFuture = new FailedFuture<Void>(GlobalEventExecutor.INSTANCE,
+            connectionReadyFuture = new FailedFuture<>(GlobalEventExecutor.INSTANCE,
                     new IllegalStateException("Client's event loop group has been shut down and cannot be restarted."));
         } else {
             synchronized (this.bootstrap) {
@@ -530,7 +529,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
             } else {
                 // We're not connected and have no reconnection future, which means we've either never connected or have
                 // explicitly disconnected.
-                reconnectionFuture = new FailedFuture<Void>(GlobalEventExecutor.INSTANCE,
+                reconnectionFuture = new FailedFuture<>(GlobalEventExecutor.INSTANCE,
                         new IllegalStateException("Client was not previously connected."));
             }
         }
@@ -575,7 +574,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
 
         if (connectionReadyPromise != null && connectionReadyPromise.isSuccess() && connectionReadyPromise.channel().isActive()) {
             final DefaultPromise<PushNotificationResponse<T>> responsePromise =
-                    new DefaultPromise<PushNotificationResponse<T>>(connectionReadyPromise.channel().eventLoop());
+                    new DefaultPromise<>(connectionReadyPromise.channel().eventLoop());
 
             connectionReadyPromise.channel().eventLoop().submit(new Runnable() {
 
@@ -605,7 +604,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
             responseFuture = responsePromise;
         } else {
             log.debug("Failed to send push notification because client is not connected: {}", notification);
-            responseFuture = new FailedFuture<PushNotificationResponse<T>>(
+            responseFuture = new FailedFuture<>(
                     GlobalEventExecutor.INSTANCE, NOT_CONNECTED_EXCEPTION);
         }
 
@@ -670,7 +669,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
             if (this.connectionReadyPromise != null) {
                 channelCloseFuture = this.connectionReadyPromise.channel().close();
             } else {
-                channelCloseFuture = new SucceededFuture<Void>(GlobalEventExecutor.INSTANCE, null);
+                channelCloseFuture = new SucceededFuture<>(GlobalEventExecutor.INSTANCE, null);
             }
 
             if (this.shouldShutDownEventLoopGroup) {
@@ -685,7 +684,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
 
                 // Since the termination future for the event loop group is a Future<?> instead of a Future<Void>,
                 // we'll need to create our own promise and then notify it when the termination future completes.
-                disconnectFuture = new DefaultPromise<Void>(GlobalEventExecutor.INSTANCE);
+                disconnectFuture = new DefaultPromise<>(GlobalEventExecutor.INSTANCE);
 
                 this.bootstrap.group().terminationFuture().addListener(new GenericFutureListener() {
 

--- a/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
@@ -53,8 +53,8 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
 
     private int nextStreamId = 1;
 
-    private final Map<Integer, T> pushNotificationsByStreamId = new HashMap<Integer, T>();
-    private final Map<Integer, Http2Headers> headersByStreamId = new HashMap<Integer, Http2Headers>();
+    private final Map<Integer, T> pushNotificationsByStreamId = new HashMap<>();
+    private final Map<Integer, Http2Headers> headersByStreamId = new HashMap<>();
 
     private ApnsClient<T> apnsClient;
 
@@ -88,7 +88,7 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
 
         @Override
         public ApnsClientHandler<S> build0(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder) {
-            final ApnsClientHandler<S> handler = new ApnsClientHandler<S>(decoder, encoder, this.initialSettings(), this.apnsClient());
+            final ApnsClientHandler<S> handler = new ApnsClientHandler<>(decoder, encoder, this.initialSettings(), this.apnsClient());
             this.frameListener(handler.new ApnsClientHandlerFrameAdapter());
             return handler;
         }
@@ -108,7 +108,7 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
                 final boolean success = HttpResponseStatus.OK.equals(HttpResponseStatus.parseLine(headers.status()));
                 final ErrorResponse errorResponse = gson.fromJson(data.toString(UTF8), ErrorResponse.class);
 
-                ApnsClientHandler.this.apnsClient.handlePushNotificationResponse(new SimplePushNotificationResponse<T>(
+                ApnsClientHandler.this.apnsClient.handlePushNotificationResponse(new SimplePushNotificationResponse<>(
                         pushNotification, success, errorResponse.getReason(), errorResponse.getTimestamp()));
             } else {
                 log.error("Gateway sent a DATA frame that was not the end of a stream.");
@@ -135,7 +135,7 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
 
                 final T pushNotification = ApnsClientHandler.this.pushNotificationsByStreamId.remove(streamId);
 
-                ApnsClientHandler.this.apnsClient.handlePushNotificationResponse(new SimplePushNotificationResponse<T>(
+                ApnsClientHandler.this.apnsClient.handlePushNotificationResponse(new SimplePushNotificationResponse<>(
                         pushNotification, success, null, null));
             } else {
                 ApnsClientHandler.this.headersByStreamId.put(streamId, headers);

--- a/src/main/java/com/relayrides/pushy/apns/P12Util.java
+++ b/src/main/java/com/relayrides/pushy/apns/P12Util.java
@@ -4,18 +4,16 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.KeyStore;
+import java.security.KeyStore.PrivateKeyEntry;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableEntryException;
 import java.security.cert.CertificateException;
-import java.security.KeyStore.PrivateKeyEntry;
 
 public class P12Util {
 
     public static PrivateKeyEntry getPrivateKeyEntryFromP12File(final File p12File, final String password) throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableEntryException, CertificateException, IOException {
-        final FileInputStream p12InputStream = new FileInputStream(p12File);
-
-        try {
+        try (final FileInputStream p12InputStream = new FileInputStream(p12File)) {
             final KeyStore keyStore = KeyStore.getInstance("PKCS12");
 
             keyStore.load(p12InputStream, password != null ? password.toCharArray() : null);
@@ -32,8 +30,6 @@ public class P12Util {
             }
 
             return (PrivateKeyEntry) entry;
-        } finally {
-            p12InputStream.close();
         }
     }
 }

--- a/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
@@ -91,7 +91,7 @@ public class ApnsClientTest {
         this.server = new MockApnsServer(EVENT_LOOP_GROUP);
         this.server.start(PORT).await();
 
-        this.client = new ApnsClient<SimpleApnsPushNotification>(
+        this.client = new ApnsClient<>(
                 ApnsClientTest.getSslContextForTestClient(SINGLE_TOPIC_CLIENT_KEYSTORE, KEYSTORE_PASSWORD),
                 EVENT_LOOP_GROUP);
 
@@ -148,7 +148,7 @@ public class ApnsClientTest {
 
     @Test
     public void testApnsClientWithManagedEventLoopGroup() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> managedGroupClient = new ApnsClient<SimpleApnsPushNotification>(
+        final ApnsClient<SimpleApnsPushNotification> managedGroupClient = new ApnsClient<>(
                 ApnsClientTest.getSslContextForTestClient(SINGLE_TOPIC_CLIENT_KEYSTORE, KEYSTORE_PASSWORD), null);
 
         assertTrue(managedGroupClient.connect(HOST, PORT).await().isSuccess());
@@ -157,7 +157,7 @@ public class ApnsClientTest {
 
     @Test
     public void testRestartApnsClientWithManagedEventLoopGroup() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> managedGroupClient = new ApnsClient<SimpleApnsPushNotification>(
+        final ApnsClient<SimpleApnsPushNotification> managedGroupClient = new ApnsClient<>(
                 ApnsClientTest.getSslContextForTestClient(SINGLE_TOPIC_CLIENT_KEYSTORE, KEYSTORE_PASSWORD), null);
 
         assertTrue(managedGroupClient.connect(HOST, PORT).await().isSuccess());
@@ -214,7 +214,7 @@ public class ApnsClientTest {
 
     @Test
     public void testGetReconnectionFutureWhenNotConnected() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> unconnectedClient = new ApnsClient<SimpleApnsPushNotification>(
+        final ApnsClient<SimpleApnsPushNotification> unconnectedClient = new ApnsClient<>(
                 ApnsClientTest.getSslContextForTestClient(SINGLE_TOPIC_CLIENT_KEYSTORE, KEYSTORE_PASSWORD),
                 EVENT_LOOP_GROUP);
 
@@ -228,7 +228,7 @@ public class ApnsClientTest {
 
     @Test
     public void testConnectWithUntrustedCertificate() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> untrustedClient = new ApnsClient<SimpleApnsPushNotification>(
+        final ApnsClient<SimpleApnsPushNotification> untrustedClient = new ApnsClient<>(
                 ApnsClientTest.getSslContextForTestClient(UNTRUSTED_CLIENT_KEYSTORE, KEYSTORE_PASSWORD),
                 EVENT_LOOP_GROUP);
 
@@ -240,7 +240,7 @@ public class ApnsClientTest {
 
     @Test
     public void testSendNotificationBeforeConnected() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> unconnectedClient = new ApnsClient<SimpleApnsPushNotification>(
+        final ApnsClient<SimpleApnsPushNotification> unconnectedClient = new ApnsClient<>(
                 ApnsClientTest.getSslContextForTestClient(SINGLE_TOPIC_CLIENT_KEYSTORE, KEYSTORE_PASSWORD),
                 EVENT_LOOP_GROUP);
 
@@ -273,7 +273,7 @@ public class ApnsClientTest {
     public void testSendManyNotifications() throws Exception {
         final int notificationCount = 1000;
 
-        final List<SimpleApnsPushNotification> pushNotifications = new ArrayList<SimpleApnsPushNotification>();
+        final List<SimpleApnsPushNotification> pushNotifications = new ArrayList<>();
 
         for (int i = 0; i < notificationCount; i++) {
             final String token = ApnsClientTest.generateRandomToken();
@@ -283,8 +283,7 @@ public class ApnsClientTest {
             pushNotifications.add(new SimpleApnsPushNotification(token, DEFAULT_TOPIC, payload));
         }
 
-        final List<Future<PushNotificationResponse<SimpleApnsPushNotification>>> futures =
-                new ArrayList<Future<PushNotificationResponse<SimpleApnsPushNotification>>>();
+        final List<Future<PushNotificationResponse<SimpleApnsPushNotification>>> futures = new ArrayList<>();
 
         for (final SimpleApnsPushNotification pushNotification : pushNotifications) {
             futures.add(this.client.sendNotification(pushNotification));
@@ -318,7 +317,7 @@ public class ApnsClientTest {
 
     @Test
     public void testSendNotificationWithMissingTopic() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> multiTopicClient = new ApnsClient<SimpleApnsPushNotification>(
+        final ApnsClient<SimpleApnsPushNotification> multiTopicClient = new ApnsClient<>(
                 ApnsClientTest.getSslContextForTestClient(MULTI_TOPIC_CLIENT_KEYSTORE, KEYSTORE_PASSWORD),
                 EVENT_LOOP_GROUP);
 
@@ -342,7 +341,7 @@ public class ApnsClientTest {
 
     @Test
     public void testSendNotificationWithSpecifiedTopic() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> multiTopicClient = new ApnsClient<SimpleApnsPushNotification>(
+        final ApnsClient<SimpleApnsPushNotification> multiTopicClient = new ApnsClient<>(
                 ApnsClientTest.getSslContextForTestClient(MULTI_TOPIC_CLIENT_KEYSTORE, KEYSTORE_PASSWORD),
                 EVENT_LOOP_GROUP);
 

--- a/src/test/java/com/relayrides/pushy/apns/ExampleApp.java
+++ b/src/test/java/com/relayrides/pushy/apns/ExampleApp.java
@@ -24,9 +24,8 @@ public class ExampleApp {
         // certificate and private key to authenticate with the APNs server. The
         // most common way to store the certificate and key is in a
         // password-protected PKCS#12 file.
-        final ApnsClient<SimpleApnsPushNotification> apnsClient =
-                new ApnsClient<SimpleApnsPushNotification>(
-                        new File("/path/to/certificate.p12"), "p12-file-password");
+        final ApnsClient<SimpleApnsPushNotification> apnsClient = new ApnsClient<>(
+                new File("/path/to/certificate.p12"), "p12-file-password");
 
         // Once we've created a client, we can connect it to the APNs gateway.
         // Note that this process is asynchronous; we'll get a Future right

--- a/src/test/java/com/relayrides/pushy/apns/MockApnsServer.java
+++ b/src/test/java/com/relayrides/pushy/apns/MockApnsServer.java
@@ -43,7 +43,7 @@ public class MockApnsServer {
 
     private final ServerBootstrap bootstrap;
 
-    final Map<String, Map<String, Date>> tokenExpirationsByTopic = new HashMap<String, Map<String, Date>>();
+    final Map<String, Map<String, Date>> tokenExpirationsByTopic = new HashMap<>();
 
     private ChannelGroup allChannels;
 
@@ -89,7 +89,7 @@ public class MockApnsServer {
                     @Override
                     protected void configurePipeline(final ChannelHandlerContext context, final String protocol) throws Exception {
                         if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
-                            final Set<String> topics = new HashSet<String>();
+                            final Set<String> topics = new HashSet<>();
                             {
                                 final SSLSession sslSession = sslHandler.engine().getSession();
 

--- a/src/test/java/com/relayrides/pushy/apns/MockApnsServerHandler.java
+++ b/src/test/java/com/relayrides/pushy/apns/MockApnsServerHandler.java
@@ -35,7 +35,7 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
     private final MockApnsServer apnsServer;
     private final Set<String> topics;
 
-    private final Map<Integer, UUID> requestsWaitingForDataFrame = new HashMap<Integer, UUID>();
+    private final Map<Integer, UUID> requestsWaitingForDataFrame = new HashMap<>();
 
     private static final Http2Headers SUCCESS_HEADERS = new DefaultHttp2Headers()
             .status(HttpResponseStatus.OK.codeAsText());
@@ -316,7 +316,6 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
     public void onUnknownFrame(final ChannelHandlerContext ctx, final byte frameType, final int streamId, final Http2Flags flags, final ByteBuf payload) throws Http2Exception {
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void write(final ChannelHandlerContext context, final Object message, final ChannelPromise promise) throws Exception {
         if (message instanceof AcceptNotificationResponse) {

--- a/src/test/java/com/relayrides/pushy/apns/TopicUtilTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/TopicUtilTest.java
@@ -36,13 +36,9 @@ public class TopicUtilTest {
     }
 
     private static Certificate loadCertificateFromResource(final String resourceName) throws CertificateException, IOException {
-        final InputStream certificateInputStream = TopicUtilTest.class.getResourceAsStream(resourceName);
-
-        try {
+        try (final InputStream certificateInputStream = TopicUtilTest.class.getResourceAsStream(resourceName)) {
             final CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
             return certificateFactory.generateCertificate(certificateInputStream);
-        } finally {
-            certificateInputStream.close();
         }
     }
 }


### PR DESCRIPTION
Regrettably, `netty-tcnative` doesn't support Java 6 (see #224). I think our only option is to drop support for Java 6. The silver lining is that we can now use Java 7 language features (like `<>` and try-with-resources).