### PR TITLE
Drop fancy workaround for Travis CI hostname issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,3 @@
-# Workaround for Travis CI issue 5227, which results in a buffer overflow
-# caused by Java when running the build on OpenJDK.
-# https://github.com/travis-ci/travis-ci/issues/5227
-before_install:
-    - cat /etc/hosts # optionally check the content *before*
-    - sudo hostname "$(hostname | cut -c1-63)"
-    - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
-    - cat /etc/hosts # optionally check the content *after*
 language: java
 jdk:
     - oraclejdk8


### PR DESCRIPTION
Travis has been having [some issues with new images](https://www.traviscistatus.com/incidents/11hp8bhkrkn7) lately; some of our tests have been failing intermittently when getting hostnames, and I wonder if removing this old hostname workaround will actually help things.