### PR TITLE
Flexible notification topic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.relayrides</groupId>
     <artifactId>pushy-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.9</version>
+    <version>0.8.1</version>
     <name>Pushy parent</name>
     <description>A Java library for sending push notifications</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.relayrides</groupId>
     <artifactId>pushy-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.8-SNAPSHOT</version>
+    <version>0.9</version>
     <name>Pushy parent</name>
     <description>A Java library for sending push notifications</description>
 

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.relayrides</groupId>
         <artifactId>pushy-parent</artifactId>
-        <version>0.9</version>
+        <version>0.8.1</version>
     </parent>
 
     <dependencies>

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.relayrides</groupId>
         <artifactId>pushy-parent</artifactId>
-        <version>0.8-SNAPSHOT</version>
+        <version>0.9</version>
     </parent>
 
     <dependencies>

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -31,6 +31,7 @@ import java.security.KeyStoreException;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -149,6 +150,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
 
     private ApnsClientMetricsListener metricsListener = new NoopMetricsListener();
     private final AtomicLong nextNotificationId = new AtomicLong(0);
+    private ArrayList<String> identities;
 
     /**
      * The default write timeout, in milliseconds.
@@ -264,6 +266,9 @@ public class ApnsClient<T extends ApnsPushNotification> {
      */
     public ApnsClient(final File p12File, final String password, final EventLoopGroup eventLoopGroup) throws SSLException, FileNotFoundException, IOException {
         this(ApnsClient.getSslContextWithP12File(p12File, password), eventLoopGroup);
+        try (final InputStream p12InputStream = new FileInputStream(p12File)) {
+        	buildIdentifiers(p12InputStream,password);
+        }
     }
 
     /**
@@ -312,9 +317,20 @@ public class ApnsClient<T extends ApnsPushNotification> {
      */
     public ApnsClient(final InputStream p12InputStream, final String password, final EventLoopGroup eventLoopGroup) throws SSLException {
         this(ApnsClient.getSslContextWithP12InputStream(p12InputStream, password), eventLoopGroup);
+        buildIdentifiers(p12InputStream,password);
     }
 
-    /**
+    private void buildIdentifiers(InputStream p12InputStream, String password) {
+    	try {
+			this.identities = P12Util.getIdentitiesForP12File(p12InputStream, password);
+		} catch (KeyStoreException e) {
+			e.printStackTrace();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	/**
      * <p>Creates a new APNs client that will identify itself to the APNs gateway with the given certificate and
      * key.</p>
      *
@@ -372,7 +388,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
 
         try {
             final PrivateKeyEntry privateKeyEntry = P12Util.getFirstPrivateKeyEntryFromP12InputStream(p12InputStream, password);
-
+            
             final Certificate certificate = privateKeyEntry.getCertificate();
 
             if (!(certificate instanceof X509Certificate)) {
@@ -871,6 +887,8 @@ public class ApnsClient<T extends ApnsPushNotification> {
     public Future<PushNotificationResponse<T>> sendNotification(final T notification) {
         final Future<PushNotificationResponse<T>> responseFuture;
         final long notificationId = this.nextNotificationId.getAndIncrement();
+        
+        verifyTopic(notification);
 
         // Instead of synchronizing here, we keep a final reference to the connection ready promise. We can get away
         // with this because we're not changing the state of the connection or its promises. Keeping a reference ensures
@@ -943,7 +961,15 @@ public class ApnsClient<T extends ApnsPushNotification> {
         return responseFuture;
     }
 
-    protected void handlePushNotificationResponse(final PushNotificationResponse<T> response) {
+    private void verifyTopic(T notification) {
+    	if(notification.getTopic() == null 
+    			&& this.identities != null
+    			&& !this.identities.isEmpty()) {
+    		notification.setTopic(this.identities.get(0));
+    	}
+	}
+
+	protected void handlePushNotificationResponse(final PushNotificationResponse<T> response) {
         log.debug("Received response from APNs gateway: {}", response);
 
         // This will always be called from inside the channel's event loop, so we don't have to worry about

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -267,7 +267,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
     public ApnsClient(final File p12File, final String password, final EventLoopGroup eventLoopGroup) throws SSLException, FileNotFoundException, IOException {
         this(ApnsClient.getSslContextWithP12File(p12File, password), eventLoopGroup);
         try (final InputStream p12InputStream = new FileInputStream(p12File)) {
-        	buildIdentifiers(p12InputStream,password);
+        	loadIdentifiers(p12InputStream,password);
         }
     }
 
@@ -317,10 +317,16 @@ public class ApnsClient<T extends ApnsPushNotification> {
      */
     public ApnsClient(final InputStream p12InputStream, final String password, final EventLoopGroup eventLoopGroup) throws SSLException {
         this(ApnsClient.getSslContextWithP12InputStream(p12InputStream, password), eventLoopGroup);
-        buildIdentifiers(p12InputStream,password);
+        loadIdentifiers(p12InputStream,password);
     }
 
