### PR TITLE
Auto-flush

### DIFF
--- a/benchmark/src/main/java/com/relayrides/pushy/apns/ApnsClientBenchmark.java
+++ b/benchmark/src/main/java/com/relayrides/pushy/apns/ApnsClientBenchmark.java
@@ -4,8 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.commons.lang3.RandomStringUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -40,9 +38,6 @@ public class ApnsClientBenchmark {
     @Param({"10000"})
     public int notificationCount;
 
-    @Param({"true", "false"})
-    public boolean flushImmediately;
-
     private static final String CA_CERTIFICATE_FILENAME = "/ca.pem";
     private static final String CLIENT_KEYSTORE_FILENAME = "/client.p12";
     private static final String SERVER_CERTIFICATES_FILENAME = "/server_certs.pem";
@@ -64,10 +59,6 @@ public class ApnsClientBenchmark {
                 .setClientCredentials(ApnsClientBenchmark.class.getResourceAsStream(CLIENT_KEYSTORE_FILENAME), KEYSTORE_PASSWORD)
                 .setTrustedServerCertificateChain(ApnsClientBenchmark.class.getResourceAsStream(CA_CERTIFICATE_FILENAME))
                 .setEventLoopGroup(this.eventLoopGroup);
-
-        if (this.flushImmediately) {
-            clientBuilder.setFlushThresholds(0, 0, TimeUnit.SECONDS);
-        }
 
         this.client = clientBuilder.build();
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </licenses>
 
     <properties>
-        <netty.version>4.1.1.Final</netty.version>
+        <netty.version>4.1.2.Final</netty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -182,6 +182,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
 
         this.bootstrap.channel(SocketChannelClassUtil.getSocketChannelClass(this.bootstrap.config().group()));
         this.bootstrap.option(ChannelOption.TCP_NODELAY, true);
+        this.bootstrap.option(ChannelOption.AUTO_FLUSH, true);
         this.bootstrap.handler(new ChannelInitializer<SocketChannel>() {
 
             @Override

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -111,9 +111,6 @@ public class ApnsClient<T extends ApnsPushNotification> {
     private long writeTimeoutMillis = DEFAULT_WRITE_TIMEOUT_MILLIS;
     private Long gracefulShutdownTimeoutMillis;
 
-    private int maxUnflushedNotifications = DEFAULT_MAX_UNFLUSHED_NOTIFICATIONS;
-    private long flushAfterIdleTimeMillis = DEFAULT_FLUSH_AFTER_IDLE_MILLIS;
-
     private volatile ChannelPromise connectionReadyPromise;
     private volatile ChannelPromise reconnectionPromise;
     private long reconnectDelaySeconds = INITIAL_RECONNECT_DELAY_SECONDS;
@@ -129,21 +126,6 @@ public class ApnsClient<T extends ApnsPushNotification> {
      * @since 0.6
      */
     public static final long DEFAULT_WRITE_TIMEOUT_MILLIS = 20_000;
-
-    /**
-     * The default inactivity period after which all unflushed notifications will be sent to the APNs server.
-     *
-     * @since 0.7
-     */
-    public static final long DEFAULT_FLUSH_AFTER_IDLE_MILLIS = 50;
-
-    /**
-     * The default maximum number of notifications that may be buffered by a client before being sent to the APNs
-     * server.
-     *
-     * @since 0.7
-     */
-    public static final int DEFAULT_MAX_UNFLUSHED_NOTIFICATIONS = 128;
 
     /**
      * The hostname for the production APNs gateway.
@@ -225,7 +207,6 @@ public class ApnsClient<T extends ApnsPushNotification> {
                                     .server(false)
                                     .apnsClient(ApnsClient.this)
                                     .authority(((InetSocketAddress) context.channel().remoteAddress()).getHostName())
-                                    .maxUnflushedNotifications(ApnsClient.this.maxUnflushedNotifications)
                                     .encoderEnforceMaxConcurrentStreams(true)
                                     .build();
 
@@ -235,7 +216,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
                                 }
                             }
 
-                            context.pipeline().addLast(new IdleStateHandler(0, ApnsClient.this.flushAfterIdleTimeMillis, PING_IDLE_TIME_MILLIS, TimeUnit.MILLISECONDS));
+                            context.pipeline().addLast(new IdleStateHandler(0, 0, PING_IDLE_TIME_MILLIS, TimeUnit.MILLISECONDS));
                             context.pipeline().addLast(apnsClientHandler);
 
                             // Add this to the end of the queue so any events enqueued by the client handler happen
@@ -335,38 +316,6 @@ public class ApnsClient<T extends ApnsPushNotification> {
      */
     protected void setWriteTimeout(final long writeTimeoutMillis) {
         this.writeTimeoutMillis = writeTimeoutMillis;
-    }
-
-    /**
-     * <p>Sets the thresholds at which this client will flush notifications enqueued for sending to the APNs server. By
-     * default, notifications will be flushed after
-     * {@value com.relayrides.pushy.apns.ApnsClient#DEFAULT_MAX_UNFLUSHED_NOTIFICATIONS} unflushed
-     * notifications have been enqueued or {@value com.relayrides.pushy.apns.ApnsClient#DEFAULT_FLUSH_AFTER_IDLE_MILLIS}
-     * milliseconds of inactivity have elapsed.</p>
-     *
-     * <p>Callers may set both thresholds to zero to flush all notifications immediately, which will reduce latency at
-     * the expense of decreasing efficiency and throughput. Changes to the flushing thresholds will take effect on the
-     * next connection attempt.</p>
-     *
-     * @param maxUnflushedNotifications The maximum number of notifications that may be enqueued before the sending
-     * queue is flushed. Must be positive if {@code maxIdleTimeMillis} is also positive or zero if
-     * {@code maxIdleTimeMillis} is also zero. If zero, notifications are always sent immediately.
-     * @param maxIdleTimeMillis The maximum amount of time, in milliseconds, since the last attempt to send a
-     * notification that may elapse before the sending queue is flushed. Must be positive if
-     * {@code maxUnflushedNotifications} is also positive or zero if {@code maxUnflushedNotifications} is also zero. If
-     * zero, notifications are always sent immediately.
-     *
-     * @since 0.7
-     */
-    protected void setFlushThresholds(final int maxUnflushedNotifications, final long maxIdleTimeMillis) {
-        if ((maxUnflushedNotifications > 0 && maxIdleTimeMillis > 0) || (maxUnflushedNotifications == 0 && maxIdleTimeMillis == 0)) {
-            synchronized (this.bootstrap) {
-                this.maxUnflushedNotifications = maxUnflushedNotifications;
-                this.flushAfterIdleTimeMillis = maxIdleTimeMillis;
-            }
-        } else {
-            throw new IllegalArgumentException("Notification count and idle time must both be positive or both be zero.");
-        }
     }
 
     /**
@@ -610,15 +559,10 @@ public class ApnsClient<T extends ApnsPushNotification> {
      * automatically. Callers may wait for a reconnection attempt to complete by waiting for the {@code Future} returned
      * by the {@link ApnsClient#getReconnectionFuture()} method.</p>
      *
-     * <p>Note that, depending on this client's flushing thresholds, notifications may be enqueued so they may be sent
-     * in bulk to increase efficiency and throughput at the expense of latency.</p>
-     *
      * @param notification the notification to send to the APNs gateway
      *
      * @return a {@code Future} that will complete when the notification has been either accepted or rejected by the
      * APNs gateway
-     *
-     * @see ApnsClient#setFlushThresholds(int, long)
      *
      * @since 0.5
      */

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientBuilder.java
@@ -82,10 +82,6 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
     private Long connectionTimeout;
     private TimeUnit connectionTimeoutUnit;
 
-    private Integer maxUnflushedNotifications;
-    private Long maxIdleTimeBeforeFlush;
-    private TimeUnit maxIdleTimeBeforeFlushUnits;
-
     private Long writeTimeout;
     private TimeUnit writeTimeoutUnit;
 
@@ -311,36 +307,6 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
     }
 
     /**
-     * <p>Sets the thresholds at which this client under construction will flush notifications enqueued for sending to
-     * the APNs server. By default, notifications will be flushed after
-     * {@value com.relayrides.pushy.apns.ApnsClient#DEFAULT_MAX_UNFLUSHED_NOTIFICATIONS} unflushed
-     * notifications have been enqueued or {@value com.relayrides.pushy.apns.ApnsClient#DEFAULT_FLUSH_AFTER_IDLE_MILLIS}
-     * milliseconds of inactivity have elapsed.</p>
-     *
-     * <p>Callers may set both thresholds to zero to flush all notifications immediately, which will reduce latency at
-     * the expense of decreasing efficiency and throughput.</p>
-     *
-     * @param maxUnflushedNotifications The maximum number of notifications that may be enqueued before the sending
-     * queue is flushed. Must be positive if {@code maxIdleTimeMillis} is also positive or zero if
-     * {@code maxIdleTimeMillis} is also zero. If zero, notifications are always sent immediately.
-     * @param maxIdleTime The maximum amount of time since the last attempt to send a notification that may elapse
-     * before the sending queue is flushed. Must be positive if {@code maxUnflushedNotifications} is also positive or
-     * zero if {@code maxUnflushedNotifications} is also zero. If zero, notifications are always sent immediately.
-     * @param maxIdleTimeUnits the time unit for the given maximum idle time
-     *
-     * @return a reference to this builder
-     *
-     * @since 0.8
-     */
-    public ApnsClientBuilder<T> setFlushThresholds(final int maxUnflushedNotifications, final long maxIdleTime, final TimeUnit maxIdleTimeUnits) {
-        this.maxUnflushedNotifications = maxUnflushedNotifications;
-        this.maxIdleTimeBeforeFlush = maxIdleTime;
-        this.maxIdleTimeBeforeFlushUnits = maxIdleTimeUnits;
-
-        return this;
-    }
-
-    /**
      * <p>Sets the write timeout for the client to build. If an attempt to send a notification to the APNs server takes
      * longer than the given timeout, the connection will be closed (and automatically reconnected later). Note that
      * write timeouts refer to the amount of time taken to <em>send</em> a notification to the server, and not the time
@@ -442,10 +408,6 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
 
         if (this.connectionTimeout != null) {
             apnsClient.setConnectionTimeout((int) this.connectionTimeoutUnit.toMillis(this.connectionTimeout));
-        }
-
-        if (this.maxUnflushedNotifications != null) {
-            apnsClient.setFlushThresholds(this.maxUnflushedNotifications, this.maxIdleTimeBeforeFlushUnits.toMillis(this.maxIdleTimeBeforeFlush));
         }
 
         if (this.writeTimeout != null) {

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
@@ -50,7 +50,6 @@ import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2FrameAdapter;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Settings;
-import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.WriteTimeoutException;
 import io.netty.util.AsciiString;
@@ -71,9 +70,6 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
 
     private long nextPingId = new Random().nextLong();
     private ScheduledFuture<?> pingTimeoutFuture;
-
-    private final int maxUnflushedNotifications;
-    private int unflushedNotifications = 0;
 
     private static final int PING_TIMEOUT = 30; // seconds
 
@@ -96,7 +92,6 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
 
         private ApnsClient<S> apnsClient;
         private String authority;
-        private int maxUnflushedNotifications = 0;
 
         public ApnsClientHandlerBuilder<S> apnsClient(final ApnsClient<S> apnsClient) {
             this.apnsClient = apnsClient;
@@ -116,15 +111,6 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
             return this.authority;
         }
 
-        public ApnsClientHandlerBuilder<S> maxUnflushedNotifications(final int maxUnflushedNotifications) {
-            this.maxUnflushedNotifications = maxUnflushedNotifications;
-            return this;
-        }
-
-        public int maxUnflushedNotifications() {
-            return this.maxUnflushedNotifications;
-        }
-
         @Override
         public ApnsClientHandlerBuilder<S> server(final boolean isServer) {
             return super.server(isServer);
@@ -139,7 +125,7 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
         public ApnsClientHandler<S> build(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings) {
             Objects.requireNonNull(this.authority(), "Authority must be set before building an ApnsClientHandler.");
 
-            final ApnsClientHandler<S> handler = new ApnsClientHandler<>(decoder, encoder, initialSettings, this.apnsClient(), this.authority(), this.maxUnflushedNotifications());
+            final ApnsClientHandler<S> handler = new ApnsClientHandler<>(decoder, encoder, initialSettings, this.apnsClient(), this.authority());
             this.frameListener(handler.new ApnsClientHandlerFrameAdapter());
             return handler;
         }
@@ -224,12 +210,11 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
         }
     }
 
-    protected ApnsClientHandler(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings, final ApnsClient<T> apnsClient, final String authority, final int maxUnflushedNotifications) {
+    protected ApnsClientHandler(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings, final ApnsClient<T> apnsClient, final String authority) {
         super(decoder, encoder, initialSettings);
 
         this.apnsClient = apnsClient;
         this.authority = authority;
-        this.maxUnflushedNotifications = maxUnflushedNotifications;
     }
 
     @Override
@@ -284,10 +269,6 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
 
             this.nextStreamId += 2;
 
-            if (++this.unflushedNotifications >= this.maxUnflushedNotifications) {
-                this.flush(context);
-            }
-
             if (this.nextStreamId >= STREAM_ID_RESET_THRESHOLD) {
                 // This is very unlikely, but in the event that we run out of stream IDs (the maximum allowed is
                 // 2^31, per https://httpwg.github.io/specs/rfc7540.html#StreamIdentifiers), we need to open a new
@@ -304,51 +285,36 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
     }
 
     @Override
-    public void flush(final ChannelHandlerContext context) throws Http2Exception {
-        super.flush(context);
-
-        this.unflushedNotifications = 0;
-    }
-
-    @Override
     public void userEventTriggered(final ChannelHandlerContext context, final Object event) throws Exception {
         if (event instanceof IdleStateEvent) {
-            final IdleStateEvent idleStateEvent = (IdleStateEvent) event;
+            assert PING_TIMEOUT < ApnsClient.PING_IDLE_TIME_MILLIS;
 
-            if (IdleState.WRITER_IDLE.equals(idleStateEvent.state())) {
-                if (this.unflushedNotifications > 0) {
-                    this.flush(context);
-                }
-            } else {
-                assert PING_TIMEOUT < ApnsClient.PING_IDLE_TIME_MILLIS;
+            log.trace("Sending ping due to inactivity.");
 
-                log.trace("Sending ping due to inactivity.");
+            final ByteBuf pingDataBuffer = context.alloc().ioBuffer(8, 8);
+            pingDataBuffer.writeLong(this.nextPingId++);
 
-                final ByteBuf pingDataBuffer = context.alloc().ioBuffer(8, 8);
-                pingDataBuffer.writeLong(this.nextPingId++);
+            this.encoder().writePing(context, false, pingDataBuffer, context.newPromise()).addListener(new GenericFutureListener<ChannelFuture>() {
 
-                this.encoder().writePing(context, false, pingDataBuffer, context.newPromise()).addListener(new GenericFutureListener<ChannelFuture>() {
+                @Override
+                public void operationComplete(final ChannelFuture future) throws Exception {
+                    if (future.isSuccess()) {
+                        ApnsClientHandler.this.pingTimeoutFuture = future.channel().eventLoop().schedule(new Runnable() {
 
-                    @Override
-                    public void operationComplete(final ChannelFuture future) throws Exception {
-                        if (future.isSuccess()) {
-                            ApnsClientHandler.this.pingTimeoutFuture = future.channel().eventLoop().schedule(new Runnable() {
-
-                                @Override
-                                public void run() {
-                                    log.debug("Closing channel due to ping timeout.");
-                                    future.channel().close();
-                                }
-                            }, PING_TIMEOUT, TimeUnit.SECONDS);
-                        } else {
-                            log.debug("Failed to write PING frame.", future.cause());
-                            future.channel().close();
-                        }
+                            @Override
+                            public void run() {
+                                log.debug("Closing channel due to ping timeout.");
+                                future.channel().close();
+                            }
+                        }, PING_TIMEOUT, TimeUnit.SECONDS);
+                    } else {
+                        log.debug("Failed to write PING frame.", future.cause());
+                        future.channel().close();
                     }
-                });
+                }
+            });
 
-                this.flush(context);
-            }
+            this.flush(context);
         }
 
         super.userEventTriggered(context, event);

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
@@ -313,8 +313,6 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
                     }
                 }
             });
-
-            this.flush(context);
         }
 
         super.userEventTriggered(context, event);

--- a/pushy/src/main/java/com/relayrides/pushy/apns/MockApnsServer.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/MockApnsServer.java
@@ -9,6 +9,7 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.DefaultChannelGroup;
@@ -59,6 +60,7 @@ public class MockApnsServer {
         }
 
         this.bootstrap.channel(SocketChannelClassUtil.getServerSocketChannelClass(this.bootstrap.config().group()));
+        this.bootstrap.option(ChannelOption.AUTO_FLUSH, true);
         this.bootstrap.childHandler(new ChannelInitializer<SocketChannel>() {
 
             @Override

--- a/pushy/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
+++ b/pushy/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
@@ -259,23 +259,6 @@ public class ApnsClientTest {
     }
 
     @Test
-    public void testSetFlushThresholds() {
-        // We're happy here as long as nothing explodes
-        this.client.setFlushThresholds(0, 0);
-        this.client.setFlushThresholds(1, 1);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testSetFlushThresholdsWithZeroNotificationCount() {
-        this.client.setFlushThresholds(0, 1);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testSetFlushThresholdsWithZeroTimeout() {
-        this.client.setFlushThresholds(1,  0);
-    }
-
-    @Test
     public void testRestartApnsClientWithManagedEventLoopGroup() throws Exception {
         final ApnsClient<SimpleApnsPushNotification> managedGroupClient;
 
@@ -420,23 +403,6 @@ public class ApnsClientTest {
     @Test
     public void testSendNotificationAfterInitialSettings() throws Exception {
         this.client.waitForInitialSettings();
-
-        final String testToken = ApnsClientTest.generateRandomToken();
-
-        this.server.addToken(DEFAULT_TOPIC, testToken, null);
-
-        final SimpleApnsPushNotification pushNotification = new SimpleApnsPushNotification(testToken, DEFAULT_TOPIC, "test-payload");
-        final PushNotificationResponse<SimpleApnsPushNotification> response =
-                this.client.sendNotification(pushNotification).get();
-
-        assertTrue(response.isAccepted());
-    }
-
-    @Test
-    public void testSendNotificationWithImmediateFlush() throws Exception {
-        this.client.disconnect().await();
-        this.client.setFlushThresholds(0, 0);
-        this.client.connect(HOST, PORT).await();
 
         final String testToken = ApnsClientTest.generateRandomToken();
 


### PR DESCRIPTION
This moves to using Netty's nascent auto-flush feature instead of flushing explicitly. The main benefit here is simplicity. Depends on ~~https://github.com/netty/netty/pull/5395~~ ~~https://github.com/netty/netty/pull/5445~~ ~~https://github.com/netty/netty/pull/5395~~ https://github.com/netty/netty/pull/5716, which is currently scheduled for Netty ~~4.1.2~~ ~~4.1.3~~ ~~4.1.4~~ oh who even knows any more.

TODO:
- [ ] Wait for Netty ~~4.1.2~~ ~~4.1.3~~ ~~4.1.4~~
- [x] Make sure the benchmarks still look good after this change
