### PR TITLE
Update to Netty 4.1 CR2 (closes #231)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
-            <version>4.1.0.Beta8</version>
+            <version>4.1.0.CR1</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
-            <version>4.1.0.CR1</version>
+            <version>4.1.0.CR2</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -318,7 +318,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
                     @Override
                     protected void configurePipeline(final ChannelHandlerContext context, final String protocol) {
                         if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
-                            final ApnsClientHandler<T> apnsClientHandler = new ApnsClientHandler.Builder<T>()
+                            final ApnsClientHandler<T> apnsClientHandler = new ApnsClientHandler.ApnsClientHandlerBuilder<T>()
                                     .server(false)
                                     .apnsClient(ApnsClient.this)
                                     .encoderEnforceMaxConcurrentStreams(true)

--- a/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
@@ -38,6 +38,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.ChannelPromiseAggregator;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
@@ -73,11 +74,11 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
 
     private static final Logger log = LoggerFactory.getLogger(ApnsClientHandler.class);
 
-    public static class Builder<S extends ApnsPushNotification> extends BuilderBase<ApnsClientHandler<S>, Builder<S>> {
+    public static class ApnsClientHandlerBuilder<S extends ApnsPushNotification> extends AbstractHttp2ConnectionHandlerBuilder<ApnsClientHandler<S>, ApnsClientHandlerBuilder<S>> {
 
         private ApnsClient<S> apnsClient;
 
-        public Builder<S> apnsClient(final ApnsClient<S> apnsClient) {
+        public ApnsClientHandlerBuilder<S> apnsClient(final ApnsClient<S> apnsClient) {
             this.apnsClient = apnsClient;
             return this;
         }
@@ -87,10 +88,25 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
         }
 
         @Override
-        public ApnsClientHandler<S> build0(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder) {
-            final ApnsClientHandler<S> handler = new ApnsClientHandler<>(decoder, encoder, this.initialSettings(), this.apnsClient());
+        public ApnsClientHandlerBuilder<S> server(final boolean isServer) {
+            return super.server(isServer);
+        }
+
+        @Override
+        public ApnsClientHandlerBuilder<S> encoderEnforceMaxConcurrentStreams(final boolean enforceMaxConcurrentStreams) {
+            return super.encoderEnforceMaxConcurrentStreams(enforceMaxConcurrentStreams);
+        }
+
+        @Override
+        public ApnsClientHandler<S> build(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings) {
+            final ApnsClientHandler<S> handler = new ApnsClientHandler<>(decoder, encoder, initialSettings, this.apnsClient());
             this.frameListener(handler.new ApnsClientHandlerFrameAdapter());
             return handler;
+        }
+
+        @Override
+        public ApnsClientHandler<S> build() {
+            return super.build();
         }
     }
 

--- a/src/test/java/com/relayrides/pushy/apns/MockApnsServer.java
+++ b/src/test/java/com/relayrides/pushy/apns/MockApnsServer.java
@@ -98,7 +98,7 @@ public class MockApnsServer {
                                 }
                             }
 
-                            context.pipeline().addLast(new MockApnsServerHandler.Builder()
+                            context.pipeline().addLast(new MockApnsServerHandler.MockApnsServerHandlerBuilder()
                                     .apnsServer(MockApnsServer.this)
                                     .topics(topics)
                                     .initialSettings(new Http2Settings().maxConcurrentStreams(8))

--- a/src/test/java/com/relayrides/pushy/apns/MockApnsServerHandler.java
+++ b/src/test/java/com/relayrides/pushy/apns/MockApnsServerHandler.java
@@ -19,6 +19,7 @@ import io.netty.channel.ChannelPromiseAggregator;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http2.AbstractHttp2ConnectionHandlerBuilder;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
@@ -52,7 +53,7 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
             .registerTypeAdapter(Date.class, new DateAsSecondsSinceEpochTypeAdapter())
             .create();
 
-    public static final class Builder extends BuilderBase<MockApnsServerHandler, Builder> {
+    public static final class Builder extends AbstractHttp2ConnectionHandlerBuilder<MockApnsServerHandler, Builder> {
         private MockApnsServer apnsServer;
         private Set<String> topics;
 
@@ -75,10 +76,20 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
         }
 
         @Override
-        public MockApnsServerHandler build0(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder) {
-            final MockApnsServerHandler handler = new MockApnsServerHandler(decoder, encoder, this.initialSettings(), this.apnsServer(), this.topics());
+        public Builder initialSettings(final Http2Settings initialSettings) {
+            return super.initialSettings(initialSettings);
+        }
+
+        @Override
+        public MockApnsServerHandler build(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings) {
+            final MockApnsServerHandler handler = new MockApnsServerHandler(decoder, encoder, initialSettings, this.apnsServer(), this.topics());
             this.frameListener(handler);
             return handler;
+        }
+
+        @Override
+        public MockApnsServerHandler build() {
+            return super.build();
         }
     }
 

--- a/src/test/java/com/relayrides/pushy/apns/MockApnsServerHandler.java
+++ b/src/test/java/com/relayrides/pushy/apns/MockApnsServerHandler.java
@@ -53,11 +53,11 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
             .registerTypeAdapter(Date.class, new DateAsSecondsSinceEpochTypeAdapter())
             .create();
 
-    public static final class Builder extends AbstractHttp2ConnectionHandlerBuilder<MockApnsServerHandler, Builder> {
+    public static final class MockApnsServerHandlerBuilder extends AbstractHttp2ConnectionHandlerBuilder<MockApnsServerHandler, MockApnsServerHandlerBuilder> {
         private MockApnsServer apnsServer;
         private Set<String> topics;
 
-        public Builder apnsServer(final MockApnsServer apnsServer) {
+        public MockApnsServerHandlerBuilder apnsServer(final MockApnsServer apnsServer) {
             this.apnsServer = apnsServer;
             return this;
         }
@@ -66,7 +66,7 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
             return this.apnsServer;
         }
 
-        public Builder topics(final Set<String> topics) {
+        public MockApnsServerHandlerBuilder topics(final Set<String> topics) {
             this.topics = topics;
             return this;
         }
@@ -76,7 +76,7 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
         }
 
         @Override
-        public Builder initialSettings(final Http2Settings initialSettings) {
+        public MockApnsServerHandlerBuilder initialSettings(final Http2Settings initialSettings) {
             return super.initialSettings(initialSettings);
         }
 


### PR DESCRIPTION
This updates everything to use Netty 4.1 CR2, which includes a number of HTTP/2 bugfixes.