### PR TITLE
set handshake failure exception in connectionReadyPromise

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -453,13 +453,13 @@ public class ApnsClient<T extends ApnsPushNotification> {
 
                     @Override
                     protected void handshakeFailure(final ChannelHandlerContext context, final Throwable cause) throws Exception {
-                        super.handshakeFailure(context, cause);
-
                         final ChannelPromise connectionReadyPromise = ApnsClient.this.connectionReadyPromise;
 
                         if (connectionReadyPromise != null) {
                             connectionReadyPromise.tryFailure(cause);
                         }
+
+                        super.handshakeFailure(context, cause);
                     }
                 });
             }


### PR DESCRIPTION
Hi dear jchambers, 

I found that from the `cause` method for `connectionReadyPromise` we never get the `SSLHandshakeException` even though there do have a handshake failure occured because we used a bad certificate to send notification and get this log in `ApplicationProtocolNegotiationHandler`
```
logger.warn("{} TLS handshake failed:", ctx.channel(), cause);
```

What we always get from the `cause` method for `connectionReadyPromise` when handshake failure occur is the `IllegalStateException` created in `closeFuture`'s listener in `ApnsClient`:
```
new IllegalStateException("Channel closed before HTTP/2 preface completed.")
```

I think we need to call 
```
super.handshakeFailure(context, cause);
```
behind `ctx.close()` in the `handshakeFailure` method of `ApplicationProtocolNegotiationHandler`. In this way we never got this problem ever.

What do you think? 