### PR TITLE
Further efficient-ize ApnsPayloadBuilder

### DIFF
--- a/pushy/src/test/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -24,7 +24,7 @@ package com.relayrides.pushy.apns.util;
 import static org.junit.Assert.*;
 
 import java.lang.reflect.Type;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -295,8 +295,9 @@ public class ApnsPayloadBuilderTest {
 
     @Test
     public void testBuildWithMaximumLength() {
-        final String reallyLongAlertMessage =
-                "All non-glanded recruited mercenaries now engaging in training excercises are herefore and forever ordered to desist. Aforementioned activities have resulted in cost-defective damage to training areas.";
+        final String reallyLongAlertMessage = "All non-glanded recruited mercenaries now engaging in training " +
+                "excercises are herefore and forever ordered to desist. Aforementioned activities have resulted in " +
+                "cost-defective damage to training areas.";
 
         final int maxLength = 128;
 
@@ -304,7 +305,8 @@ public class ApnsPayloadBuilderTest {
 
         final String payloadString = this.builder.buildWithMaximumLength(maxLength);
 
-        assertTrue(payloadString.getBytes(Charset.forName("UTF-8")).length <= maxLength);
+        assertTrue(reallyLongAlertMessage.getBytes(StandardCharsets.UTF_8).length > maxLength);
+        assertTrue(payloadString.getBytes(StandardCharsets.UTF_8).length == maxLength);
     }
 
     @Test
@@ -328,7 +330,7 @@ public class ApnsPayloadBuilderTest {
 
         final String payloadString = this.builder.buildWithMaximumLength(maxLength);
 
-        assertTrue(payloadString.getBytes(Charset.forName("UTF-8")).length <= maxLength);
+        assertTrue(payloadString.getBytes(StandardCharsets.UTF_8).length <= maxLength);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
This does two things to make `ApnsPayloadBuilder` a bit more efficient:

1. It introduces a reusable buffer for JSON generation, which should cut down on buffer allocations and reduce GC pressure when reusing `ApnsPayloadBuilder` instances.
2. It totally changes the algorithm for finding alert bodies that fit within a limited payload size. Previously, we were doing a binary search. In c9c9b89, we just count bytes to figure out how much of the alert body we can include.

Benchmarks:

```
Before:

(messageBodyLength)      (unicodeBlockName)   Mode  Cnt       Score      Error  Units
                512             BASIC_LATIN  thrpt   80  222343.928 ± 4858.257  ops/s
                512  CJK_UNIFIED_IDEOGRAPHS  thrpt   80  305840.679 ± 1133.963  ops/s
               8192             BASIC_LATIN  thrpt   80    3323.071 ±  238.083  ops/s
               8192  CJK_UNIFIED_IDEOGRAPHS  thrpt   80    6939.819 ±   25.177  ops/s

After:

(messageBodyLength)      (unicodeBlockName)   Mode  Cnt       Score      Error  Units
                512             BASIC_LATIN  thrpt   80  222640.631 ± 1577.262  ops/s
                512  CJK_UNIFIED_IDEOGRAPHS  thrpt   80  331607.892 ± 1820.027  ops/s
               8192             BASIC_LATIN  thrpt   80    9927.099 ±   69.721  ops/s
               8192  CJK_UNIFIED_IDEOGRAPHS  thrpt   80   21185.339 ±   83.509  ops/s
```