### PR TITLE
Expand Travis CI build matrix (closes #232)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,10 @@ language: java
 jdk:
     - oraclejdk8
     - oraclejdk7
-    - openjdk7
 env:
     - PUSHY_SSL_PROVIDER=jdk
     - PUSHY_SSL_PROVIDER=native
 matrix:
     exclude:
         - jdk: oraclejdk7
-          env: PUSHY_SSL_PROVIDER=jdk
-        - jdk: openjdk7
           env: PUSHY_SSL_PROVIDER=jdk

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,14 @@
 language: java
 jdk:
     - oraclejdk8
+    - oraclejdk7
+    - openjdk7
+env:
+    - PUSHY_SSL_PROVIDER=jdk
+    - PUSHY_SSL_PROVIDER=native
+matrix:
+    exclude:
+        - jdk: oraclejdk7
+          env: PUSHY_SSL_PROVIDER=jdk
+        - jdk: openjdk7
+          env: PUSHY_SSL_PROVIDER=jdk

--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,12 @@
             <version>1.7.6</version>
         </dependency>
         <dependency>
-          <groupId>org.eclipse.jetty.alpn</groupId>
-          <artifactId>alpn-api</artifactId>
-          <version>1.1.2.v20150522</version>
-          <!-- Provided by alpn-boot; see
+            <groupId>org.eclipse.jetty.alpn</groupId>
+            <artifactId>alpn-api</artifactId>
+            <version>1.1.2.v20150522</version>
+            <!-- Provided by alpn-boot; see
           http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html#alpn-understanding -->
-          <scope>provided</scope>
+            <scope>provided</scope>
         </dependency>
         <!-- Test dependencies -->
         <dependency>
@@ -70,12 +70,15 @@
     <properties>
         <netty.version>4.1.0.CR6</netty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.alpnAgent.version>2.0.0</jetty.alpnAgent.version>
-        <jetty.alpnAgent.path>${settings.localRepository}/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
-        <jetty.alpnAgent.option>forceNpn=false</jetty.alpnAgent.option>
-        <argLine.alpnAgent>-javaagent:${jetty.alpnAgent.path}=${jetty.alpnAgent.option}</argLine.alpnAgent>
     </properties>
     <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.4.0.Final</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -84,14 +87,6 @@
                 <configuration>
                     <source>1.7</source>
                     <target>1.7</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
-                <configuration>
-                    <argLine>${argLine.alpnAgent} -Dorg.slf4j.simpleLogger.defaultLogLevel=warn</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -127,27 +122,84 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Download the alpn-boot.jar in advance to add it to the boot classpath. -->
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>get-alpn-boot</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>get</goal>
-                        </goals>
-                        <configuration>
-                            <groupId>org.mortbay.jetty.alpn</groupId>
-                            <artifactId>jetty-alpn-agent</artifactId>
-                            <version>${jetty.alpnAgent.version}</version>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <id>test-with-alpn-boot</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>env.PUSHY_SSL_PROVIDER</name>
+                    <value>jdk</value>
+                </property>
+            </activation>
+            <properties>
+                <jetty.alpnAgent.version>2.0.0</jetty.alpnAgent.version>
+                <jetty.alpnAgent.path>${settings.localRepository}/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
+                <jetty.alpnAgent.option>forceNpn=false</jetty.alpnAgent.option>
+                <argLine.alpnAgent>-javaagent:${jetty.alpnAgent.path}=${jetty.alpnAgent.option}</argLine.alpnAgent>
+            </properties>
+            <build>
+                <plugins>
+                    <!-- Download the alpn-boot.jar in advance to add it to the boot classpath. -->
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>get-alpn-boot</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>get</goal>
+                                </goals>
+                                <configuration>
+                                    <groupId>org.mortbay.jetty.alpn</groupId>
+                                    <artifactId>jetty-alpn-agent</artifactId>
+                                    <version>${jetty.alpnAgent.version}</version>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.16</version>
+                        <configuration>
+                            <argLine>${argLine.alpnAgent} -Dorg.slf4j.simpleLogger.defaultLogLevel=warn</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-with-netty-tcnative</id>
+            <activation>
+                <property>
+                    <name>env.PUSHY_SSL_PROVIDER</name>
+                    <value>native</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                    <version>1.1.33.Fork15</version>
+                    <classifier>${os.detected.classifier}</classifier>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.16</version>
+                        <configuration>
+                            <argLine>-Dorg.slf4j.simpleLogger.defaultLogLevel=warn</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>release-sign-artifacts</id>
             <activation>


### PR DESCRIPTION
This expands the Travis CI build matrix to cover Java 7 and native SSL providers.