### PR TITLE
Exclude .gitignore files from jars (fixes #355)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,17 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/.gitignore</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>


### PR DESCRIPTION
This fixes an oversight where `.gitignore` files used to convince git to create "empty" directories were making their way into distribution jars. Oops.