### PR TITLE
add APNS-COLLAPSE-ID header to support notification management on iOS10

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
@@ -75,6 +75,7 @@ class ApnsClientHandler extends Http2ConnectionHandler {
     private static final AsciiString APNS_EXPIRATION_HEADER = new AsciiString("apns-expiration");
     private static final AsciiString APNS_TOPIC_HEADER = new AsciiString("apns-topic");
     private static final AsciiString APNS_PRIORITY_HEADER = new AsciiString("apns-priority");
+    private static final AsciiString APNS_COLLAPSE_ID = new AsciiString("apns-collapse-id");
 
     private static final long STREAM_ID_RESET_THRESHOLD = Integer.MAX_VALUE - 1;
 
@@ -234,6 +235,10 @@ class ApnsClientHandler extends Http2ConnectionHandler {
                     .authority(this.authority)
                     .path(APNS_PATH_PREFIX + pushNotification.getToken())
                     .addInt(APNS_EXPIRATION_HEADER, pushNotification.getExpiration() == null ? 0 : (int) (pushNotification.getExpiration().getTime() / 1000));
+
+            if (pushNotification.getCollapseId() != null) {
+                headers.add(APNS_COLLAPSE_ID, pushNotification.getCollapseId());
+            }
 
             if (pushNotification.getPriority() != null) {
                 headers.addInt(APNS_PRIORITY_HEADER, pushNotification.getPriority().getCode());

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsPushNotification.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsPushNotification.java
@@ -25,11 +25,9 @@ import java.util.Date;
 import com.relayrides.pushy.apns.util.ApnsPayloadBuilder;
 
 /**
- * <p>
- * A push notification that can be sent through the Apple Push Notification service (APNs). Push notifications have a
+ * <p>A push notification that can be sent through the Apple Push Notification service (APNs). Push notifications have a
  * token that identifies the device to which it should be sent, a topic (generally the bundle ID of the receiving app),
- * a JSON payload, and (optionally) a time at which the notification is invalid and should no longer be delivered.
- * </p>
+ * a JSON payload, and (optionally) a time at which the notification is invalid and should no longer be delivered.</p>
  *
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
  *
@@ -99,16 +97,12 @@ public interface ApnsPushNotification {
     DeliveryPriority getPriority();
 
     /**
-     * <p>
-     * Returns the topic to which this notification should be sent. This is generally the bundle ID of the receiving
-     * app.
-     * </p>
+     * <p>Returns the topic to which this notification should be sent. This is generally the bundle ID of the receiving
+     * app.</p>
      *
-     * <p>
-     * Some (older) APNs certificates contain only a single topic; if this push notification is sent via a client using
-     * a single-topic certificate, this topic may be {@code null}, in which case the APNs gateway will use the
-     * certificate's subject (the bundle ID for the receiving app) as the topic.
-     * </p>
+     * <p>Some (older) APNs certificates contain only a single topic; if this push notification is sent via a client
+     * using a single-topic certificate, this topic may be {@code null}, in which case the APNs gateway will use the
+     * certificate's subject (the bundle ID for the receiving app) as the topic.</p>
      *
      * @return the topic to which this notification should be sent, or {@code null} for the default topic if this
      *         notification is sent on a connection with a single-topic certificate
@@ -122,21 +116,14 @@ public interface ApnsPushNotification {
     String getTopic();
 
     /**
-     * <p>
-     * Returns the id of the notification. This is generally used for notification management
-     * app.
-     * </p>
+     * Returns an optional identifier for this notification that allows this notification to supersede previous
+     * notifications or to be superseded by later notifications with the same identifier.
      *
-     * <p>
-     * Some (older) APNs notifications did not include apns-collaps-id header; this header may be {@code null}, in which case the APNs gateway will ignore it
-     * </p>
+     * @return an identifier for this notification; may be {@code null}
      *
-     * @return the apns-collapse-id to
+     * @see <a href="https://developer.apple.com/videos/play/wwdc2016/707/">APNs Notification managment</a>
      *
-     * @see <a href=
-     *      "https://developer.apple.com/videos/play/wwdc2016/707/">
-     *      APNs Notification managment</a>
-     *
+     * @since 0.8.1
      */
     String getCollapseId();
 }

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsPushNotification.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsPushNotification.java
@@ -120,4 +120,23 @@ public interface ApnsPushNotification {
      * @since 0.5
      */
     String getTopic();
+
+    /**
+     * <p>
+     * Returns the id of the notification. This is generally used for notification management
+     * app.
+     * </p>
+     *
+     * <p>
+     * Some (older) APNs notifications did not include apns-collaps-id header; this header may be {@code null}, in which case the APNs gateway will ignore it
+     * </p>
+     *
+     * @return the apns-collapse-id to
+     *
+     * @see <a href=
+     *      "https://developer.apple.com/videos/play/wwdc2016/707/">
+     *      APNs Notification managment</a>
+     *
+     */
+    String getCollapseId();
 }

--- a/pushy/src/main/java/com/relayrides/pushy/apns/util/SimpleApnsPushNotification.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/util/SimpleApnsPushNotification.java
@@ -21,6 +21,7 @@
 package com.relayrides.pushy.apns.util;
 
 import java.util.Date;
+import java.util.Objects;
 
 import com.relayrides.pushy.apns.ApnsPushNotification;
 import com.relayrides.pushy.apns.DeliveryPriority;
@@ -39,6 +40,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
     private final Date invalidationTime;
     private final DeliveryPriority priority;
     private final String topic;
+    private final String collapseId;
 
     /**
      * Constructs a new push notification with the given token, topic, and payload. No expiration time is set for the
@@ -56,9 +58,8 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
      * @see DeliveryPriority#IMMEDIATE
      */
     public SimpleApnsPushNotification(final String token, final String topic, final String payload) {
-        this(token, topic, payload, null, DeliveryPriority.IMMEDIATE);
+        this(token, topic, payload, null, DeliveryPriority.IMMEDIATE, null);
     }
-
     /**
      * Constructs a new push notification with the given token, topic, payload, and expiration time. An "immediate"
      * delivery priority is used for the notification, and as such the payload should contain an alert, sound, or badge
@@ -77,8 +78,16 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
      * @see DeliveryPriority#IMMEDIATE
      */
     public SimpleApnsPushNotification(final String token, final String topic, final String payload, final Date invalidationTime) {
-        this(token, topic, payload, invalidationTime, DeliveryPriority.IMMEDIATE);
+        this(token, topic, payload, invalidationTime, DeliveryPriority.IMMEDIATE, null);
     }
+
+    public SimpleApnsPushNotification(final String token, final String topic, final String payload, final Date invalidationTime,
+                                      final DeliveryPriority priority){
+
+        this(token, topic, payload, invalidationTime, priority, null);
+    }
+
+
 
     /**
      * Constructs a new push notification with the given token, topic, payload, delivery expiration time, and delivery
@@ -96,15 +105,18 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
      * @param priority
      *            the priority with which this notification should be delivered to the receiving device
      */
+
     public SimpleApnsPushNotification(final String token, final String topic, final String payload, final Date invalidationTime,
-            final DeliveryPriority priority) {
+                                      final DeliveryPriority priority, final String collapseId) {
 
         this.token = token;
         this.payload = payload;
         this.invalidationTime = invalidationTime;
         this.priority = priority;
         this.topic = topic;
+        this.collapseId = collapseId;
     }
+
 
     /**
      * Returns the token of the device to which this push notification should be delivered.
@@ -156,6 +168,11 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         return this.topic;
     }
 
+    @Override
+    public String getCollapseId() {
+        return this.collapseId;
+    }
+
     /* (non-Javadoc)
      * @see java.lang.Object#hashCode()
      */
@@ -168,6 +185,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         result = prime * result + ((this.priority == null) ? 0 : this.priority.hashCode());
         result = prime * result + ((this.token == null) ? 0 : this.token.hashCode());
         result = prime * result + ((this.topic == null) ? 0 : this.topic.hashCode());
+        result = prime * result + ((this.collapseId == null) ? 0 : this.collapseId.hashCode());
         return result;
     }
 
@@ -217,6 +235,13 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         } else if (!this.topic.equals(other.topic)) {
             return false;
         }
