### PR TITLE
Make `ApnsClient#sendNotification` generic (closes #342)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ Before you can get started with Pushy, you'll need to do some provisioning work 
 Once you've registered your app and have the requisite certificates, the first thing you'll need to do to start sending push notifications with Pushy is to create an [`ApnsClient`](http://relayrides.github.io/pushy/apidocs/0.7/com/relayrides/pushy/apns/ApnsClient.html). Clients need a certificate and private key to authenticate with the APNs server. The most common way to store the certificate and key is in a password-protected PKCS#12 file (you'll wind up with a password-protected .p12 file if you follow Apple's instructions at the time of this writing):
 
 ```java
-final ApnsClient<SimpleApnsPushNotification> apnsClient =
-    new ApnsClientBuilder<SimpleApnsPushNotification>()
+final ApnsClient apnsClient = new ApnsClientBuilder()
         .setClientCredentials(new File("/path/to/certificate.p12"), "p12-file-password")
         .build();
 ```
@@ -163,8 +162,7 @@ If you know exactly which version of Java you'll be running, you can just add th
 Pushy includes an interface for monitoring metrics that provide insight into clients' behavior and performance. You can write your own implementation of the `ApnsClientMetricsListener` interface to record and report metrics. We also provide a [https://github.com/relayrides/pushy/tree/master/dropwizard-metrics-listener](metrics listener that uses the Dropwizard Metrics library) as a separate module. To begin receiving metrics, set a listener when building a new client:
 
 ```java
-final ApnsClient<SimpleApnsPushNotification> apnsClient =
-    new ApnsClientBuilder<SimpleApnsPushNotification>()
+final ApnsClient apnsClient = new ApnsClientBuilder()
         .setClientCredentials(new File("/path/to/certificate.p12"), "p12-file-password")
         .setMetricsListener(new MyCustomMetricsListener())
         .build();
@@ -179,8 +177,7 @@ If you need to use a proxy for outbound connections, you may specify a [`ProxyHa
 An example:
 
 ```java
-final ApnsClient<SimpleApnsPushNotification> apnsClient =
-    new ApnsClientBuilder<SimpleApnsPushNotification>()
+final ApnsClient apnsClient = new ApnsClientBuilder()
         .setClientCredentials(new File("/path/to/certificate.p12"), "p12-file-password")
         .setProxyHandlerFactory(new Socks5ProxyHandlerFactory(
             new InetSocketAddress("my.proxy.com", 1080), "username", "password"))

--- a/benchmark/src/main/java/com/relayrides/pushy/apns/ApnsClientBenchmark.java
+++ b/benchmark/src/main/java/com/relayrides/pushy/apns/ApnsClientBenchmark.java
@@ -32,7 +32,7 @@ public class ApnsClientBenchmark {
 
     private EventLoopGroup eventLoopGroup;
 
-    private ApnsClient<SimpleApnsPushNotification> client;
+    private ApnsClient client;
     private MockApnsServer server;
 
     private List<SimpleApnsPushNotification> pushNotifications;
@@ -60,7 +60,7 @@ public class ApnsClientBenchmark {
     public void setUp() throws Exception {
         this.eventLoopGroup = new NioEventLoopGroup(2);
 
-        final ApnsClientBuilder<SimpleApnsPushNotification> clientBuilder = new ApnsClientBuilder<SimpleApnsPushNotification>()
+        final ApnsClientBuilder clientBuilder = new ApnsClientBuilder()
                 .setClientCredentials(ApnsClientBenchmark.class.getResourceAsStream(CLIENT_KEYSTORE_FILENAME), KEYSTORE_PASSWORD)
                 .setTrustedServerCertificateChain(ApnsClientBenchmark.class.getResourceAsStream(CA_CERTIFICATE_FILENAME))
                 .setEventLoopGroup(this.eventLoopGroup);

--- a/dropwizard-metrics-listener/src/main/java/com/relayrides/pushy/apns/metrics/dropwizard/DropwizardApnsClientMetricsListener.java
+++ b/dropwizard-metrics-listener/src/main/java/com/relayrides/pushy/apns/metrics/dropwizard/DropwizardApnsClientMetricsListener.java
@@ -31,7 +31,6 @@ import com.codahale.metrics.MetricSet;
 import com.codahale.metrics.Timer;
 import com.relayrides.pushy.apns.ApnsClient;
 import com.relayrides.pushy.apns.ApnsClientMetricsListener;
-import com.relayrides.pushy.apns.ApnsPushNotification;
 
 /**
  * <p>An {@link com.relayrides.pushy.apns.ApnsClientMetricsListener} implementation that gathers and reports metrics
@@ -188,7 +187,7 @@ public class DropwizardApnsClientMetricsListener implements ApnsClientMetricsLis
      * @param notificationId an opaque, unique identifier for the notification that could not be written
      */
     @Override
-    public void handleWriteFailure(final ApnsClient<? extends ApnsPushNotification> apnsClient, final long notificationId) {
+    public void handleWriteFailure(final ApnsClient apnsClient, final long notificationId) {
         this.stopTimerForNotification(notificationId);
         this.writeFailures.mark();
     }
@@ -201,7 +200,7 @@ public class DropwizardApnsClientMetricsListener implements ApnsClientMetricsLis
      * @param notificationId an opaque, unique identifier for the notification that was sent
      */
     @Override
-    public void handleNotificationSent(final ApnsClient<? extends ApnsPushNotification> apnsClient, final long notificationId) {
+    public void handleNotificationSent(final ApnsClient apnsClient, final long notificationId) {
         this.sentNotifications.mark();
         this.notificationTimerContexts.put(notificationId, this.notificationTimer.time());
     }
@@ -214,7 +213,7 @@ public class DropwizardApnsClientMetricsListener implements ApnsClientMetricsLis
      * @param notificationId an opaque, unique identifier for the notification that was accepted
      */
     @Override
-    public void handleNotificationAccepted(final ApnsClient<? extends ApnsPushNotification> apnsClient, final long notificationId) {
+    public void handleNotificationAccepted(final ApnsClient apnsClient, final long notificationId) {
         this.stopTimerForNotification(notificationId);
         this.acceptedNotifications.mark();
     }
@@ -227,7 +226,7 @@ public class DropwizardApnsClientMetricsListener implements ApnsClientMetricsLis
      * @param notificationId an opaque, unique identifier for the notification that was rejected
      */
     @Override
-    public void handleNotificationRejected(final ApnsClient<? extends ApnsPushNotification> apnsClient, final long notificationId) {
+    public void handleNotificationRejected(final ApnsClient apnsClient, final long notificationId) {
         this.stopTimerForNotification(notificationId);
         this.rejectedNotifications.mark();
     }
@@ -247,7 +246,7 @@ public class DropwizardApnsClientMetricsListener implements ApnsClientMetricsLis
      * {@code DropwizardApnsClientMetricsListener} instances, which should always be used for exactly one client
      */
     @Override
-    public void handleConnectionAttemptStarted(final ApnsClient<? extends ApnsPushNotification> apnsClient) {
+    public void handleConnectionAttemptStarted(final ApnsClient apnsClient) {
         this.connectionTimerContext = this.connectionTimer.time();
         this.connected = false;
     }
@@ -260,7 +259,7 @@ public class DropwizardApnsClientMetricsListener implements ApnsClientMetricsLis
      * {@code DropwizardApnsClientMetricsListener} instances, which should always be used for exactly one client
      */
     @Override
-    public void handleConnectionAttemptSucceeded(final ApnsClient<? extends ApnsPushNotification> apnsClient) {
+    public void handleConnectionAttemptSucceeded(final ApnsClient apnsClient) {
         this.stopConnectionTimer();
         this.connected = true;
     }
@@ -272,7 +271,7 @@ public class DropwizardApnsClientMetricsListener implements ApnsClientMetricsLis
      * {@code DropwizardApnsClientMetricsListener} instances, which should always be used for exactly one client
      */
     @Override
-    public void handleConnectionAttemptFailed(final ApnsClient<? extends ApnsPushNotification> apnsClient) {
+    public void handleConnectionAttemptFailed(final ApnsClient apnsClient) {
         this.stopConnectionTimer();
         this.connectionFailures.mark();
         this.connected = false;

--- a/dropwizard-metrics-listener/src/test/java/com/relayrides/pushy/apns/metrics/dropwizard/ExampleApp.java
+++ b/dropwizard-metrics-listener/src/test/java/com/relayrides/pushy/apns/metrics/dropwizard/ExampleApp.java
@@ -5,7 +5,6 @@ import java.io.File;
 import com.codahale.metrics.MetricRegistry;
 import com.relayrides.pushy.apns.ApnsClient;
 import com.relayrides.pushy.apns.ApnsClientBuilder;
-import com.relayrides.pushy.apns.util.SimpleApnsPushNotification;
 
 public class ExampleApp {
 
@@ -17,8 +16,7 @@ public class ExampleApp {
         final DropwizardApnsClientMetricsListener listener =
                 new DropwizardApnsClientMetricsListener();
 
-        final ApnsClient<SimpleApnsPushNotification> apnsClient =
-                new ApnsClientBuilder<SimpleApnsPushNotification>()
+        final ApnsClient apnsClient = new ApnsClientBuilder()
                 .setClientCredentials(new File("/path/to/certificate.p12"), "p12-file-password")
                 .setMetricsListener(listener)
                 .build();

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientBuilder.java
@@ -61,10 +61,8 @@ import io.netty.handler.ssl.SupportedCipherSuiteFilter;
  * the next.</p>
  *
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
- *
- * @param <T> the type of notification handled by client instances created by this builder
  */
-public class ApnsClientBuilder<T extends ApnsPushNotification> {
+public class ApnsClientBuilder {
     private X509Certificate clientCertificate;
     private PrivateKey privateKey;
     private String privateKeyPassword;
@@ -112,7 +110,7 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
      *
      * @since 0.8
      */
-    public ApnsClientBuilder<T> setClientCredentials(final File p12File, final String p12Password) throws SSLException, IOException {
+    public ApnsClientBuilder setClientCredentials(final File p12File, final String p12Password) throws SSLException, IOException {
         try (final InputStream p12InputStream = new FileInputStream(p12File)) {
             return this.setClientCredentials(p12InputStream, p12Password);
         }
@@ -135,7 +133,7 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
      *
      * @since 0.8
      */
-    public ApnsClientBuilder<T> setClientCredentials(final InputStream p12InputStream, final String p12Password) throws SSLException, IOException {
+    public ApnsClientBuilder setClientCredentials(final InputStream p12InputStream, final String p12Password) throws SSLException, IOException {
         final X509Certificate x509Certificate;
         final PrivateKey privateKey;
 
@@ -169,7 +167,7 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
      *
      * @since 0.8
      */
-    public ApnsClientBuilder<T> setClientCredentials(final X509Certificate clientCertificate, final PrivateKey privateKey, final String privateKeyPassword) {
+    public ApnsClientBuilder setClientCredentials(final X509Certificate clientCertificate, final PrivateKey privateKey, final String privateKeyPassword) {
         this.clientCertificate = clientCertificate;
         this.privateKey = privateKey;
         this.privateKeyPassword = privateKeyPassword;
@@ -189,7 +187,7 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
      *
      * @return a reference to this builder
      */
-    public ApnsClientBuilder<T> setTrustedServerCertificateChain(final File certificatePemFile) {
+    public ApnsClientBuilder setTrustedServerCertificateChain(final File certificatePemFile) {
         this.trustedServerCertificatePemFile = certificatePemFile;
         this.trustedServerCertificateInputStream = null;
         this.trustedServerCertificates = null;
@@ -209,7 +207,7 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
      *
      * @return a reference to this builder
      */
-    public ApnsClientBuilder<T> setTrustedServerCertificateChain(final InputStream certificateInputStream) {
+    public ApnsClientBuilder setTrustedServerCertificateChain(final InputStream certificateInputStream) {
         this.trustedServerCertificatePemFile = null;
         this.trustedServerCertificateInputStream = certificateInputStream;
         this.trustedServerCertificates = null;
@@ -229,7 +227,7 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
      *
      * @return a reference to this builder
      */
-    public ApnsClientBuilder<T> setTrustedServerCertificateChain(final X509Certificate... certificates) {
+    public ApnsClientBuilder setTrustedServerCertificateChain(final X509Certificate... certificates) {
         this.trustedServerCertificatePemFile = null;
         this.trustedServerCertificateInputStream = null;
         this.trustedServerCertificates = certificates;
@@ -254,7 +252,7 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
      *
      * @since 0.8
      */
-    public ApnsClientBuilder<T> setEventLoopGroup(final EventLoopGroup eventLoopGroup) {
+    public ApnsClientBuilder setEventLoopGroup(final EventLoopGroup eventLoopGroup) {
         this.eventLoopGroup = eventLoopGroup;
         return this;
     }
@@ -270,7 +268,7 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
      *
      * @since 0.8
      */
-    public ApnsClientBuilder<T> setMetricsListener(final ApnsClientMetricsListener metricsListener) {
+    public ApnsClientBuilder setMetricsListener(final ApnsClientMetricsListener metricsListener) {
         this.metricsListener = metricsListener;
         return this;
     }
@@ -287,7 +285,7 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
      *
      * @since 0.8
      */
-    public ApnsClientBuilder<T> setProxyHandlerFactory(final ProxyHandlerFactory proxyHandlerFactory) {
+    public ApnsClientBuilder setProxyHandlerFactory(final ProxyHandlerFactory proxyHandlerFactory) {
         this.proxyHandlerFactory = proxyHandlerFactory;
         return this;
     }
@@ -303,7 +301,7 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
      *
      * @since 0.8
      */
-    public ApnsClientBuilder<T> setConnectionTimeout(final long connectionTimeout, final TimeUnit timeoutUnit) {
+    public ApnsClientBuilder setConnectionTimeout(final long connectionTimeout, final TimeUnit timeoutUnit) {
         this.connectionTimeout = connectionTimeout;
         this.connectionTimeoutUnit = timeoutUnit;
 
@@ -332,7 +330,7 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
      *
      * @since 0.8
      */
-    public ApnsClientBuilder<T> setFlushThresholds(final int maxUnflushedNotifications, final long maxIdleTime, final TimeUnit maxIdleTimeUnits) {
+    public ApnsClientBuilder setFlushThresholds(final int maxUnflushedNotifications, final long maxIdleTime, final TimeUnit maxIdleTimeUnits) {
         this.maxUnflushedNotifications = maxUnflushedNotifications;
         this.maxIdleTimeBeforeFlush = maxIdleTime;
         this.maxIdleTimeBeforeFlushUnits = maxIdleTimeUnits;
@@ -356,7 +354,7 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
      *
      * @since 0.8
      */
-    public ApnsClientBuilder<T> setWriteTimeout(final long writeTimeout, final TimeUnit timeoutUnit) {
+    public ApnsClientBuilder setWriteTimeout(final long writeTimeout, final TimeUnit timeoutUnit) {
         this.writeTimeout = writeTimeout;
         this.writeTimeoutUnit = timeoutUnit;
 
@@ -377,7 +375,7 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
      *
      * @since 0.8
      */
-    public ApnsClientBuilder<T> setGracefulShutdownTimeout(final long gracefulShutdownTimeout, final TimeUnit timeoutUnit) {
+    public ApnsClientBuilder setGracefulShutdownTimeout(final long gracefulShutdownTimeout, final TimeUnit timeoutUnit) {
         this.gracefulShutdownTimeout = gracefulShutdownTimeout;
         this.gracefulShutdownTimeoutUnit = timeoutUnit;
 
@@ -393,7 +391,7 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
      *
      * @since 0.8
      */
-    public ApnsClient<T> build() throws SSLException {
+    public ApnsClient build() throws SSLException {
         Objects.requireNonNull(this.clientCertificate, "Client certificate must be set before building an APNs client.");
         Objects.requireNonNull(this.privateKey, "Private key must be set before building an APNs client.");
 
@@ -435,7 +433,7 @@ public class ApnsClientBuilder<T extends ApnsPushNotification> {
             sslContext = sslContextBuilder.build();
         }
 
-        final ApnsClient<T> apnsClient = new ApnsClient<T>(sslContext, this.eventLoopGroup);
+        final ApnsClient apnsClient = new ApnsClient(sslContext, this.eventLoopGroup);
 
         apnsClient.setMetricsListener(this.metricsListener);
         apnsClient.setProxyHandlerFactory(this.proxyHandlerFactory);

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
@@ -58,15 +58,15 @@ import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.PromiseCombiner;
 import io.netty.util.concurrent.ScheduledFuture;
 
-class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionHandler {
+class ApnsClientHandler extends Http2ConnectionHandler {
 
     private final AtomicBoolean receivedInitialSettings = new AtomicBoolean(false);
     private long nextStreamId = 1;
 
-    private final Map<Integer, T> pushNotificationsByStreamId = new HashMap<>();
+    private final Map<Integer, ApnsPushNotification> pushNotificationsByStreamId = new HashMap<>();
     private final Map<Integer, Http2Headers> headersByStreamId = new HashMap<>();
 
-    private final ApnsClient<T> apnsClient;
+    private final ApnsClient apnsClient;
     private final String authority;
 
     private long nextPingId = new Random().nextLong();
@@ -92,22 +92,22 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
 
     private static final Logger log = LoggerFactory.getLogger(ApnsClientHandler.class);
 
-    public static class ApnsClientHandlerBuilder<S extends ApnsPushNotification> extends AbstractHttp2ConnectionHandlerBuilder<ApnsClientHandler<S>, ApnsClientHandlerBuilder<S>> {
+    public static class ApnsClientHandlerBuilder extends AbstractHttp2ConnectionHandlerBuilder<ApnsClientHandler, ApnsClientHandlerBuilder> {
 
-        private ApnsClient<S> apnsClient;
+        private ApnsClient apnsClient;
         private String authority;
         private int maxUnflushedNotifications = 0;
 
-        public ApnsClientHandlerBuilder<S> apnsClient(final ApnsClient<S> apnsClient) {
+        public ApnsClientHandlerBuilder apnsClient(final ApnsClient apnsClient) {
             this.apnsClient = apnsClient;
             return this;
         }
 
-        public ApnsClient<S> apnsClient() {
+        public ApnsClient apnsClient() {
             return this.apnsClient;
         }
 
-        public ApnsClientHandlerBuilder<S> authority(final String authority) {
+        public ApnsClientHandlerBuilder authority(final String authority) {
             this.authority = authority;
             return this;
         }
@@ -116,7 +116,7 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
             return this.authority;
         }
 
-        public ApnsClientHandlerBuilder<S> maxUnflushedNotifications(final int maxUnflushedNotifications) {
+        public ApnsClientHandlerBuilder maxUnflushedNotifications(final int maxUnflushedNotifications) {
             this.maxUnflushedNotifications = maxUnflushedNotifications;
             return this;
         }
@@ -126,26 +126,26 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
         }
 
         @Override
-        public ApnsClientHandlerBuilder<S> server(final boolean isServer) {
+        public ApnsClientHandlerBuilder server(final boolean isServer) {
             return super.server(isServer);
         }
 
         @Override
-        public ApnsClientHandlerBuilder<S> encoderEnforceMaxConcurrentStreams(final boolean enforceMaxConcurrentStreams) {
+        public ApnsClientHandlerBuilder encoderEnforceMaxConcurrentStreams(final boolean enforceMaxConcurrentStreams) {
             return super.encoderEnforceMaxConcurrentStreams(enforceMaxConcurrentStreams);
         }
 
         @Override
-        public ApnsClientHandler<S> build(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings) {
+        public ApnsClientHandler build(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings) {
             Objects.requireNonNull(this.authority(), "Authority must be set before building an ApnsClientHandler.");
 
-            final ApnsClientHandler<S> handler = new ApnsClientHandler<>(decoder, encoder, initialSettings, this.apnsClient(), this.authority(), this.maxUnflushedNotifications());
+            final ApnsClientHandler handler = new ApnsClientHandler(decoder, encoder, initialSettings, this.apnsClient(), this.authority(), this.maxUnflushedNotifications());
             this.frameListener(handler.new ApnsClientHandlerFrameAdapter());
             return handler;
         }
 
         @Override
-        public ApnsClientHandler<S> build() {
+        public ApnsClientHandler build() {
             return super.build();
         }
     }
@@ -169,7 +169,7 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
 
             if (endOfStream) {
                 final Http2Headers headers = ApnsClientHandler.this.headersByStreamId.remove(streamId);
-                final T pushNotification = ApnsClientHandler.this.pushNotificationsByStreamId.remove(streamId);
+                final ApnsPushNotification pushNotification = ApnsClientHandler.this.pushNotificationsByStreamId.remove(streamId);
 
                 final HttpResponseStatus status = HttpResponseStatus.parseLine(headers.status());
                 final String responseBody = data.toString(StandardCharsets.UTF_8);
@@ -180,7 +180,7 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
                     final ErrorResponse errorResponse = gson.fromJson(responseBody, ErrorResponse.class);
 
                     ApnsClientHandler.this.apnsClient.handlePushNotificationResponse(
-                            new SimplePushNotificationResponse<>(pushNotification, HttpResponseStatus.OK.equals(status), errorResponse.getReason(), errorResponse.getTimestamp()));
+                            new SimplePushNotificationResponse<ApnsPushNotification>(pushNotification, HttpResponseStatus.OK.equals(status), errorResponse.getReason(), errorResponse.getTimestamp()));
                 }
             } else {
                 log.error("Gateway sent a DATA frame that was not the end of a stream.");
@@ -206,13 +206,13 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
                     log.warn("Gateway sent an end-of-stream HEADERS frame for an unsuccessful notification.");
                 }
 
-                final T pushNotification = ApnsClientHandler.this.pushNotificationsByStreamId.remove(streamId);
+                final ApnsPushNotification pushNotification = ApnsClientHandler.this.pushNotificationsByStreamId.remove(streamId);
 
                 if (HttpResponseStatus.INTERNAL_SERVER_ERROR.equals(status)) {
                     ApnsClientHandler.this.apnsClient.handleServerError(pushNotification, null);
                 } else {
                     ApnsClientHandler.this.apnsClient.handlePushNotificationResponse(
-                            new SimplePushNotificationResponse<>(pushNotification, success, null, null));
+                            new SimplePushNotificationResponse<ApnsPushNotification>(pushNotification, success, null, null));
                 }
             } else {
                 ApnsClientHandler.this.headersByStreamId.put(streamId, headers);
@@ -235,7 +235,7 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
         }
     }
 
-    protected ApnsClientHandler(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings, final ApnsClient<T> apnsClient, final String authority, final int maxUnflushedNotifications) {
+    protected ApnsClientHandler(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings, final ApnsClient apnsClient, final String authority, final int maxUnflushedNotifications) {
         super(decoder, encoder, initialSettings);
 
         this.apnsClient = apnsClient;
@@ -244,11 +244,10 @@ class ApnsClientHandler<T extends ApnsPushNotification> extends Http2ConnectionH
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void write(final ChannelHandlerContext context, final Object message, final ChannelPromise writePromise) throws Http2Exception {
         try {
             // We'll catch class cast issues gracefully
-            final T pushNotification = (T) message;
+            final ApnsPushNotification pushNotification = (ApnsPushNotification) message;
 
             final int streamId = (int) this.nextStreamId;
 

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientMetricsListener.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientMetricsListener.java
@@ -48,7 +48,7 @@ public interface ApnsClientMetricsListener {
      *
      * @since 0.6
      */
-    void handleWriteFailure(ApnsClient<? extends ApnsPushNotification> apnsClient, long notificationId);
+    void handleWriteFailure(ApnsClient apnsClient, long notificationId);
 
     /**
      * Indicates that a notification was sent to the APNs server. Note that a sent notification may still be either
@@ -61,7 +61,7 @@ public interface ApnsClientMetricsListener {
      *
      * @since 0.6
      */
-    void handleNotificationSent(ApnsClient<? extends ApnsPushNotification> apnsClient, long notificationId);
+    void handleNotificationSent(ApnsClient apnsClient, long notificationId);
 
     /**
      * Indicates that a notification that was previously sent to an APNs server was accepted by the server.
@@ -72,7 +72,7 @@ public interface ApnsClientMetricsListener {
      *
      * @since 0.6
      */
-    void handleNotificationAccepted(ApnsClient<? extends ApnsPushNotification> apnsClient, long notificationId);
+    void handleNotificationAccepted(ApnsClient apnsClient, long notificationId);
 
     /**
      * Indicates that a notification that was previously sent to an APNs server was rejected by the server.
@@ -83,7 +83,7 @@ public interface ApnsClientMetricsListener {
      *
      * @since 0.6
      */
-    void handleNotificationRejected(ApnsClient<? extends ApnsPushNotification> apnsClient, long notificationId);
+    void handleNotificationRejected(ApnsClient apnsClient, long notificationId);
 
     /**
      * Indicates that the client has started an attempt to connect to an APNs server. This event will always be followed
@@ -94,7 +94,7 @@ public interface ApnsClientMetricsListener {
      *
      * @since 0.6
      */
-    void handleConnectionAttemptStarted(ApnsClient<? extends ApnsPushNotification> apnsClient);
+    void handleConnectionAttemptStarted(ApnsClient apnsClient);
 
     /**
      * Indicates that a previously-started connection attempt completed successfully.
@@ -103,7 +103,7 @@ public interface ApnsClientMetricsListener {
      *
      * @since 0.6
      */
-    void handleConnectionAttemptSucceeded(ApnsClient<? extends ApnsPushNotification> apnsClient);
+    void handleConnectionAttemptSucceeded(ApnsClient apnsClient);
 
     /**
      * Indicates that a previously-started connection attempt failed.
@@ -112,5 +112,5 @@ public interface ApnsClientMetricsListener {
      *
      * @since 0.6
      */
-    void handleConnectionAttemptFailed(ApnsClient<? extends ApnsPushNotification> apnsClient);
+    void handleConnectionAttemptFailed(ApnsClient apnsClient);
 }

--- a/pushy/src/main/java/com/relayrides/pushy/apns/NoopMetricsListener.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/NoopMetricsListener.java
@@ -8,30 +8,30 @@ package com.relayrides.pushy.apns;
 class NoopMetricsListener implements ApnsClientMetricsListener {
 
     @Override
-    public void handleWriteFailure(final ApnsClient<? extends ApnsPushNotification> apnsClient, final long notificationId) {
+    public void handleWriteFailure(final ApnsClient apnsClient, final long notificationId) {
     }
 
     @Override
-    public void handleNotificationSent(final ApnsClient<? extends ApnsPushNotification> apnsClient, final long notificationId) {
+    public void handleNotificationSent(final ApnsClient apnsClient, final long notificationId) {
     }
 
     @Override
-    public void handleNotificationAccepted(final ApnsClient<? extends ApnsPushNotification> apnsClient, final long notificationId) {
+    public void handleNotificationAccepted(final ApnsClient apnsClient, final long notificationId) {
     }
 
     @Override
-    public void handleNotificationRejected(final ApnsClient<? extends ApnsPushNotification> apnsClient, final long notificationId) {
+    public void handleNotificationRejected(final ApnsClient apnsClient, final long notificationId) {
     }
 
     @Override
-    public void handleConnectionAttemptStarted(final ApnsClient<? extends ApnsPushNotification> apnsClient) {
+    public void handleConnectionAttemptStarted(final ApnsClient apnsClient) {
     }
 
     @Override
-    public void handleConnectionAttemptSucceeded(final ApnsClient<? extends ApnsPushNotification> apnsClient) {
+    public void handleConnectionAttemptSucceeded(final ApnsClient apnsClient) {
     }
 
     @Override
-    public void handleConnectionAttemptFailed(final ApnsClient<? extends ApnsPushNotification> apnsClient) {
+    public void handleConnectionAttemptFailed(final ApnsClient apnsClient) {
     }
 }

--- a/pushy/src/test/java/com/relayrides/pushy/apns/ApnsClientBuilderTest.java
+++ b/pushy/src/test/java/com/relayrides/pushy/apns/ApnsClientBuilderTest.java
@@ -7,8 +7,6 @@ import java.security.cert.X509Certificate;
 
 import org.junit.Test;
 
-import com.relayrides.pushy.apns.util.SimpleApnsPushNotification;
-
 public class ApnsClientBuilderTest {
 
     private static final String SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME = "/single-topic-client.p12";
@@ -19,7 +17,7 @@ public class ApnsClientBuilderTest {
     @Test
     public void testBuildClientWithPasswordProtectedP12File() throws Exception {
         // We're happy here as long as nothing throws an exception
-        new ApnsClientBuilder<SimpleApnsPushNotification>()
+        new ApnsClientBuilder()
         .setClientCredentials(new File(ApnsClientBuilderTest.class.getResource(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME).toURI()), KEYSTORE_PASSWORD)
         .build();
     }
@@ -28,7 +26,7 @@ public class ApnsClientBuilderTest {
     public void testBuildClientWithPasswordProtectedP12InputStream() throws Exception {
         // We're happy here as long as nothing throws an exception
         try (final InputStream p12InputStream = ApnsClientBuilderTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
-            new ApnsClientBuilder<SimpleApnsPushNotification>()
+            new ApnsClientBuilder()
             .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
             .build();
         }
@@ -36,7 +34,7 @@ public class ApnsClientBuilderTest {
 
     @Test(expected = NullPointerException.class)
     public void testBuildClientWithNullPassword() throws Exception {
-        new ApnsClientBuilder<SimpleApnsPushNotification>()
+        new ApnsClientBuilder()
         .setClientCredentials(new File(ApnsClientBuilderTest.class.getResource(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME).toURI()), null)
         .build();
     }
@@ -48,7 +46,7 @@ public class ApnsClientBuilderTest {
             final PrivateKeyEntry privateKeyEntry =
                     P12Util.getFirstPrivateKeyEntryFromP12InputStream(p12InputStream, KEYSTORE_PASSWORD);
 
-            new ApnsClientBuilder<SimpleApnsPushNotification>()
+            new ApnsClientBuilder()
             .setClientCredentials((X509Certificate) privateKeyEntry.getCertificate(), privateKeyEntry.getPrivateKey(), KEYSTORE_PASSWORD)
             .build();
         }
@@ -62,7 +60,7 @@ public class ApnsClientBuilderTest {
             final PrivateKeyEntry privateKeyEntry =
                     P12Util.getFirstPrivateKeyEntryFromP12InputStream(p12InputStream, KEYSTORE_PASSWORD);
 
-            new ApnsClientBuilder<SimpleApnsPushNotification>()
+            new ApnsClientBuilder()
             .setClientCredentials((X509Certificate) privateKeyEntry.getCertificate(), privateKeyEntry.getPrivateKey(), null)
             .build();
         }
@@ -70,6 +68,6 @@ public class ApnsClientBuilderTest {
 
     @Test(expected = NullPointerException.class)
     public void testBuildWithoutClientCredentials() throws Exception {
-        new ApnsClientBuilder<>().build();
+        new ApnsClientBuilder().build();
     }
 }

--- a/pushy/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
+++ b/pushy/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
@@ -55,7 +55,7 @@ public class ApnsClientTest {
     private static final int TOKEN_LENGTH = 32; // bytes
 
     private MockApnsServer server;
-    private ApnsClient<SimpleApnsPushNotification> client;
+    private ApnsClient client;
 
     private static class TestMetricsListener implements ApnsClientMetricsListener {
 
@@ -69,7 +69,7 @@ public class ApnsClientTest {
         private final AtomicInteger failedConnectionAttempts = new AtomicInteger(0);
 
         @Override
-        public void handleWriteFailure(final ApnsClient<? extends ApnsPushNotification> apnsClient, final long notificationId) {
+        public void handleWriteFailure(final ApnsClient apnsClient, final long notificationId) {
             synchronized (this.writeFailures) {
                 this.writeFailures.add(notificationId);
                 this.writeFailures.notifyAll();
@@ -77,12 +77,12 @@ public class ApnsClientTest {
         }
 
         @Override
-        public void handleNotificationSent(final ApnsClient<? extends ApnsPushNotification> apnsClient, final long notificationId) {
+        public void handleNotificationSent(final ApnsClient apnsClient, final long notificationId) {
             this.sentNotifications.add(notificationId);
         }
 
         @Override
-        public void handleNotificationAccepted(final ApnsClient<? extends ApnsPushNotification> apnsClient, final long notificationId) {
+        public void handleNotificationAccepted(final ApnsClient apnsClient, final long notificationId) {
             synchronized (this.acceptedNotifications) {
                 this.acceptedNotifications.add(notificationId);
                 this.acceptedNotifications.notifyAll();
@@ -90,7 +90,7 @@ public class ApnsClientTest {
         }
 
         @Override
-        public void handleNotificationRejected(final ApnsClient<? extends ApnsPushNotification> apnsClient, final long notificationId) {
+        public void handleNotificationRejected(final ApnsClient apnsClient, final long notificationId) {
             synchronized (this.rejectedNotifications) {
                 this.rejectedNotifications.add(notificationId);
                 this.rejectedNotifications.notifyAll();
@@ -98,12 +98,12 @@ public class ApnsClientTest {
         }
 
         @Override
-        public void handleConnectionAttemptStarted(final ApnsClient<? extends ApnsPushNotification> apnsClient) {
+        public void handleConnectionAttemptStarted(final ApnsClient apnsClient) {
             this.connectionAttemptsStarted.getAndIncrement();
         }
 
         @Override
-        public void handleConnectionAttemptSucceeded(final ApnsClient<? extends ApnsPushNotification> apnsClient) {
+        public void handleConnectionAttemptSucceeded(final ApnsClient apnsClient) {
             synchronized (this.successfulConnectionAttempts) {
                 this.successfulConnectionAttempts.getAndIncrement();
                 this.successfulConnectionAttempts.notifyAll();
@@ -111,7 +111,7 @@ public class ApnsClientTest {
         }
 
         @Override
-        public void handleConnectionAttemptFailed(final ApnsClient<? extends ApnsPushNotification> apnsClient) {
+        public void handleConnectionAttemptFailed(final ApnsClient apnsClient) {
             synchronized (this.failedConnectionAttempts) {
                 this.failedConnectionAttempts.getAndIncrement();
                 this.failedConnectionAttempts.notifyAll();
@@ -214,7 +214,7 @@ public class ApnsClientTest {
         this.server.start(PORT).await();
 
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
-            this.client = new ApnsClientBuilder<SimpleApnsPushNotification>()
+            this.client = new ApnsClientBuilder()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
@@ -245,10 +245,10 @@ public class ApnsClientTest {
 
     @Test
     public void testApnsClientWithManagedEventLoopGroup() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> managedGroupClient;
+        final ApnsClient managedGroupClient;
 
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
-            managedGroupClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
+            managedGroupClient = new ApnsClientBuilder()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .build();
@@ -277,10 +277,10 @@ public class ApnsClientTest {
 
     @Test
     public void testRestartApnsClientWithManagedEventLoopGroup() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> managedGroupClient;
+        final ApnsClient managedGroupClient;
 
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
-            managedGroupClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
+            managedGroupClient = new ApnsClientBuilder()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .build();
@@ -340,10 +340,10 @@ public class ApnsClientTest {
 
     @Test
     public void testGetReconnectionFutureWhenNotConnected() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> unconnectedClient;
+        final ApnsClient unconnectedClient;
 
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
-            unconnectedClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
+            unconnectedClient = new ApnsClientBuilder()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
@@ -360,10 +360,10 @@ public class ApnsClientTest {
 
     @Test
     public void testConnectWithUntrustedCertificate() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> untrustedClient;
+        final ApnsClient untrustedClient;
 
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(UNTRUSTED_CLIENT_KEYSTORE_FILENAME)) {
-            untrustedClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
+            untrustedClient = new ApnsClientBuilder()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
@@ -378,10 +378,10 @@ public class ApnsClientTest {
 
     @Test
     public void testSendNotificationBeforeConnected() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> unconnectedClient;
+        final ApnsClient unconnectedClient;
 
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
-            unconnectedClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
+            unconnectedClient = new ApnsClientBuilder()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
@@ -564,10 +564,10 @@ public class ApnsClientTest {
     @Test
     @Ignore("Ignored until auth tokens are implemented; see https://github.com/relayrides/pushy/issues/313 for details")
     public void testSendNotificationWithMissingTopic() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> multiTopicClient;
+        final ApnsClient multiTopicClient;
 
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(MULTI_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
-            multiTopicClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
+            multiTopicClient = new ApnsClientBuilder()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
@@ -594,10 +594,10 @@ public class ApnsClientTest {
 
     @Test
     public void testSendNotificationWithSpecifiedTopic() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> multiTopicClient;
+        final ApnsClient multiTopicClient;
 
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(MULTI_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
-            multiTopicClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
+            multiTopicClient = new ApnsClientBuilder()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
@@ -669,10 +669,10 @@ public class ApnsClientTest {
                     .build();
         }
 
-        final ApnsClient<SimpleApnsPushNotification> unfortunateClient;
+        final ApnsClient unfortunateClient;
 
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
-            unfortunateClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
+            unfortunateClient = new ApnsClientBuilder()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
@@ -701,10 +701,10 @@ public class ApnsClientTest {
 
     @Test
     public void testWriteFailureMetrics() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> unconnectedClient;
+        final ApnsClient unconnectedClient;
 
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
-            unconnectedClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
+            unconnectedClient = new ApnsClientBuilder()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
@@ -757,10 +757,10 @@ public class ApnsClientTest {
 
     @Test
     public void testSuccessfulConnectionMetrics() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> unconnectedClient;
+        final ApnsClient unconnectedClient;
 
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
-            unconnectedClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
+            unconnectedClient = new ApnsClientBuilder()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
@@ -783,10 +783,10 @@ public class ApnsClientTest {
 
     @Test
     public void testFailedConnectionMetrics() throws Exception {
-        final ApnsClient<SimpleApnsPushNotification> unconnectedClient;
+        final ApnsClient unconnectedClient;
 
         try (final InputStream p12InputStream = ApnsClientTest.class.getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
-            unconnectedClient = new ApnsClientBuilder<SimpleApnsPushNotification>()
+            unconnectedClient = new ApnsClientBuilder()
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .setTrustedServerCertificateChain(CA_CERTIFICATE)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)

--- a/pushy/src/test/java/com/relayrides/pushy/apns/ExampleApp.java
+++ b/pushy/src/test/java/com/relayrides/pushy/apns/ExampleApp.java
@@ -8,6 +8,7 @@ import com.relayrides.pushy.apns.proxy.Socks5ProxyHandlerFactory;
 import com.relayrides.pushy.apns.util.ApnsPayloadBuilder;
 import com.relayrides.pushy.apns.util.SimpleApnsPushNotification;
 import com.relayrides.pushy.apns.util.TokenUtil;
+
 import io.netty.util.concurrent.Future;
 
 /**
@@ -25,8 +26,7 @@ public class ExampleApp {
         // certificate and private key to authenticate with the APNs server. The
         // most common way to store the certificate and key is in a
         // password-protected PKCS#12 file.
-        final ApnsClient<SimpleApnsPushNotification> apnsClient =
-                new ApnsClientBuilder<SimpleApnsPushNotification>()
+        final ApnsClient apnsClient = new ApnsClientBuilder()
                 .setClientCredentials(new File("/path/to/certificate.p12"), "p12-file-password")
                 .build();
 


### PR DESCRIPTION
As suggested in #342, this change makes the `ApnsClient` class non-generic, but instead makes its `sendNotification` method generic. This makes an `ApnsClient` much more flexible in terms of the types of notifications it can handle, which is definitely a good thing. This does come with some costs, though:

1. There's some API breakage. Good thing we have a big "we may change the API before 1.0" disclaimer at the bottom of the README ;)
2. The sending code itself is incrementally more complex.
3. We have an additional listener in the cycle for each notification we send, which causes some slight (~1%) performance decreases as shown below:

```
# Before

(flushImmediately)  (notificationCount)  Mode  Cnt  Score   Error  Units
              true                10000    ss   40  0.632 ± 0.022   s/op
             false                10000    ss   40  0.606 ± 0.018   s/op

# After

(flushImmediately)  (notificationCount)  Mode  Cnt  Score   Error  Units
              true                10000    ss   40  0.640 ± 0.017   s/op
             false                10000    ss   40  0.615 ± 0.020   s/op
```

In all, I think the tradeoff is worth it, but would very much appreciate other perspectives.

----

TODO:

- [x] Update inline docs
- [x] Update README