### PR TITLE
Optimize payload construction (closes #11)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.5</version>
+            <version>2.6.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/src/main/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilder.java
@@ -75,6 +75,7 @@ public class ApnsPayloadBuilder {
     private static final int DEFAULT_PAYLOAD_SIZE = 4096;
 
     private static final Charset UTF8 = Charset.forName("UTF-8");
+    private static final String ABBREVIATION_SUBSTRING = "…";
 
     private static final Gson gson = new GsonBuilder().serializeNulls().create();
 
@@ -360,15 +361,15 @@ public class ApnsPayloadBuilder {
      * longer than the given maximum, the literal alert body will be shortened if possible. If the alert body cannot be
      * shortened or is not present, an {@code IllegalArgumentException} is thrown.</p>
      *
-     * @param maximumPayloadLength the maximum length of the payload in bytes
+     * @param maximumPayloadSize the maximum length of the payload in bytes
      *
      * @return a JSON representation of the payload under construction (possibly with an abbreviated alert body)
      */
-    public String buildWithMaximumLength(final int maximumPayloadLength) {
-        final HashMap<String, Object> payload = new HashMap<String, Object>();
+    public String buildWithMaximumLength(final int maximumPayloadSize) {
+        final Map<String, Object> payload = new HashMap<String, Object>();
 
         {
-            final HashMap<String, Object> aps = new HashMap<String, Object>();
+            final Map<String, Object> aps = new HashMap<String, Object>();
 
             if (this.badgeNumber != null) {
                 aps.put(BADGE_KEY, this.badgeNumber);
@@ -402,39 +403,61 @@ public class ApnsPayloadBuilder {
         final String payloadString = gson.toJson(payload);
         final int initialPayloadLength = payloadString.getBytes(UTF8).length;
 
-        if (initialPayloadLength <= maximumPayloadLength) {
+        if (initialPayloadLength <= maximumPayloadSize) {
             return payloadString;
         } else {
-            // TODO This could probably be more efficient
             if (this.alertBody != null) {
                 this.replaceMessageBody(payload, "");
-                final int payloadLengthWithEmptyMessage = gson.toJson(payload).getBytes(UTF8).length;
+                final int payloadSizeWithEmptyMessage = gson.toJson(payload).getBytes(UTF8).length;
 
-                if (payloadLengthWithEmptyMessage > maximumPayloadLength) {
+                if (payloadSizeWithEmptyMessage >= maximumPayloadSize) {
                     throw new IllegalArgumentException(
                             "Payload exceeds maximum length even with an empty message body.");
                 }
 
-                int maximumMessageBodyLength = maximumPayloadLength - payloadLengthWithEmptyMessage;
+                // We add 2 here because the escaped string will include opening and closing '"' characters that are
+                // already accounted for in payloadSizeWithEmptyMessage.
+                final int maximumEscapedMessageBodySize = maximumPayloadSize - payloadSizeWithEmptyMessage + 2;
 
-                this.replaceMessageBody(payload, this.abbreviateString(this.alertBody, maximumMessageBodyLength--));
+                // Characters in the message body may wind up representing different numbers of bytes as an escaped
+                // JSON string. Assuming a best case of one byte per character, we have a ceiling on the maximum number
+                // of characters we could possibly fit into the message body. Start there and then do a binary search
+                // to find the longest message we can get away with.
+                int left = 0;
+                int right = maximumEscapedMessageBodySize;
 
-                while (gson.toJson(payload).getBytes(UTF8).length > maximumPayloadLength) {
-                    this.replaceMessageBody(payload, this.abbreviateString(this.alertBody, maximumMessageBodyLength--));
+                String fittedMessageBody = null;
+
+                while (left < right) {
+                    final int middle = (left + right) / 2;
+
+                    fittedMessageBody = this.abbreviateString(this.alertBody, middle);
+                    final String escapedFittedMessageBody = gson.toJson(fittedMessageBody);
+
+                    final int fittedMessageBodySize = escapedFittedMessageBody.getBytes(UTF8).length;
+
+                    if (fittedMessageBodySize == maximumEscapedMessageBodySize) {
+                        break;
+                    } else if (fittedMessageBodySize < maximumEscapedMessageBodySize) {
+                        left = middle;
+                    } else {
+                        right = middle;
+                    }
                 }
 
-                return gson.toJson(payload);
+                this.replaceMessageBody(payload, fittedMessageBody);
 
+                return gson.toJson(payload);
             } else {
                 throw new IllegalArgumentException(String.format(
                         "Payload length is %d bytes (with a maximum of %d bytes) and cannot be shortened.",
-                        initialPayloadLength, maximumPayloadLength));
+                        initialPayloadLength, maximumPayloadSize));
             }
         }
     }
 
-    @SuppressWarnings("unchecked")
     private void replaceMessageBody(final Map<String, Object> payload, final String messageBody) {
+        @SuppressWarnings("unchecked")
         final Map<String, Object> aps = (Map<String, Object>) payload.get(APS_KEY);
         final Object alert = aps.get(ALERT_KEY);
 
@@ -442,6 +465,7 @@ public class ApnsPayloadBuilder {
             if (alert instanceof String) {
                 aps.put(ALERT_KEY, messageBody);
             } else {
+                @SuppressWarnings("unchecked")
                 final Map<String, Object> alertObject = (Map<String, Object>) alert;
 
                 if (alertObject.get(ALERT_BODY_KEY) != null) {
@@ -455,19 +479,20 @@ public class ApnsPayloadBuilder {
         }
     }
 
-    private final String abbreviateString(final String string, final int maximumLength) {
+    private String abbreviateString(final String string, final int maximumLength) {
+        final String abbreviatedString;
+
         if (string.length() <= maximumLength) {
-            return string;
+            abbreviatedString = string;
         } else {
-            if (maximumLength <= 3) {
-                throw new IllegalArgumentException("Cannot abbreviate string to fewer than three characters.");
+            if (maximumLength <= 1) {
+                throw new IllegalArgumentException("Cannot abbreviate string to fewer than one character.");
             }
 
-            // TODO Actually use a real ellipses character when
-            // https://code.google.com/p/json-simple/issues/detail?id=25 gets resolved
-            // TODO Make this locale-sensitive
-            return string.substring(0, maximumLength - 3) + "...";
+            abbreviatedString = string.substring(0, maximumLength - 1) + ABBREVIATION_SUBSTRING;
         }
+
+        return abbreviatedString;
     }
 
     private Object createAlertObject() {

--- a/src/main/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/src/main/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilder.java
@@ -485,8 +485,8 @@ public class ApnsPayloadBuilder {
         if (string.length() <= maximumLength) {
             abbreviatedString = string;
         } else {
-            if (maximumLength <= 1) {
-                throw new IllegalArgumentException("Cannot abbreviate string to fewer than one character.");
+            if (maximumLength <= ABBREVIATION_SUBSTRING.length()) {
+                throw new IllegalArgumentException("String is too short to abbreviate.");
             }
 
             abbreviatedString = string.substring(0, maximumLength - ABBREVIATION_SUBSTRING.length()) + ABBREVIATION_SUBSTRING;

--- a/src/main/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/src/main/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilder.java
@@ -489,7 +489,7 @@ public class ApnsPayloadBuilder {
                 throw new IllegalArgumentException("Cannot abbreviate string to fewer than one character.");
             }
 
-            abbreviatedString = string.substring(0, maximumLength - 1) + ABBREVIATION_SUBSTRING;
+            abbreviatedString = string.substring(0, maximumLength - ABBREVIATION_SUBSTRING.length()) + ABBREVIATION_SUBSTRING;
         }
 
         return abbreviatedString;

--- a/src/test/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/src/test/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -21,9 +21,7 @@
 
 package com.relayrides.pushy.apns.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.lang.reflect.Type;
 import java.nio.charset.Charset;
@@ -307,6 +305,16 @@ public class ApnsPayloadBuilderTest {
         final String payloadString = this.builder.buildWithMaximumLength(maxLength);
 
         assertTrue(payloadString.getBytes(Charset.forName("UTF-8")).length <= maxLength);
+    }
+
+    @Test
+    public void testBuildWithMaximumLengthAndAlreadyFittingMessageBody() {
+        final String shortAlertMessage = "This should just fit.";
+
+        this.builder.setAlertBody(shortAlertMessage);
+        final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLength(Integer.MAX_VALUE));
+
+        assertEquals(shortAlertMessage, aps.get("alert"));
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
#11 has been on the to-do list for a really long time, and this finally clears it out. This does two important things:

1. It avoids frequently modifying the payload map and regenerating the entire notification payload.
2. It uses a binary search instead of a linear search to identify maximal-length alert bodies. This may actually turn out to be very slightly slower for users who were sending mostly-ASCII messages, but will be an enormous improvement for anybody sending mostly-Unicode messages.