+        if (Objects.equals(this.collapseId, null)) {
+            if (!Objects.equals(other.collapseId , null)) {
+                return false;
+            }
+        } else if (!this.collapseId.equals(other.collapseId)) {
+            return false;
+        }
         return true;
     }
 
@@ -236,6 +261,8 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         builder.append(this.priority);
         builder.append(", topic=");
         builder.append(this.topic);
+        builder.append(", apns-collapse-id=");
+        builder.append(this.collapseId);
         builder.append("]");
         return builder.toString();
     }

--- a/pushy/src/main/java/com/relayrides/pushy/apns/util/SimpleApnsPushNotification.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/util/SimpleApnsPushNotification.java
@@ -48,12 +48,9 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
      * An "immediate" delivery priority is used for the notification, and as such the payload should contain an alert,
      * sound, or badge component.
      *
-     * @param token
-     *            the device token to which this push notification should be delivered
-     * @param topic
-     *            the topic to which this notification should be sent
-     * @param payload
-     *            the payload to include in this push notification
+     * @param token the device token to which this push notification should be delivered
+     * @param topic the topic to which this notification should be sent
+     * @param payload the payload to include in this push notification
      *
      * @see DeliveryPriority#IMMEDIATE
      */
@@ -65,15 +62,11 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
      * delivery priority is used for the notification, and as such the payload should contain an alert, sound, or badge
      * component.
      *
