### PR TITLE
Introducing jetty-alpn-agent for more clear pom file

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ As an alternative to OpenSSL, you may use Jetty's ALPN implementation if you're 
 
 Using Jetty's ALPN implementation is somewhat more complicated than using OpenSSL as an SSL provider. You'll need to choose a version of `alpn-boot` specific to the version (down to the update!) of OpenJDK you're using, and then add it to your *boot* class path. [Detailed instructions](http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html) are provided by Jetty.
 
-If you know exactly which version of Java you'll be running, you can just add that specific version of `alpn-boot` to your boot class path. If your project might run on a number of different systems and if you use Maven, you can use a `<profile>` section in your `pom.xml` to choose the correct version on the fly. Please see [Pushy's own `pom.xml`](https://github.com/relayrides/pushy/blob/http2/pom.xml#L189) for an example for Java 8. At the time of this writing, [Netty's `pom.xml`](https://github.com/netty/netty/blob/4.1/pom.xml) includes profiles for both Java 7 and Java 8.
+If you know exactly which version of Java you'll be running, you can just add that specific version of `alpn-boot` to your boot class path. If your project might run on a number of different systems and if you use Maven, you can use the [`jetty-alpn-agent`](https://github.com/jetty-project/jetty-alpn-agent) in your `pom.xml`, which loads the correct `alpn-boot` JAR file for the current Java version on the fly.
 
 ## Using a proxy
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,26 +39,20 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.6</version>
         </dependency>
+        <dependency>
+          <groupId>org.eclipse.jetty.alpn</groupId>
+          <artifactId>alpn-api</artifactId>
+          <version>1.1.2.v20150522</version>
+          <!-- Provided by alpn-boot; see
+          http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html#alpn-understanding -->
+          <scope>provided</scope>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mortbay.jetty.alpn</groupId>
-            <artifactId>alpn-boot</artifactId>
-            <version>${jetty.alpn.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.alpn</groupId>
-            <artifactId>alpn-api</artifactId>
-            <version>1.1.2.v20150522</version>
-            <!-- Provided by alpn-boot; see
-            http://www.eclipse.org/jetty/documentation/9.2.8.v20150217/alpn-chapter.html#alpn-understanding -->
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -82,8 +76,10 @@
     <properties>
         <netty.version>4.1.0.CR3</netty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.alpn.path>${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${jetty.alpn.version}/alpn-boot-${jetty.alpn.version}.jar</jetty.alpn.path>
-        <argLine.bootcp>-Xbootclasspath/p:${jetty.alpn.path}</argLine.bootcp>
+        <jetty.alpnAgent.version>2.0.0</jetty.alpnAgent.version>
+        <jetty.alpnAgent.path>${settings.localRepository}/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
+        <jetty.alpnAgent.option>forceNpn=false</jetty.alpnAgent.option>
+        <argLine.alpnAgent>-javaagent:${jetty.alpnAgent.path}=${jetty.alpnAgent.option}</argLine.alpnAgent>
     </properties>
     <build>
         <plugins>
@@ -101,7 +97,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.16</version>
                 <configuration>
-                    <argLine>${argLine.bootcp} -Dorg.slf4j.simpleLogger.defaultLogLevel=warn</argLine>
+                    <argLine>${argLine.alpnAgent} -Dorg.slf4j.simpleLogger.defaultLogLevel=warn</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -149,8 +145,8 @@
                         </goals>
                         <configuration>
                             <groupId>org.mortbay.jetty.alpn</groupId>
-                            <artifactId>alpn-boot</artifactId>
-                            <version>${jetty.alpn.version}</version>
+                            <artifactId>jetty-alpn-agent</artifactId>
+                            <version>${jetty.alpnAgent.version}</version>
                         </configuration>
                     </execution>
                 </executions>
@@ -184,139 +180,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <!--
-          Profiles that assign proper Jetty alpn-boot version. Shamelessly taken from Netty's pom.
-          See: http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html#alpn-versions
-        -->
-        <profile>
-            <id>alpn-8latest</id>
-            <activation>
-                <jdk>[1.8,)</jdk>
-            </activation>
-            <properties>
-                <jetty.alpn.version>8.1.6.v20151105</jetty.alpn.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>alpn-8u05</id>
-            <activation>
-                <property>
-                    <name>java.version</name>
-                    <value>1.8.0_05</value>
-                </property>
-            </activation>
-            <properties>
-                <jetty.alpn.version>8.1.0.v20141016</jetty.alpn.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>alpn-8u11</id>
-            <activation>
-                <property>
-                    <name>java.version</name>
-                    <value>1.8.0_11</value>
-                </property>
-            </activation>
-            <properties>
-                <jetty.alpn.version>8.1.0.v20141016</jetty.alpn.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>alpn-8u20</id>
-            <activation>
-                <property>
-                    <name>java.version</name>
-                    <value>1.8.0_20</value>
-                </property>
-            </activation>
-            <properties>
-                <jetty.alpn.version>8.1.0.v20141016</jetty.alpn.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>alpn-8u25</id>
-            <activation>
-                <property>
-                    <name>java.version</name>
-                    <value>1.8.0_25</value>
-                </property>
-            </activation>
-            <properties>
-                <jetty.alpn.version>8.1.2.v20141202</jetty.alpn.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>alpn-8u31</id>
-            <activation>
-                <property>
-                    <name>java.version</name>
-                    <value>1.8.0_31</value>
-                </property>
-            </activation>
-            <properties>
-                <jetty.alpn.version>8.1.3.v20150130</jetty.alpn.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>alpn-8u40</id>
-            <activation>
-                <property>
-                    <name>java.version</name>
-                    <value>1.8.0_40</value>
-                </property>
-            </activation>
-            <properties>
-                <jetty.alpn.version>8.1.3.v20150130</jetty.alpn.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>alpn-8u45</id>
-            <activation>
-                <property>
-                    <name>java.version</name>
-                    <value>1.8.0_45</value>
-                </property>
-            </activation>
-            <properties>
-                <jetty.alpn.version>8.1.3.v20150130</jetty.alpn.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>alpn-8u51</id>
-            <activation>
-                <property>
-                    <name>java.version</name>
-                    <value>1.8.0_51</value>
-                </property>
-            </activation>
-            <properties>
-                <jetty.alpn.version>8.1.4.v20150727</jetty.alpn.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>alpn-8u60</id>
-            <activation>
-                <property>
-                    <name>java.version</name>
-                    <value>1.8.0_60</value>
-                </property>
-            </activation>
-            <properties>
-                <jetty.alpn.version>8.1.5.v20150921</jetty.alpn.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>alpn-8u65</id>
-            <activation>
-                <property>
-                    <name>java.version</name>
-                    <value>1.8.0_65</value>
-                </property>
-            </activation>
-            <properties>
-                <jetty.alpn.version>8.1.6.v20151105</jetty.alpn.version>
-            </properties>
         </profile>
     </profiles>
     <organization>


### PR DESCRIPTION
Removes the pain of adding more and more bogus profiles to the pom