### PR TITLE
Defer flushes (fixes #276)

### DIFF
--- a/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -143,7 +143,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
 
     private volatile ChannelPromise connectionReadyPromise;
     private volatile ChannelPromise reconnectionPromise;
-    private long reconnectDelay = INITIAL_RECONNECT_DELAY_SECONDS;
+    private long reconnectDelaySeconds = INITIAL_RECONNECT_DELAY_SECONDS;
 
     private final Map<T, Promise<PushNotificationResponse<T>>> responsePromises = new IdentityHashMap<>();
 
@@ -684,7 +684,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
                                 }
 
                                 if (ApnsClient.this.reconnectionPromise != null) {
-                                    log.debug("Disconnected. Next automatic reconnection attempt in {} seconds.", ApnsClient.this.reconnectDelay);
+                                    log.debug("Disconnected. Next automatic reconnection attempt in {} seconds.", ApnsClient.this.reconnectDelaySeconds);
 
                                     future.channel().eventLoop().schedule(new Runnable() {
 
@@ -693,9 +693,9 @@ public class ApnsClient<T extends ApnsPushNotification> {
                                             log.debug("Attempting to reconnect.");
                                             ApnsClient.this.connect(host, port);
                                         }
-                                    }, ApnsClient.this.reconnectDelay, TimeUnit.SECONDS);
+                                    }, ApnsClient.this.reconnectDelaySeconds, TimeUnit.SECONDS);
 
-                                    ApnsClient.this.reconnectDelay = Math.min(ApnsClient.this.reconnectDelay, MAX_RECONNECT_DELAY_SECONDS);
+                                    ApnsClient.this.reconnectDelaySeconds = Math.min(ApnsClient.this.reconnectDelaySeconds, MAX_RECONNECT_DELAY_SECONDS);
                                 }
                             }
 
@@ -730,7 +730,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
                                         log.info("Connected to {}.", future.channel().remoteAddress());
                                     }
 
-                                    ApnsClient.this.reconnectDelay = INITIAL_RECONNECT_DELAY_SECONDS;
+                                    ApnsClient.this.reconnectDelaySeconds = INITIAL_RECONNECT_DELAY_SECONDS;
                                     ApnsClient.this.reconnectionPromise = future.channel().newPromise();
                                 }
 

--- a/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -582,7 +582,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
      * {@code maxUnflushedNotifications} is also positive or zero if {@code maxUnflushedNotifications} is also zero. If
      * zero, notifications are always sent immediately.
      *
-     * @since 0.6.2
+     * @since 0.7
      */
     public void setFlushThresholds(final int maxUnflushedNotifications, final long maxIdleTimeMillis) {
         if ((maxUnflushedNotifications > 0 && maxIdleTimeMillis > 0) || (maxUnflushedNotifications == 0 && maxIdleTimeMillis == 0)) {


### PR DESCRIPTION
This change defers calls to `flush` until either:

1. a given number of notifications are waiting to be flushed or
2. the channel has been idle for a given amount of time

This should significantly cut down on the number of calls to `flush`, which should yield significant performance benefits for users sending lots of notifications. These changes are easiest to read with [whitespace-only changes hidden](https://github.com/relayrides/pushy/pull/278/files?w=1).

----

TODO:

- [x] Update docs (9f0ea27)