-     * @param token
-     *            the device token to which this push notification should be delivered
-     * @param topic
-     *            the topic to which this notification should be sent
-     * @param payload
-     *            the payload to include in this push notification
-     * @param invalidationTime
-     *            the time at which Apple's servers should stop trying to deliver this message; if
-     *            {@code null}, no delivery attempts beyond the first will be made
+     * @param token the device token to which this push notification should be delivered
+     * @param topic the topic to which this notification should be sent
+     * @param payload the payload to include in this push notification
+     * @param invalidationTime the time at which Apple's servers should stop trying to deliver this message; if
+     * {@code null}, no delivery attempts beyond the first will be made
      *
      * @see DeliveryPriority#IMMEDIATE
      */
@@ -81,34 +74,35 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         this(token, topic, payload, invalidationTime, DeliveryPriority.IMMEDIATE, null);
     }
 
-    public SimpleApnsPushNotification(final String token, final String topic, final String payload, final Date invalidationTime,
-                                      final DeliveryPriority priority){
-
-        this(token, topic, payload, invalidationTime, priority, null);
-    }
-
-
-
     /**
      * Constructs a new push notification with the given token, topic, payload, delivery expiration time, and delivery
      * priority.
      *
-     * @param token
-     *            the device token to which this push notification should be delivered
-     * @param topic
-     *            the topic to which this notification should be sent
-     * @param payload
-     *            the payload to include in this push notification
-     * @param invalidationTime
-     *            the time at which Apple's servers should stop trying to deliver this message; if
-     *            {@code null}, no delivery attempts beyond the first will be made
-     * @param priority
-     *            the priority with which this notification should be delivered to the receiving device
+     * @param token the device token to which this push notification should be delivered
+     * @param topic the topic to which this notification should be sent
+     * @param payload the payload to include in this push notification
+     * @param invalidationTime the time at which Apple's servers should stop trying to deliver this message; if
+     * {@code null}, no delivery attempts beyond the first will be made
+     * @param priority the priority with which this notification should be delivered to the receiving device
      */
+    public SimpleApnsPushNotification(final String token, final String topic, final String payload, final Date invalidationTime, final DeliveryPriority priority) {
+        this(token, topic, payload, invalidationTime, priority, null);
+    }
 
-    public SimpleApnsPushNotification(final String token, final String topic, final String payload, final Date invalidationTime,
-                                      final DeliveryPriority priority, final String collapseId) {
-
+    /**
+     * Constructs a new push notification with the given token, topic, payload, delivery expiration time, delivery
+     * priority, and "collapse identifier."
+     *
+     * @param token the device token to which this push notification should be delivered
+     * @param topic the topic to which this notification should be sent
+     * @param payload the payload to include in this push notification
+     * @param invalidationTime the time at which Apple's servers should stop trying to deliver this message; if
+     * {@code null}, no delivery attempts beyond the first will be made
+     * @param priority the priority with which this notification should be delivered to the receiving device
+     * @param collapseId the "collapse identifier" for this notification, which allows it to supersede or be superseded
+     * by other notifications with the same identifier
+     */
+    public SimpleApnsPushNotification(final String token, final String topic, final String payload, final Date invalidationTime, final DeliveryPriority priority, final String collapseId) {
         this.token = token;
         this.payload = payload;
         this.invalidationTime = invalidationTime;
@@ -116,7 +110,6 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         this.topic = topic;
         this.collapseId = collapseId;
     }
-
 
     /**
      * Returns the token of the device to which this push notification should be delivered.
@@ -168,6 +161,12 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         return this.topic;
     }
 
+    /**
+     * Returns the "collapse ID" for this push notification, which allows it to supersede or be superseded by other
+     * notifications with the same ID.
+     *
+     * @return the "collapse ID" for this push notification
+     */
     @Override
     public String getCollapseId() {
         return this.collapseId;


### PR DESCRIPTION
This is a rebasing/squashing of #347.