### PR TITLE
Builder pattern for ApnsClients

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientBuilder.java
@@ -215,6 +215,18 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
         return this;
     }
 
+    /**
+     * Sets the proxy handler factory to be used to construct proxy handlers when establishing a new connection to the
+     * APNs gateway. A client's proxy handler factory may be {@code null}, in which case the client will connect to the
+     * gateway directly and will not use a proxy. By default, clients will not use a proxy.
+     *
+     * @param proxyHandlerFactory the proxy handler factory to be used to construct proxy handlers, or {@code null} if
+     * this client should not use a proxy
+     *
+     * @return a reference to this builder
+     *
+     * @since 0.8
+     */
     public ApnsClientBuilder<T> setProxyHandlerFactory(final ProxyHandlerFactory proxyHandlerFactory) {
         this.proxyHandlerFactory = proxyHandlerFactory;
         return this;
@@ -227,6 +239,20 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
         return this;
     }
 
+    /**
+     * <p>Sets the write timeout for the client to build. If an attempt to send a notification to the APNs server takes
+     * longer than the given timeout, the connection will be closed (and automatically reconnected later). Note that
+     * write timeouts refer to the amount of time taken to <em>send</em> a notification to the server, and not the time
+     * taken by the server to process and respond to a notification.</p>
+     *
+     * <p>By default, clients have a write timeout of
+     * {@value com.relayrides.pushy.apns.ApnsClient#DEFAULT_WRITE_TIMEOUT_MILLIS} milliseconds.</p>
+     *
+     * @param writeTimeout the write timeout for the client to be built
+     * @param timeoutUnit the time unit for the given timeout
+     *
+     * @since 0.8
+     */
     public ApnsClientBuilder<T> setWriteTimeout(final long writeTimeout, final TimeUnit timeoutUnit) {
         this.writeTimeout = writeTimeout;
         this.writeTimeoutUnit = timeoutUnit;
@@ -241,6 +267,13 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
         return this;
     }
 
