### PR TITLE
Treat upstream internal server errors as temporary failures (closes #336)

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -705,6 +705,14 @@ public class ApnsClient<T extends ApnsPushNotification> {
         this.responsePromises.remove(response.getPushNotification()).setSuccess(response);
     }
 
+    protected void handleServerError(final T pushNotification, final String message) {
+        log.warn("APNs server reported an internal error when sending {}.", pushNotification);
+
+        // This will always be called from inside the channel's event loop, so we don't have to worry about
+        // synchronization.
+        this.responsePromises.remove(pushNotification).tryFailure(new ApnsServerException(message));
+    }
+
     /**
      * <p>Gracefully disconnects from the APNs gateway. The disconnection process will wait until notifications that
      * have been sent to the APNs server have been either accepted or rejected. Note that some notifications passed to

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
@@ -171,11 +171,17 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
                 final Http2Headers headers = ApnsClientHandler.this.headersByStreamId.remove(streamId);
                 final T pushNotification = ApnsClientHandler.this.pushNotificationsByStreamId.remove(streamId);
 
-                final boolean success = HttpResponseStatus.OK.equals(HttpResponseStatus.parseLine(headers.status()));
-                final ErrorResponse errorResponse = gson.fromJson(data.toString(StandardCharsets.UTF_8), ErrorResponse.class);
+                final HttpResponseStatus status = HttpResponseStatus.parseLine(headers.status());
+                final String responseBody = data.toString(StandardCharsets.UTF_8);
 
-                ApnsClientHandler.this.apnsClient.handlePushNotificationResponse(new SimplePushNotificationResponse<>(
-                        pushNotification, success, errorResponse.getReason(), errorResponse.getTimestamp()));
+                if (HttpResponseStatus.INTERNAL_SERVER_ERROR.equals(status)) {
+                    ApnsClientHandler.this.apnsClient.handleServerError(pushNotification, responseBody);
+                } else {
+                    final ErrorResponse errorResponse = gson.fromJson(responseBody, ErrorResponse.class);
+
+                    ApnsClientHandler.this.apnsClient.handlePushNotificationResponse(
+                            new SimplePushNotificationResponse<>(pushNotification, HttpResponseStatus.OK.equals(status), errorResponse.getReason(), errorResponse.getTimestamp()));
+                }
             } else {
                 log.error("Gateway sent a DATA frame that was not the end of a stream.");
             }
@@ -192,17 +198,22 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
         public void onHeadersRead(final ChannelHandlerContext context, final int streamId, final Http2Headers headers, final int padding, final boolean endOfStream) throws Http2Exception {
             log.trace("Received headers from APNs gateway on stream {}: {}", streamId, headers);
 
-            final boolean success = HttpResponseStatus.OK.equals(HttpResponseStatus.parseLine(headers.status()));
-
             if (endOfStream) {
+                final HttpResponseStatus status = HttpResponseStatus.parseLine(headers.status());
+                final boolean success = HttpResponseStatus.OK.equals(status);
+
                 if (!success) {
-                    log.error("Gateway sent an end-of-stream HEADERS frame for an unsuccessful notification.");
+                    log.warn("Gateway sent an end-of-stream HEADERS frame for an unsuccessful notification.");
                 }
 
                 final T pushNotification = ApnsClientHandler.this.pushNotificationsByStreamId.remove(streamId);
 
-                ApnsClientHandler.this.apnsClient.handlePushNotificationResponse(new SimplePushNotificationResponse<>(
-                        pushNotification, success, null, null));
+                if (HttpResponseStatus.INTERNAL_SERVER_ERROR.equals(status)) {
+                    ApnsClientHandler.this.apnsClient.handleServerError(pushNotification, null);
+                } else {
+                    ApnsClientHandler.this.apnsClient.handlePushNotificationResponse(
+                            new SimplePushNotificationResponse<>(pushNotification, success, null, null));
+                }
             } else {
                 ApnsClientHandler.this.headersByStreamId.put(streamId, headers);
             }

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsServerException.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsServerException.java
@@ -1,0 +1,21 @@
+package com.relayrides.pushy.apns;
+
+/**
+ * An exception that indicates that a push notification could not be sent due to an upstream server error. Server errors
+ * should be considered temporary failures, and callers should attempt to send the notification again later.
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ *
+ */
+public class ApnsServerException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new APNs server exception.
+     *
+     * @param message a message from the server (if any) explaining the error; may be {@code null}
+     */
+    public ApnsServerException(final String message) {
+        super(message);
+    }
+}

--- a/pushy/src/main/java/com/relayrides/pushy/apns/MockApnsServer.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/MockApnsServer.java
@@ -47,6 +47,8 @@ public class MockApnsServer {
 
     private ChannelGroup allChannels;
 
+    private boolean emulateInternalErrors = false;
+
     protected MockApnsServer(final SslContext sslContext, final EventLoopGroup eventLoopGroup) {
         this.bootstrap = new ServerBootstrap();
 
@@ -140,6 +142,14 @@ public class MockApnsServer {
         final Map<String, Date> tokensWithinTopic = this.tokenExpirationsByTopic.get(topic);
 
         return tokensWithinTopic != null ? tokensWithinTopic.get(token) : null;
+    }
+
+    protected void setEmulateInternalErrors(final boolean emulateInternalErrors) {
+        this.emulateInternalErrors = emulateInternalErrors;
+    }
+
+    protected boolean shouldEmulateInternalErrors() {
+        return this.emulateInternalErrors;
     }
 
     /**


### PR DESCRIPTION
Prior to this change, we were treating upstream internal server errors as permanent rejections. This change introduces a special case for internal server errors so that they'll be treated as temporary write failures (i.e. write futures will fail with an `ApnsServerException`) instead of permanent rejections (i.e. a successful future with a `PushNotificationResponse` that reports `isRejected` as `true`).