-    private void buildIdentifiers(InputStream p12InputStream, String password) {
+    /**
+     * Load identifiers for push notification topic from certificate metadata
+     * 
+     * @param p12InputStream
+     * @param password
+     */
+    private void loadIdentifiers(InputStream p12InputStream, String password) {
     	try {
 			this.identities = P12Util.getIdentitiesForP12File(p12InputStream, password);
 		} catch (KeyStoreException e) {
@@ -961,6 +967,11 @@ public class ApnsClient<T extends ApnsPushNotification> {
         return responseFuture;
     }
 
+    /**
+     * Verifies if there is a topic to send to apple service, if doesn't have, fill it with the first identity found at the certificate
+     * 
+     * @param notification
+     */
     private void verifyTopic(T notification) {
     	if(notification.getTopic() == null 
     			&& this.identities != null

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsPushNotification.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsPushNotification.java
@@ -120,4 +120,6 @@ public interface ApnsPushNotification {
      * @since 0.5
      */
     String getTopic();
+    
+    void setTopic(String topic);
 }

--- a/pushy/src/main/java/com/relayrides/pushy/apns/P12Util.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/P12Util.java
@@ -67,6 +67,15 @@ class P12Util {
         throw new KeyStoreException("Key store did not contain any private key entries.");
     }
     
+    /**
+     * Returns identity based on certificate for usage as the topic of push notification
+     * 
+     * @param p12InputStream
+     * @param password
+     * @return
+     * @throws KeyStoreException
+     * @throws IOException
+     */
     public static ArrayList<String> getIdentitiesForP12File(final InputStream p12InputStream, final String password) throws KeyStoreException, IOException {
     	KeyStore keyStore = loadPCKS12KeyStore(p12InputStream, password);
     	final Enumeration<String> aliases = keyStore.aliases();
@@ -89,6 +98,15 @@ class P12Util {
     	return identifiers;
     }
     
+    /**
+     * Returns the PKCS12 KeyStore instance based on InputStream and password
+     * 
+     * @param p12InputStream
+     * @param password
+     * @return
+     * @throws KeyStoreException
+     * @throws IOException
+     */
     private static KeyStore loadPCKS12KeyStore(final InputStream p12InputStream, final String password) throws KeyStoreException, IOException {
     	final KeyStore keyStore = KeyStore.getInstance("PKCS12");
 

--- a/pushy/src/main/java/com/relayrides/pushy/apns/P12Util.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/P12Util.java
@@ -6,8 +6,11 @@ import java.security.KeyStore;
 import java.security.KeyStore.PrivateKeyEntry;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
 import java.security.UnrecoverableEntryException;
 import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Objects;
 
@@ -17,6 +20,8 @@ import java.util.Objects;
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
  */
 class P12Util {
+	
+	private static final String UDID_KEY = "UID";
 
     /**
      * Returns the first private key entry found in the given keystore. If more than one private key is present, the
@@ -33,23 +38,17 @@ class P12Util {
      */
     public static PrivateKeyEntry getFirstPrivateKeyEntryFromP12InputStream(final InputStream p12InputStream, final String password) throws KeyStoreException, IOException {
         Objects.requireNonNull(password, "Password may be blank, but must not be null.");
-
-        final KeyStore keyStore = KeyStore.getInstance("PKCS12");
-
-        try {
-            keyStore.load(p12InputStream, password.toCharArray());
-        } catch (NoSuchAlgorithmException | CertificateException e) {
-            throw new KeyStoreException(e);
-        }
+        
+        KeyStore keyStore = loadPCKS12KeyStore(p12InputStream, password);
 
         final Enumeration<String> aliases = keyStore.aliases();
         final KeyStore.PasswordProtection passwordProtection = new KeyStore.PasswordProtection(password.toCharArray());
-
+ 
         while (aliases.hasMoreElements()) {
             final String alias = aliases.nextElement();
 
             KeyStore.Entry entry;
-
+            
             try {
                 try {
                     entry = keyStore.getEntry(alias, passwordProtection);
@@ -66,5 +65,38 @@ class P12Util {
         }
 
         throw new KeyStoreException("Key store did not contain any private key entries.");
+    }
+    
+    public static ArrayList<String> getIdentitiesForP12File(final InputStream p12InputStream, final String password) throws KeyStoreException, IOException {
+    	KeyStore keyStore = loadPCKS12KeyStore(p12InputStream, password);
+    	final Enumeration<String> aliases = keyStore.aliases();
+    	ArrayList<String> identifiers = new ArrayList<String>();
+    	while (aliases.hasMoreElements()) {
+            String alias = (String) aliases.nextElement();
+            X509Certificate c = (X509Certificate) keyStore.getCertificate(alias);
+            Principal subject = c.getSubjectDN();
+            String subjectArray[] = subject.toString().split(",");
+            for (String s : subjectArray) {
+                String[] str = s.trim().split("=");
+                String key = str[0];
+                String value = str[1];
+                System.out.println(key + " - " + value);
+                if(UDID_KEY.equals(key))
+                	identifiers.add(value);
+            }
+        }
+    	
+    	return identifiers;
+    }
+    
+    private static KeyStore loadPCKS12KeyStore(final InputStream p12InputStream, final String password) throws KeyStoreException, IOException {
+    	final KeyStore keyStore = KeyStore.getInstance("PKCS12");
+
+        try {
+            keyStore.load(p12InputStream, password.toCharArray());
+        } catch (NoSuchAlgorithmException | CertificateException e) {
+            throw new KeyStoreException(e);
+        }
+        return keyStore;
     }
 }

--- a/pushy/src/main/java/com/relayrides/pushy/apns/util/SimpleApnsPushNotification.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/util/SimpleApnsPushNotification.java
@@ -156,6 +156,9 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         return this.topic;
     }
     
+    /**
+     * Defines the topic to which this push notification should be sent
+     */
     @Override
     public void setTopic(String topic) {
     	this.topic = topic;

--- a/pushy/src/main/java/com/relayrides/pushy/apns/util/SimpleApnsPushNotification.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/util/SimpleApnsPushNotification.java
@@ -38,7 +38,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
     private final String payload;
     private final Date invalidationTime;
     private final DeliveryPriority priority;
-    private final String topic;
+    private String topic;
 
     /**
      * Constructs a new push notification with the given token, topic, and payload. No expiration time is set for the
@@ -55,7 +55,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
      *
      * @see DeliveryPriority#IMMEDIATE
      */
-    public SimpleApnsPushNotification(final String token, final String topic, final String payload) {
+    public SimpleApnsPushNotification(final String token, String topic, final String payload) {
         this(token, topic, payload, null, DeliveryPriority.IMMEDIATE);
     }
 
@@ -154,6 +154,11 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
     @Override
     public String getTopic() {
         return this.topic;
+    }
+    
+    @Override
+    public void setTopic(String topic) {
+    	this.topic = topic;
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
There is now a load from certificate for those that doesn't want to inform the topic but just use the  at ApnsPushNotification, 
-Topic now can be null, when it happens, automatically uses the certificate UID.