### PR TITLE
Roll back fancy flush thresholds (closes #332)

### DIFF
--- a/benchmark/src/main/java/com/relayrides/pushy/apns/ApnsClientBenchmark.java
+++ b/benchmark/src/main/java/com/relayrides/pushy/apns/ApnsClientBenchmark.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -40,9 +39,6 @@ public class ApnsClientBenchmark {
     @Param({"10000"})
     public int notificationCount;
 
-    @Param({"true", "false"})
-    public boolean flushImmediately;
-
     private static final String CA_CERTIFICATE_FILENAME = "/ca.pem";
     private static final String CLIENT_KEYSTORE_FILENAME = "/client.p12";
     private static final String SERVER_CERTIFICATES_FILENAME = "/server_certs.pem";
@@ -64,10 +60,6 @@ public class ApnsClientBenchmark {
                 .setClientCredentials(ApnsClientBenchmark.class.getResourceAsStream(CLIENT_KEYSTORE_FILENAME), KEYSTORE_PASSWORD)
                 .setTrustedServerCertificateChain(ApnsClientBenchmark.class.getResourceAsStream(CA_CERTIFICATE_FILENAME))
                 .setEventLoopGroup(this.eventLoopGroup);
-
-        if (this.flushImmediately) {
-            clientBuilder.setFlushThresholds(0, 0, TimeUnit.SECONDS);
-        }
 
         this.client = clientBuilder.build();
 

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientBuilder.java
@@ -80,10 +80,6 @@ public class ApnsClientBuilder {
     private Long connectionTimeout;
     private TimeUnit connectionTimeoutUnit;
 
-    private Integer maxUnflushedNotifications;
-    private Long maxIdleTimeBeforeFlush;
-    private TimeUnit maxIdleTimeBeforeFlushUnits;
-
     private Long writeTimeout;
     private TimeUnit writeTimeoutUnit;
 
@@ -309,36 +305,6 @@ public class ApnsClientBuilder {
     }
 
     /**
-     * <p>Sets the thresholds at which this client under construction will flush notifications enqueued for sending to
-     * the APNs server. By default, notifications will be flushed after
-     * {@value com.relayrides.pushy.apns.ApnsClient#DEFAULT_MAX_UNFLUSHED_NOTIFICATIONS} unflushed
-     * notifications have been enqueued or {@value com.relayrides.pushy.apns.ApnsClient#DEFAULT_FLUSH_AFTER_IDLE_MILLIS}
-     * milliseconds of inactivity have elapsed.</p>
-     *
-     * <p>Callers may set both thresholds to zero to flush all notifications immediately, which will reduce latency at
-     * the expense of decreasing efficiency and throughput.</p>
-     *
-     * @param maxUnflushedNotifications The maximum number of notifications that may be enqueued before the sending
-     * queue is flushed. Must be positive if {@code maxIdleTimeMillis} is also positive or zero if
-     * {@code maxIdleTimeMillis} is also zero. If zero, notifications are always sent immediately.
-     * @param maxIdleTime The maximum amount of time since the last attempt to send a notification that may elapse
-     * before the sending queue is flushed. Must be positive if {@code maxUnflushedNotifications} is also positive or
-     * zero if {@code maxUnflushedNotifications} is also zero. If zero, notifications are always sent immediately.
-     * @param maxIdleTimeUnits the time unit for the given maximum idle time
-     *
-     * @return a reference to this builder
-     *
-     * @since 0.8
-     */
-    public ApnsClientBuilder setFlushThresholds(final int maxUnflushedNotifications, final long maxIdleTime, final TimeUnit maxIdleTimeUnits) {
-        this.maxUnflushedNotifications = maxUnflushedNotifications;
-        this.maxIdleTimeBeforeFlush = maxIdleTime;
-        this.maxIdleTimeBeforeFlushUnits = maxIdleTimeUnits;
-
-        return this;
-    }
-
-    /**
      * <p>Sets the write timeout for the client to build. If an attempt to send a notification to the APNs server takes
      * longer than the given timeout, the connection will be closed (and automatically reconnected later). Note that
      * write timeouts refer to the amount of time taken to <em>send</em> a notification to the server, and not the time
@@ -440,10 +406,6 @@ public class ApnsClientBuilder {
 
         if (this.connectionTimeout != null) {
             apnsClient.setConnectionTimeout((int) this.connectionTimeoutUnit.toMillis(this.connectionTimeout));
-        }
-
-        if (this.maxUnflushedNotifications != null) {
-            apnsClient.setFlushThresholds(this.maxUnflushedNotifications, this.maxIdleTimeBeforeFlushUnits.toMillis(this.maxIdleTimeBeforeFlush));
         }
 
         if (this.writeTimeout != null) {

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +49,6 @@ import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2FrameAdapter;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Settings;
-import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.WriteTimeoutException;
 import io.netty.util.AsciiString;
@@ -60,7 +58,6 @@ import io.netty.util.concurrent.ScheduledFuture;
 
 class ApnsClientHandler extends Http2ConnectionHandler {
 
-    private final AtomicBoolean receivedInitialSettings = new AtomicBoolean(false);
     private long nextStreamId = 1;
 
     private final Map<Integer, ApnsPushNotification> pushNotificationsByStreamId = new HashMap<>();
@@ -71,9 +68,6 @@ class ApnsClientHandler extends Http2ConnectionHandler {
 
     private long nextPingId = new Random().nextLong();
     private ScheduledFuture<?> pingTimeoutFuture;
-
-    private final int maxUnflushedNotifications;
-    private int unflushedNotifications = 0;
 
     private static final int PING_TIMEOUT = 30; // seconds
 
@@ -96,7 +90,6 @@ class ApnsClientHandler extends Http2ConnectionHandler {
 
         private ApnsClient apnsClient;
         private String authority;
-        private int maxUnflushedNotifications = 0;
 
         public ApnsClientHandlerBuilder apnsClient(final ApnsClient apnsClient) {
             this.apnsClient = apnsClient;
@@ -116,15 +109,6 @@ class ApnsClientHandler extends Http2ConnectionHandler {
             return this.authority;
         }
 
-        public ApnsClientHandlerBuilder maxUnflushedNotifications(final int maxUnflushedNotifications) {
-            this.maxUnflushedNotifications = maxUnflushedNotifications;
-            return this;
-        }
-
-        public int maxUnflushedNotifications() {
-            return this.maxUnflushedNotifications;
-        }
-
         @Override
         public ApnsClientHandlerBuilder server(final boolean isServer) {
             return super.server(isServer);
@@ -139,7 +123,7 @@ class ApnsClientHandler extends Http2ConnectionHandler {
         public ApnsClientHandler build(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings) {
             Objects.requireNonNull(this.authority(), "Authority must be set before building an ApnsClientHandler.");
 
-            final ApnsClientHandler handler = new ApnsClientHandler(decoder, encoder, initialSettings, this.apnsClient(), this.authority(), this.maxUnflushedNotifications());
+            final ApnsClientHandler handler = new ApnsClientHandler(decoder, encoder, initialSettings, this.apnsClient(), this.authority());
             this.frameListener(handler.new ApnsClientHandlerFrameAdapter());
             return handler;
         }
@@ -154,11 +138,6 @@ class ApnsClientHandler extends Http2ConnectionHandler {
         @Override
         public void onSettingsRead(final ChannelHandlerContext context, final Http2Settings settings) {
             log.trace("Received settings from APNs gateway: {}", settings);
-
-            synchronized (ApnsClientHandler.this.receivedInitialSettings) {
-                ApnsClientHandler.this.receivedInitialSettings.set(true);
-                ApnsClientHandler.this.receivedInitialSettings.notifyAll();
-            }
         }
 
         @Override
@@ -235,12 +214,11 @@ class ApnsClientHandler extends Http2ConnectionHandler {
         }
     }
 
-    protected ApnsClientHandler(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings, final ApnsClient apnsClient, final String authority, final int maxUnflushedNotifications) {
+    protected ApnsClientHandler(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings, final ApnsClient apnsClient, final String authority) {
         super(decoder, encoder, initialSettings);
 
         this.apnsClient = apnsClient;
         this.authority = authority;
-        this.maxUnflushedNotifications = maxUnflushedNotifications;
     }
 
     @Override
@@ -294,10 +272,6 @@ class ApnsClientHandler extends Http2ConnectionHandler {
 
             this.nextStreamId += 2;
 
-            if (++this.unflushedNotifications >= this.maxUnflushedNotifications) {
-                this.flush(context);
-            }
-
             if (this.nextStreamId >= STREAM_ID_RESET_THRESHOLD) {
                 // This is very unlikely, but in the event that we run out of stream IDs (the maximum allowed is
                 // 2^31, per https://httpwg.github.io/specs/rfc7540.html#StreamIdentifiers), we need to open a new
@@ -314,51 +288,36 @@ class ApnsClientHandler extends Http2ConnectionHandler {
     }
 
     @Override
-    public void flush(final ChannelHandlerContext context) throws Http2Exception {
-        super.flush(context);
-
-        this.unflushedNotifications = 0;
-    }
-
-    @Override
     public void userEventTriggered(final ChannelHandlerContext context, final Object event) throws Exception {
         if (event instanceof IdleStateEvent) {
-            final IdleStateEvent idleStateEvent = (IdleStateEvent) event;
+            assert PING_TIMEOUT < ApnsClient.PING_IDLE_TIME_MILLIS;
 
-            if (IdleState.WRITER_IDLE.equals(idleStateEvent.state())) {
-                if (this.unflushedNotifications > 0) {
-                    this.flush(context);
-                }
-            } else {
-                assert PING_TIMEOUT < ApnsClient.PING_IDLE_TIME_MILLIS;
+            log.trace("Sending ping due to inactivity.");
 
-                log.trace("Sending ping due to inactivity.");
+            final ByteBuf pingDataBuffer = context.alloc().ioBuffer(8, 8);
+            pingDataBuffer.writeLong(this.nextPingId++);
 
-                final ByteBuf pingDataBuffer = context.alloc().ioBuffer(8, 8);
-                pingDataBuffer.writeLong(this.nextPingId++);
+            this.encoder().writePing(context, false, pingDataBuffer, context.newPromise()).addListener(new GenericFutureListener<ChannelFuture>() {
 
-                this.encoder().writePing(context, false, pingDataBuffer, context.newPromise()).addListener(new GenericFutureListener<ChannelFuture>() {
+                @Override
+                public void operationComplete(final ChannelFuture future) throws Exception {
+                    if (future.isSuccess()) {
+                        ApnsClientHandler.this.pingTimeoutFuture = future.channel().eventLoop().schedule(new Runnable() {
 
-                    @Override
-                    public void operationComplete(final ChannelFuture future) throws Exception {
-                        if (future.isSuccess()) {
-                            ApnsClientHandler.this.pingTimeoutFuture = future.channel().eventLoop().schedule(new Runnable() {
-
-                                @Override
-                                public void run() {
-                                    log.debug("Closing channel due to ping timeout.");
-                                    future.channel().close();
-                                }
-                            }, PING_TIMEOUT, TimeUnit.SECONDS);
-                        } else {
-                            log.debug("Failed to write PING frame.", future.cause());
-                            future.channel().close();
-                        }
+                            @Override
+                            public void run() {
+                                log.debug("Closing channel due to ping timeout.");
+                                future.channel().close();
+                            }
+                        }, PING_TIMEOUT, TimeUnit.SECONDS);
+                    } else {
+                        log.debug("Failed to write PING frame.", future.cause());
+                        future.channel().close();
                     }
-                });
+                }
+            });
 
-                this.flush(context);
-            }
+            this.flush(context);
         }
 
         super.userEventTriggered(context, event);
@@ -371,17 +330,6 @@ class ApnsClientHandler extends Http2ConnectionHandler {
             context.close();
         } else {
             log.warn("APNs client pipeline caught an exception.", cause);
-        }
-    }
-
-    /*
-     * Waits for the initial SETTINGS frame from the server after connecting. For testing purposes only.
-     */
-    void waitForInitialSettings() throws InterruptedException {
-        synchronized (this.receivedInitialSettings) {
-            while (!this.receivedInitialSettings.get()) {
-                this.receivedInitialSettings.wait();
-            }
         }
     }
 }

--- a/pushy/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
+++ b/pushy/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
@@ -259,23 +259,6 @@ public class ApnsClientTest {
     }
 
     @Test
-    public void testSetFlushThresholds() {
-        // We're happy here as long as nothing explodes
-        this.client.setFlushThresholds(0, 0);
-        this.client.setFlushThresholds(1, 1);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testSetFlushThresholdsWithZeroNotificationCount() {
-        this.client.setFlushThresholds(0, 1);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testSetFlushThresholdsWithZeroTimeout() {
-        this.client.setFlushThresholds(1,  0);
-    }
-
-    @Test
     public void testRestartApnsClientWithManagedEventLoopGroup() throws Exception {
         final ApnsClient managedGroupClient;
 
@@ -402,42 +385,6 @@ public class ApnsClientTest {
 
     @Test
     public void testSendNotification() throws Exception {
-        final String testToken = ApnsClientTest.generateRandomToken();
-
-        this.server.addToken(DEFAULT_TOPIC, testToken, null);
-
-        final SimpleApnsPushNotification pushNotification = new SimpleApnsPushNotification(testToken, DEFAULT_TOPIC, "test-payload");
-        final PushNotificationResponse<SimpleApnsPushNotification> response =
-                this.client.sendNotification(pushNotification).get();
-
-        assertTrue(response.isAccepted());
-    }
-
-    /*
-     * This addresses an issue identified in https://github.com/relayrides/pushy/issues/283 where the initial SETTINGS
-     * frame from the server would trigger a flush, which was masking some issues with the deferred flush code.
-     */
-    @Test
-    public void testSendNotificationAfterInitialSettings() throws Exception {
-        this.client.waitForInitialSettings();
-
-        final String testToken = ApnsClientTest.generateRandomToken();
-
-        this.server.addToken(DEFAULT_TOPIC, testToken, null);
-
-        final SimpleApnsPushNotification pushNotification = new SimpleApnsPushNotification(testToken, DEFAULT_TOPIC, "test-payload");
-        final PushNotificationResponse<SimpleApnsPushNotification> response =
-                this.client.sendNotification(pushNotification).get();
-
-        assertTrue(response.isAccepted());
-    }
-
-    @Test
-    public void testSendNotificationWithImmediateFlush() throws Exception {
-        this.client.disconnect().await();
-        this.client.setFlushThresholds(0, 0);
-        this.client.connect(HOST, PORT).await();
-
         final String testToken = ApnsClientTest.generateRandomToken();
 
         this.server.addToken(DEFAULT_TOPIC, testToken, null);


### PR DESCRIPTION
Flush thresholds are, I think, a good idea from a performance perspective, but have been causing some problems in practice (see #332). At the same time, it looks like a better, more robust, upstream solution is on its way (see #326). This pull request rolls back flush thresholds entirely with the understanding that we'll have a drop-in replacement soon.

So why do this? Why not just fix the underlying bug in #332? We could, but auto-flushing (#326) will represent a breaking API change when it happens, and v0.8 is loaded with API-breaking changes anyhow. The idea is to get the API breakage out of the way now, then chase it with a non-breaking performance boost later.

I am very, very open to arguments that this is a dumb idea and we should just fix the bug now ;)