+    /**
+     * Constructs a new {@link ApnsClient} with the previously-set configuration.
+     *
+     * @return a new ApnsClient instance with the previously-set configuration
+     *
+     * @throws SSLException if an SSL context could not be created for the new client for any reason
+     */
     public ApnsClient<T> build() throws SSLException {
         Objects.requireNonNull(this.clientCertificate, "Client certificate must be set before building an APNs client.");
         Objects.requireNonNull(this.privateKey, "Private key must be set before building an APNs client.");

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientBuilder.java
@@ -1,0 +1,301 @@
+/* Copyright (c) 2013-2016 RelayRides
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE. */
+
+package com.relayrides.pushy.apns;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.PrivateKey;
+import java.security.KeyStore.PrivateKeyEntry;
+import java.security.KeyStoreException;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.relayrides.pushy.apns.proxy.ProxyHandlerFactory;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.handler.codec.http2.Http2SecurityUtil;
+import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
+import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
+import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
+import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
+
+/**
+ * <p>An {@code ApnsClientBuilder} constructs new {@link ApnsClient} instances. Callers must supply client credentials
+ * via one of the {@code setClientCredentials} methods prior to constructing a new client with the
+ * {@link com.relayrides.pushy.apns.ApnsClientBuilder#build()} method; all other settings are optional.</p>
+ *
+ * <p>Client builders may be reused to generate multiple clients, and their settings may be changed from one client to
+ * the next.</p>
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ *
+ * @param <T> the type of notification handled by client instances created by this builder
+ */
+public class ApnsClientBuilder<T extends ApnsPushNotification> {
+    private X509Certificate clientCertificate;
+    private PrivateKey privateKey;
+    private String privateKeyPassword;
+
+    private File trustedServerCertificatePemFile;
+
+    private EventLoopGroup eventLoopGroup;
+
+    private ApnsClientMetricsListener metricsListener;
+
+    private ProxyHandlerFactory proxyHandlerFactory;
+
+    private Long connectionTimeout;
+    private TimeUnit connectionTimeoutUnit;
+
+    private Long writeTimeout;
+    private TimeUnit writeTimeoutUnit;
+
+    private Long gracefulShutdownTimeout;
+    private TimeUnit gracefulShutdownTimeoutUnit;
+
+    private static final Logger log = LoggerFactory.getLogger(ApnsClientBuilder.class);
+
+    /**
+     * <p>Sets the credentials for the client to be built using the contents of the given PKCS#12 file. The PKCS#12 file
+     * <em>must</em> contain a single certificate/private key pair.</p>
+     *
+     * @param p12File a PKCS#12-formatted file containing the certificate and private key to be used to identify the
+     * client to the APNs server
+     * @param p12Password the password to be used to decrypt the contents of the given PKCS#12 file; passwords may be
+     * blank (i.e. {@code ""}), but must not be {@code null}
+     *
+     * @throws SSLException if the given PKCS#12 file could not be loaded or if any other SSL-related problem arises
+     * when constructing the context
+     * @throws IOException if any IO problem occurs while attempting to read the given PKCS#12 file, or the PKCS#12 file
+     * could not be found
+     *
+     * @return a reference to this builder
+     *
+     * @since 0.8
+     */
+    public ApnsClientBuilder<T> setClientCredentials(final File p12File, final String p12Password) throws SSLException, IOException {
+        try (final InputStream p12InputStream = new FileInputStream(p12File)) {
+            return this.setClientCredentials(p12InputStream, p12Password);
+        }
+    }
+
+    /**
+     * <p>Sets the credentials for the client to be built using the data from the given PKCS#12 input stream. The
+     * PKCS#12 data <em>must</em> contain a single certificate/private key pair.</p>
+     *
+     * @param p12File an input stream to a PKCS#12-formatted file containing the certificate and private key to be used
+     * to identify the client to the APNs server
+     * @param p12Password the password to be used to decrypt the contents of the given PKCS#12 file; passwords may be
+     * blank (i.e. {@code ""}), but must not be {@code null}
+     *
+     * @throws SSLException if the given PKCS#12 file could not be loaded or if any other SSL-related problem arises
+     * when constructing the context
+     * @throws IOException if any IO problem occurs while attempting to read the given PKCS#12 file, or the PKCS#12 file
+     * could not be found
+     *
+     * @return a reference to this builder
+     *
+     * @since 0.8
+     */
+    public ApnsClientBuilder<T> setClientCredentials(final InputStream p12InputStream, final String p12Password) throws SSLException, IOException {
+        final X509Certificate x509Certificate;
+        final PrivateKey privateKey;
+
+        try {
+            final PrivateKeyEntry privateKeyEntry = P12Util.getFirstPrivateKeyEntryFromP12InputStream(p12InputStream, p12Password);
+
+            final Certificate certificate = privateKeyEntry.getCertificate();
+
+            if (!(certificate instanceof X509Certificate)) {
+                throw new KeyStoreException("Found a certificate in the provided PKCS#12 file, but it was not an X.509 certificate.");
+            }
+
+            x509Certificate = (X509Certificate) certificate;
+            privateKey = privateKeyEntry.getPrivateKey();
+        } catch (final KeyStoreException e) {
+            throw new SSLException(e);
+        }
+
+        return this.setClientCredentials(x509Certificate, privateKey, p12Password);
+    }
+
+    /**
+     * <p>Sets the credentials for the client to be built.</p>
+     *
+     * @param clientCertificate the certificate to be used to identify the client to the APNs server
+     * @param privateKey the private key for the client certificate
+     * @param privateKeyPassword the password to be used to decrypt the private key; may be {@code null} if the private
+     * key does not require a password
+     *
+     * @return a reference to this builder
+     *
+     * @since 0.8
+     */
+    public ApnsClientBuilder<T> setClientCredentials(final X509Certificate clientCertificate, final PrivateKey privateKey, final String privateKeyPassword) {
+        this.clientCertificate = clientCertificate;
+        this.privateKey = privateKey;
+        this.privateKeyPassword = privateKeyPassword;
+
+        return this;
+    }
+
+    protected ApnsClientBuilder<T> setTrustedServerCertificate(final File trustedServerCertificatePemFile) {
+        this.trustedServerCertificatePemFile = trustedServerCertificatePemFile;
+        return this;
+    }
+
+    /**
+     * <p>Sets the event loop group to be used by the client to be built. If not set (or if {@code null}), the client
+     * will create and manage its own event loop group.</p>
+     *
+     * <p>Generally speaking, callers don't need to set event loop groups for clients, but it may be useful to specify
+     * an event loop group under certain circumstances. In particular, specifying an event loop group that is shared
+     * among multiple {@code ApnsClient} instances can keep thread counts manageable. Regardless of the number of
+     * concurrent {@code ApnsClient} instances, callers may also wish to specify an event loop group to take advantage
+     * of certain platform-specific optimizations (e.g. epoll event loop groups).</p>
+     *
+     * @param eventLoopGroup the event loop group to use for this client, or {@code null} to let the client manage its
+     * own event loop group
+     *
+     * @return a reference to this builder
+     *
+     * @since 0.8
+     */
+    public ApnsClientBuilder<T> setEventLoopGroup(final EventLoopGroup eventLoopGroup) {
+        this.eventLoopGroup = eventLoopGroup;
+        return this;
+    }
+
+    /**
+     * Sets the metrics listener for the client to be built. Metrics listeners gather information that describes the
+     * performance and behavior of a client, and are completely optional.
+     *
+     * @param metricsListener the metrics listener for the client under construction, or {@code null} if this client
+     * should not report metrics to a listener
+     *
+     * @return a reference to this builder
+     *
+     * @since 0.8
+     */
+    public ApnsClientBuilder<T> setMetricsListener(final ApnsClientMetricsListener metricsListener) {
+        this.metricsListener = metricsListener;
+        return this;
+    }
+
+    public ApnsClientBuilder<T> setProxyHandlerFactory(final ProxyHandlerFactory proxyHandlerFactory) {
+        this.proxyHandlerFactory = proxyHandlerFactory;
+        return this;
+    }
+
+    public ApnsClientBuilder<T> setConnectionTimeout(final long connectionTimeout, final TimeUnit timeoutUnit) {
+        this.connectionTimeout = connectionTimeout;
+        this.connectionTimeoutUnit = timeoutUnit;
+
+        return this;
+    }
+
+    public ApnsClientBuilder<T> setWriteTimeout(final long writeTimeout, final TimeUnit timeoutUnit) {
+        this.writeTimeout = writeTimeout;
+        this.writeTimeoutUnit = timeoutUnit;
+
+        return this;
+    }
+
+    public ApnsClientBuilder<T> setGracefulShutdownTimeout(final long gracefulShutdownTimeout, final TimeUnit timeoutUnit) {
+        this.gracefulShutdownTimeout = gracefulShutdownTimeout;
+        this.gracefulShutdownTimeoutUnit = timeoutUnit;
+
+        return this;
+    }
+
+    public ApnsClient<T> build() throws SSLException {
+        Objects.requireNonNull(this.clientCertificate, "Client certificate must be set before building an APNs client.");
+        Objects.requireNonNull(this.privateKey, "Private key must be set before building an APNs client.");
+
+        final SslContext sslContext;
+        {
+            final SslProvider sslProvider;
+
+            if (OpenSsl.isAvailable()) {
+                if (OpenSsl.isAlpnSupported()) {
+                    log.info("Native SSL provider is available and supports ALPN; will use native provider.");
+                    sslProvider = SslProvider.OPENSSL;
+                } else {
+                    log.info("Native SSL provider is available, but does not support ALPN; will use JDK SSL provider.");
+                    sslProvider = SslProvider.JDK;
+                }
+            } else {
+                log.info("Native SSL provider not available; will use JDK SSL provider.");
+                sslProvider = SslProvider.JDK;
+            }
+
+            final SslContextBuilder sslContextBuilder = SslContextBuilder.forClient()
+                    .sslProvider(sslProvider)
+                    .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+                    .keyManager(this.privateKey, this.privateKeyPassword, this.clientCertificate)
+                    .applicationProtocolConfig(
+                            new ApplicationProtocolConfig(Protocol.ALPN,
+                                    SelectorFailureBehavior.NO_ADVERTISE,
+                                    SelectedListenerFailureBehavior.ACCEPT,
+                                    ApplicationProtocolNames.HTTP_2));
+
+            if (this.trustedServerCertificatePemFile != null) {
+                sslContextBuilder.trustManager(this.trustedServerCertificatePemFile);
+            }
+
+            sslContext = sslContextBuilder.build();
+        }
+
+        final ApnsClient<T> apnsClient = new ApnsClient<T>(sslContext, this.eventLoopGroup);
+
+        apnsClient.setMetricsListener(this.metricsListener);
+        apnsClient.setProxyHandlerFactory(this.proxyHandlerFactory);
+
+        if (this.connectionTimeout != null) {
+            apnsClient.setConnectionTimeout((int) this.connectionTimeoutUnit.toMillis(this.connectionTimeout));
+        }
+
+        if (this.writeTimeout != null) {
+            apnsClient.setWriteTimeout(this.writeTimeoutUnit.toMillis(this.writeTimeout));
+        }
+
+        if (this.gracefulShutdownTimeout != null) {
+            apnsClient.setGracefulShutdownTimeout(this.gracefulShutdownTimeoutUnit.toMillis(this.gracefulShutdownTimeout));
+        }
+
+        return apnsClient;
+    }
+}

--- a/pushy/src/test/java/com/relayrides/pushy/apns/ApnsClientBuilderTest.java
+++ b/pushy/src/test/java/com/relayrides/pushy/apns/ApnsClientBuilderTest.java
@@ -1,0 +1,75 @@
+package com.relayrides.pushy.apns;
+
+import java.io.File;
+import java.io.InputStream;
+import java.security.KeyStore.PrivateKeyEntry;
+import java.security.cert.X509Certificate;
+
+import org.junit.Test;
+
+import com.relayrides.pushy.apns.util.SimpleApnsPushNotification;
+
+public class ApnsClientBuilderTest {
+
+    private static final String SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME = "/single-topic-client.p12";
+    private static final String SINGLE_TOPIC_CLIENT_KEYSTORE_UNPROTECTED_FILENAME = "/single-topic-client-unprotected.p12";
+
+    private static final String KEYSTORE_PASSWORD = "pushy-test";
+
+    @Test
+    public void testBuildClientWithPasswordProtectedP12File() throws Exception {
+        // We're happy here as long as nothing throws an exception
+        new ApnsClientBuilder<SimpleApnsPushNotification>()
+        .setClientCredentials(new File(ApnsClientBuilderTest.class.getResource(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME).toURI()), KEYSTORE_PASSWORD)
+        .build();
+    }
+
+    @Test
+    public void testBuildClientWithPasswordProtectedP12InputStream() throws Exception {
+        // We're happy here as long as nothing throws an exception
+        try (final InputStream p12InputStream = ApnsClientBuilderTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
+            new ApnsClientBuilder<SimpleApnsPushNotification>()
+            .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
+            .build();
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testBuildClientWithNullPassword() throws Exception {
+        new ApnsClientBuilder<SimpleApnsPushNotification>()
+        .setClientCredentials(new File(ApnsClientBuilderTest.class.getResource(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME).toURI()), null)
+        .build();
+    }
+
+    @Test
+    public void testBuildClientWithCertificateAndPasswordProtectedKey() throws Exception {
+        // We're happy here as long as nothing throws an exception
+        try (final InputStream p12InputStream = ApnsClientBuilderTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
+            final PrivateKeyEntry privateKeyEntry =
+                    P12Util.getFirstPrivateKeyEntryFromP12InputStream(p12InputStream, KEYSTORE_PASSWORD);
+
+            new ApnsClientBuilder<SimpleApnsPushNotification>()
+            .setClientCredentials((X509Certificate) privateKeyEntry.getCertificate(), privateKeyEntry.getPrivateKey(), KEYSTORE_PASSWORD)
+            .build();
+        }
+    }
+
+    @Test
+    public void testBuildClientWithCertificateAndUnprotectedKey() throws Exception {
+        // We DO need a password to unlock the keystore, but the key itself should be unprotected
+        try (final InputStream p12InputStream = ApnsClientBuilderTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_UNPROTECTED_FILENAME)) {
+
+            final PrivateKeyEntry privateKeyEntry =
+                    P12Util.getFirstPrivateKeyEntryFromP12InputStream(p12InputStream, KEYSTORE_PASSWORD);
+
+            new ApnsClientBuilder<SimpleApnsPushNotification>()
+            .setClientCredentials((X509Certificate) privateKeyEntry.getCertificate(), privateKeyEntry.getPrivateKey(), null)
+            .build();
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testBuildWithoutClientCredentials() throws Exception {
+        new ApnsClientBuilder<>().build();
+    }
+}

--- a/pushy/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
+++ b/pushy/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
@@ -199,7 +199,7 @@ public class ApnsClientTest {
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
             this.client = new ApnsClientBuilder<SimpleApnsPushNotification>()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
-                    .setTrustedServerCertificate(CA_CERTIFICATE)
+                    .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .build();
         }
@@ -233,7 +233,7 @@ public class ApnsClientTest {
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
             managedGroupClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
-                    .setTrustedServerCertificate(CA_CERTIFICATE)
+                    .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .build();
         }
 
@@ -265,7 +265,7 @@ public class ApnsClientTest {
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
             managedGroupClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
-                    .setTrustedServerCertificate(CA_CERTIFICATE)
+                    .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .build();
         }
 
@@ -328,7 +328,7 @@ public class ApnsClientTest {
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
             unconnectedClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
-                    .setTrustedServerCertificate(CA_CERTIFICATE)
+                    .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .build();
         }
@@ -348,7 +348,7 @@ public class ApnsClientTest {
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(UNTRUSTED_CLIENT_KEYSTORE_FILENAME)) {
             untrustedClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
-                    .setTrustedServerCertificate(CA_CERTIFICATE)
+                    .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .build();
         }
@@ -366,7 +366,7 @@ public class ApnsClientTest {
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
             unconnectedClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
-                    .setTrustedServerCertificate(CA_CERTIFICATE)
+                    .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .build();
         }
@@ -551,7 +551,7 @@ public class ApnsClientTest {
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(MULTI_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
             multiTopicClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
-                    .setTrustedServerCertificate(CA_CERTIFICATE)
+                    .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .build();
         }
@@ -581,7 +581,7 @@ public class ApnsClientTest {
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(MULTI_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
             multiTopicClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
-                    .setTrustedServerCertificate(CA_CERTIFICATE)
+                    .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .build();
         }
@@ -640,7 +640,7 @@ public class ApnsClientTest {
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
             unconnectedClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
-                    .setTrustedServerCertificate(CA_CERTIFICATE)
+                    .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .build();
         }
@@ -696,7 +696,7 @@ public class ApnsClientTest {
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
             unconnectedClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
-                    .setTrustedServerCertificate(CA_CERTIFICATE)
+                    .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .build();
         }
@@ -722,7 +722,7 @@ public class ApnsClientTest {
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
             unconnectedClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
-                    .setTrustedServerCertificate(CA_CERTIFICATE)
+                    .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .build();
         }

--- a/pushy/src/test/java/com/relayrides/pushy/apns/ExampleApp.java
+++ b/pushy/src/test/java/com/relayrides/pushy/apns/ExampleApp.java
@@ -25,8 +25,10 @@ public class ExampleApp {
         // certificate and private key to authenticate with the APNs server. The
         // most common way to store the certificate and key is in a
         // password-protected PKCS#12 file.
-        final ApnsClient<SimpleApnsPushNotification> apnsClient = new ApnsClient<>(
-                new File("/path/to/certificate.p12"), "p12-file-password");
+        final ApnsClient<SimpleApnsPushNotification> apnsClient =
+                new ApnsClientBuilder<SimpleApnsPushNotification>()
+                .setClientCredentials(new File("/path/to/certificate.p12"), "p12-file-password")
+                .build();
 
         // Optional: we can listen for metrics by setting a metrics listener.
         apnsClient.setMetricsListener(new NoopMetricsListener());


### PR DESCRIPTION
The number of options for `ApnsClient` instances was growing, and will probably continue to grow in the future. Many of them also only really made sense to set before starting a client, and making them all constructor arguments was going to get crazy really fast. The idea here is to introduce a builder pattern for `ApnsClient` instances. That should clarify which options should be set at client construction time (basically all of them) without resulting in huge constructors.

TODO:

- [x] Finish documenting `ApnsClientBuilder`
- [x] Update README (75f1ced)
- [x] Figure out certificate chain stuff for `setTrustedServerCertificate`