### PR TITLE
Ping when idle (fixes #264, fixes #257)

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -182,7 +182,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
 
     private static final long INITIAL_RECONNECT_DELAY = 1; // second
     private static final long MAX_RECONNECT_DELAY = 60; // seconds
-    private static final int PING_IDLE_TIME = 60; // seconds
+    static final int PING_IDLE_TIME = 60; // seconds
 
     private static final Logger log = LoggerFactory.getLogger(ApnsClient.class);
 

--- a/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -71,6 +71,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
+import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
 import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.FailedFuture;
@@ -181,6 +182,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
 
     private static final long INITIAL_RECONNECT_DELAY = 1; // second
     private static final long MAX_RECONNECT_DELAY = 60; // seconds
+    private static final int PING_IDLE_TIME = 60; // seconds
 
     private static final Logger log = LoggerFactory.getLogger(ApnsClient.class);
 
@@ -430,6 +432,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
                                 }
                             }
 
+                            context.pipeline().addLast(new IdleStateHandler(0, 0, PING_IDLE_TIME));
                             context.pipeline().addLast(apnsClientHandler);
 
                             // Add this to the end of the queue so any events enqueued by the client handler happen

--- a/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
@@ -24,7 +24,8 @@ import java.nio.charset.Charset;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +33,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -45,10 +47,12 @@ import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2FrameAdapter;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.WriteTimeoutException;
 import io.netty.util.AsciiString;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.PromiseCombiner;
+import io.netty.util.concurrent.ScheduledFuture;
 
 class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionHandler {
 
@@ -58,6 +62,11 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
     private final Map<Integer, Http2Headers> headersByStreamId = new HashMap<>();
 
     private ApnsClient<T> apnsClient;
+
+    private long nextPingId = new Random().nextLong();
+    private final Map<Long, ScheduledFuture<?>> pingTimeoutFutures = new HashMap<>();
+
+    private static final int PING_TIMEOUT = 30; // seconds
 
     private static final String APNS_PATH_PREFIX = "/3/device/";
     private static final AsciiString APNS_EXPIRATION_HEADER = new AsciiString("apns-expiration");
@@ -161,6 +170,20 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
         }
 
         @Override
+        public void onPingAckRead(final ChannelHandlerContext context, final ByteBuf data) {
+            final long pingData = data.readLong();
+            final ScheduledFuture<?> timeoutFuture = ApnsClientHandler.this.pingTimeoutFutures.get(pingData);
+
+            if (timeoutFuture != null) {
+                log.debug("Received reply to ping.");
+                timeoutFuture.cancel(false);
+            } else {
+                log.error("Received PING ACK, but no corresponding outbound PING found.");
+                context.close();
+            }
+        }
+
+        @Override
         public void onGoAwayRead(final ChannelHandlerContext context, final int lastStreamId, final long errorCode, final ByteBuf debugData) throws Http2Exception {
             log.info("Received GOAWAY from APNs server: {}", debugData.toString(UTF8));
         }
@@ -237,6 +260,43 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
             log.error("Unexpected object in pipeline: {}", message);
             context.write(message, writePromise);
         }
+    }
+
+    @Override
+    public void userEventTriggered(final ChannelHandlerContext context, final Object event) throws Exception {
+        if (event instanceof IdleStateEvent) {
+            log.debug("Sending ping due to inactivity.");
+
+            final long pingData = this.nextPingId++;
+
+            final ByteBuf pingDataBuffer = context.alloc().ioBuffer(8, 8);
+            pingDataBuffer.writeLong(pingData);
+
+            this.encoder().writePing(context, false, pingDataBuffer, context.newPromise()).addListener(
+                    new GenericFutureListener<ChannelFuture>() {
+
+                        @Override
+                        public void operationComplete(final ChannelFuture future) throws Exception {
+                            if (future.isSuccess()) {
+                                final ScheduledFuture<?> timeoutFuture = future.channel().eventLoop().schedule(new Runnable() {
+
+                                    @Override
+                                    public void run() {
+                                        log.debug("Closing channel due to ping timeout.");
+                                        future.channel().close();
+                                    }
+                                }, PING_TIMEOUT, TimeUnit.SECONDS);
+
+                                ApnsClientHandler.this.pingTimeoutFutures.put(pingData, timeoutFuture);
+                            } else {
+                                log.debug("Failed to write PING frame.", future.cause());
+                                future.channel().close();
+                            }
+                        }
+                    });
+        }
+
+        super.userEventTriggered(context, event);
     }
 
     @Override

--- a/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
@@ -188,7 +188,7 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
             final ScheduledFuture<?> timeoutFuture = ApnsClientHandler.this.pingTimeoutFutures.get(pingData);
 
             if (timeoutFuture != null) {
-                log.debug("Received reply to ping.");
+                log.trace("Received reply to ping.");
                 timeoutFuture.cancel(false);
             } else {
                 log.error("Received PING ACK, but no corresponding outbound PING found.");
@@ -287,7 +287,7 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
     @Override
     public void userEventTriggered(final ChannelHandlerContext context, final Object event) throws Exception {
         if (event instanceof IdleStateEvent) {
-            log.debug("Sending ping due to inactivity.");
+            log.trace("Sending ping due to inactivity.");
 
             final long pingId = this.nextPingId++;
 


### PR DESCRIPTION
As discussed in #265, #264, and #257, this change causes clients to send `PING` frames after they've been idle for some time. This should prevent connections from being closed due to inactivity at either the transport layer or the application layer. It also has the nice benefit of helping us detect flaky connections earlier.