### PR TITLE
No-op name resolvers for proxies (fixes #309)

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -74,6 +74,8 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
+import io.netty.resolver.DefaultAddressResolverGroup;
+import io.netty.resolver.NoopAddressResolverGroup;
 import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.FailedFuture;
 import io.netty.util.concurrent.Future;
@@ -637,6 +639,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
      */
     public void setProxyHandlerFactory(final ProxyHandlerFactory proxyHandlerFactory) {
         this.proxyHandlerFactory = proxyHandlerFactory;
+        this.bootstrap.resolver(proxyHandlerFactory == null ? DefaultAddressResolverGroup.INSTANCE : NoopAddressResolverGroup.INSTANCE);
     }
 
     /**


### PR DESCRIPTION
This fixes an issue where we'd add a proxy handler to the pipeline, but would try to resolve addresses using un-proxied DNS lookups. This caused two classes of problems:

1. In heavily restricted environments, the DNS lookup would fail entirely. See #309.
2. In less restricted environments, the DNS lookup might succeed, but then connections to an already-resolved IP would be blocked by proxies looking for connections to specific domains. See [the mailing list](https://groups.google.com/d/msg/pushy-apns/iYtB7TSi9lU/FKbVE1wdAQAJ) for discussion of this case.

By letting the proxy deal with name resolution, we should avoid both issues.