### PR TITLE
Add support for `subtitle` and `mutable-content` payload fields

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilder.java
@@ -45,6 +45,7 @@ public class ApnsPayloadBuilder {
     private String localizedAlertKey = null;
     private String[] localizedAlertArguments = null;
     private String alertTitle = null;
+    private String alertSubtitle = null;
     private String localizedAlertTitleKey = null;
     private String[] localizedAlertTitleArguments = null;
     private String launchImageFileName = null;
@@ -54,6 +55,7 @@ public class ApnsPayloadBuilder {
     private String soundFileName = null;
     private String categoryName = null;
     private boolean contentAvailable = false;
+    private boolean mutableContent = false;
 
     private final CharArrayWriter buffer = new CharArrayWriter(DEFAULT_PAYLOAD_SIZE / 4);
 
@@ -63,8 +65,10 @@ public class ApnsPayloadBuilder {
     private static final String SOUND_KEY = "sound";
     private static final String CATEGORY_KEY = "category";
     private static final String CONTENT_AVAILABLE_KEY = "content-available";
+    private static final String MUTABLE_CONTENT_KEY = "mutable-content";
 
     private static final String ALERT_TITLE_KEY = "title";
+    private static final String ALERT_SUBTITLE_KEY = "subtitle";
     private static final String ALERT_BODY_KEY = "body";
     private static final String ALERT_TITLE_LOC_KEY = "title-loc-key";
     private static final String ALERT_TITLE_ARGS_KEY = "title-loc-args";
@@ -169,6 +173,18 @@ public class ApnsPayloadBuilder {
 
         this.alertTitle = alertTitle;
 
+        return this;
+    }
+
+    /**
+     * <p>The subtitle for ios 10</p>
+     *
+     * @param alertSubtitle the subtitle for ios 10
+     *
+     * @return a reference to this payload builder
+     */
+    public ApnsPayloadBuilder setAlertSubtitle(final String alertSubtitle) {
+        this.alertSubtitle = alertSubtitle;
         return this;
     }
 
@@ -328,6 +344,22 @@ public class ApnsPayloadBuilder {
     }
 
     /**
+     * <p>mutable-content for ios 10</p>
+     *
+     * @param mutableContent {@code true} to include a flag that intercept the payload and mutate or replace it or {@code false} otherwise
+     *
+     * @return a reference to this payload builder
+     *
+     * @see <a href=
+     *      "https://developer.apple.com/reference/usernotifications/unnotificationserviceextension">
+     *      UNNotificationServiceExtension</a>
+     */
+    public ApnsPayloadBuilder setMutableContent(final boolean mutableContent) {
+        this.mutableContent = mutableContent;
+        return this;
+    }
+
+    /**
      * <p>Adds a custom property to the payload. According to Apple's documentation:</p>
      *
      * <blockquote>Providers can specify custom payload values outside the Apple-reserved {@code aps} namespace. Custom
@@ -388,6 +420,10 @@ public class ApnsPayloadBuilder {
 
             if (this.contentAvailable) {
                 aps.put(CONTENT_AVAILABLE_KEY, 1);
+            }
+
+            if (this.mutableContent) {
+                aps.put(MUTABLE_CONTENT_KEY, 1);
             }
 
             final Object alertObject = this.createAlertObject();
@@ -486,6 +522,10 @@ public class ApnsPayloadBuilder {
                     alert.put(ALERT_TITLE_KEY, this.alertTitle);
                 }
 
+                if (this.alertSubtitle != null) {
+                    alert.put(ALERT_SUBTITLE_KEY, this.alertSubtitle);
+                }
+
                 if (this.showActionButton) {
                     if (this.localizedActionButtonKey != null) {
                         alert.put(ACTION_LOC_KEY, this.localizedActionButtonKey);
@@ -530,7 +570,7 @@ public class ApnsPayloadBuilder {
     private boolean hasAlertContent() {
         return this.alertBody != null || this.alertTitle != null || this.localizedAlertTitleKey != null
                 || this.localizedAlertKey != null || this.localizedActionButtonKey != null
-                || this.launchImageFileName != null || this.showActionButton == false;
+                || this.launchImageFileName != null || this.showActionButton == false || alertSubtitle != null;
     }
 
     /**
@@ -546,7 +586,7 @@ public class ApnsPayloadBuilder {
      */
     private boolean shouldRepresentAlertAsString() {
         return this.alertBody != null && this.launchImageFileName == null && this.showActionButton
-                && this.localizedActionButtonKey == null && this.alertTitle == null
+                && this.localizedActionButtonKey == null && this.alertTitle == null && this.alertSubtitle == null
                 && this.localizedAlertTitleKey == null && this.localizedAlertKey == null
                 && this.localizedAlertArguments == null && this.localizedAlertTitleArguments == null;
     }

--- a/pushy/src/main/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilder.java
@@ -177,9 +177,9 @@ public class ApnsPayloadBuilder {
     }
 
     /**
-     * <p>The subtitle for ios 10</p>
+     * Sets a subtitle for the notification. Requires iOS 10 or newer.
      *
-     * @param alertSubtitle the subtitle for ios 10
+     * @param alertSubtitle the subtitle for this push notification
      *
      * @return a reference to this payload builder
      */
@@ -344,9 +344,11 @@ public class ApnsPayloadBuilder {
     }
 
     /**
-     * <p>mutable-content for ios 10</p>
+     * Sets whether the receiving device may modify the content of the push notification before displaying it. Requires
+     * iOS 10 or newer.
      *
-     * @param mutableContent {@code true} to include a flag that intercept the payload and mutate or replace it or {@code false} otherwise
+     * @param mutableContent {@code true} if the receiving device may modify the push notification before displaying it
+     * or {@code false} otherwise
      *
      * @return a reference to this payload builder
      *
@@ -570,7 +572,7 @@ public class ApnsPayloadBuilder {
     private boolean hasAlertContent() {
         return this.alertBody != null || this.alertTitle != null || this.localizedAlertTitleKey != null
                 || this.localizedAlertKey != null || this.localizedActionButtonKey != null
-                || this.launchImageFileName != null || this.showActionButton == false || alertSubtitle != null;
+                || this.launchImageFileName != null || this.showActionButton == false || this.alertSubtitle != null;
     }
 
     /**
@@ -615,7 +617,7 @@ public class ApnsPayloadBuilder {
         return i;
     }
 
-    static int getSizeOfJsonEscapedUtf8Character(char c) {
+    static int getSizeOfJsonEscapedUtf8Character(final char c) {
         final int charSize;
 
         if (c == '"' || c == '\\' || c == '\b' || c == '\f' || c == '\n' || c == '\r' || c == '\t') {

--- a/pushy/src/main/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilder.java
@@ -45,9 +45,11 @@ public class ApnsPayloadBuilder {
     private String localizedAlertKey = null;
     private String[] localizedAlertArguments = null;
     private String alertTitle = null;
-    private String alertSubtitle = null;
     private String localizedAlertTitleKey = null;
     private String[] localizedAlertTitleArguments = null;
+    private String alertSubtitle = null;
+    private String localizedAlertSubtitleKey = null;
+    private String[] localizedAlertSubtitleArguments = null;
     private String launchImageFileName = null;
     private boolean showActionButton = true;
     private String localizedActionButtonKey = null;
@@ -68,13 +70,15 @@ public class ApnsPayloadBuilder {
     private static final String MUTABLE_CONTENT_KEY = "mutable-content";
 
     private static final String ALERT_TITLE_KEY = "title";
-    private static final String ALERT_SUBTITLE_KEY = "subtitle";
-    private static final String ALERT_BODY_KEY = "body";
     private static final String ALERT_TITLE_LOC_KEY = "title-loc-key";
     private static final String ALERT_TITLE_ARGS_KEY = "title-loc-args";
-    private static final String ACTION_LOC_KEY = "action-loc-key";
+    private static final String ALERT_SUBTITLE_KEY = "subtitle";
+    private static final String ALERT_SUBTITLE_LOC_KEY = "subtitle-loc-key";
+    private static final String ALERT_SUBTITLE_ARGS_KEY = "subtitle-loc-args";
+    private static final String ALERT_BODY_KEY = "body";
     private static final String ALERT_LOC_KEY = "loc-key";
     private static final String ALERT_ARGS_KEY = "loc-args";
+    private static final String ACTION_LOC_KEY = "action-loc-key";
     private static final String LAUNCH_IMAGE_KEY = "launch-image";
 
     private final HashMap<String, Object> customProperties = new HashMap<String, Object>();
@@ -177,18 +181,6 @@ public class ApnsPayloadBuilder {
     }
 
     /**
-     * Sets a subtitle for the notification. Requires iOS 10 or newer.
-     *
-     * @param alertSubtitle the subtitle for this push notification
-     *
-     * @return a reference to this payload builder
-     */
-    public ApnsPayloadBuilder setAlertSubtitle(final String alertSubtitle) {
-        this.alertSubtitle = alertSubtitle;
-        return this;
-    }
-
-    /**
      * <p>Sets the key of the title string in the receiving app's localized string list to be shown for the push
      * notification. The message in the app's string list may optionally have placeholders, which will be populated by
      * values from the given {@code alertArguments}.</p>
@@ -212,6 +204,53 @@ public class ApnsPayloadBuilder {
 
         this.localizedAlertTitleKey = localizedAlertTitleKey;
         this.localizedAlertTitleArguments = alertTitleArguments;
+
+        return this;
+    }
+
+    /**
+     * Sets a subtitle for the notification. Requires iOS 10 or newer.
+     *
+     * @param alertSubtitle the subtitle for this push notification
+     *
+     * @return a reference to this payload builder
+     *
+     * @since 0.8.1
+     */
+    public ApnsPayloadBuilder setAlertSubtitle(final String alertSubtitle) {
+        if (alertSubtitle != null && this.localizedAlertSubtitleKey != null) {
+            throw new IllegalStateException("Cannot set a literal subtitle when a localized subtitle key has already been set");
+        }
+
+        this.alertSubtitle = alertSubtitle;
+
+        return this;
+    }
+
+    /**
+     * <p>Sets the key of the subtitle string in the receiving app's localized string list to be shown for the push
+     * notification. The message in the app's string list may optionally have placeholders, which will be populated by
+     * values from the given {@code alertSubtitleArguments}.</p>
+     *
+     * @param localizedAlertSubtitleKey a key to a string in the receiving app's localized string list
+     * @param alertSubtitleArguments arguments to populate placeholders in the localized subtitle string; may be
+     * {@code null}
+     *
+     * @return a reference to this payload builder
+     *
+     * @since 0.8.1
+     */
+    public ApnsPayloadBuilder setLocalizedAlertSubtitle(final String localizedAlertSubtitleKey, final String... alertSubtitleArguments) {
+        if (localizedAlertSubtitleKey != null && this.alertSubtitle != null) {
+            throw new IllegalStateException("Cannot set a localized subtitle key when a literal subtitle has already been set");
+        }
+
+        if (localizedAlertSubtitleKey == null && alertSubtitleArguments != null) {
+            throw new IllegalArgumentException("Cannot set localized subtitle arguments without a localized subtitle key.");
+        }
+
+        this.localizedAlertSubtitleKey = localizedAlertSubtitleKey;
+        this.localizedAlertSubtitleArguments = alertSubtitleArguments;
 
         return this;
     }
@@ -553,6 +592,14 @@ public class ApnsPayloadBuilder {
                     }
                 }
 
+                if (this.localizedAlertSubtitleKey != null) {
+                    alert.put(ALERT_SUBTITLE_LOC_KEY, this.localizedAlertSubtitleKey);
+
+                    if (this.localizedAlertSubtitleArguments != null) {
+                        alert.put(ALERT_SUBTITLE_ARGS_KEY, Arrays.asList(this.localizedAlertSubtitleArguments));
+                    }
+                }
+
                 if (this.launchImageFileName != null) {
                     alert.put(LAUNCH_IMAGE_KEY, this.launchImageFileName);
                 }
@@ -572,7 +619,8 @@ public class ApnsPayloadBuilder {
     private boolean hasAlertContent() {
         return this.alertBody != null || this.alertTitle != null || this.localizedAlertTitleKey != null
                 || this.localizedAlertKey != null || this.localizedActionButtonKey != null
-                || this.launchImageFileName != null || this.showActionButton == false || this.alertSubtitle != null;
+                || this.launchImageFileName != null || this.showActionButton == false || this.alertSubtitle != null
+                || this.localizedAlertSubtitleKey != null;
     }
 
     /**

--- a/pushy/src/test/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -93,6 +93,22 @@ public class ApnsPayloadBuilderTest {
     }
 
     @Test
+    public void testSetAlertSubTitle() {
+        final String alertSubtitle = "This is a test alert message.";
+
+        this.builder.setAlertSubtitle(alertSubtitle);
+
+        {
+            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
+
+            assertEquals(alertSubtitle, alert.get("subtitle"));
+        }
+    }
+
+    @Test
     public void testSetAlertTitleAndBody() {
         final String alertTitle = "This is a short alert title";
         final String alertBody = "This is a longer alert body";
@@ -280,6 +296,21 @@ public class ApnsPayloadBuilderTest {
 
             final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
             assertEquals(1, ((Number) aps.get("content-available")).intValue());
+        }
+    }
+
+    @Test
+    public void testSetMutableContent() {
+        {
+            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+            assertNull(aps.get("mutable-content"));
+        }
+
+        {
+            this.builder.setMutableContent(true);
+
+            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+            assertEquals(1, ((Number) aps.get("mutable-content")).intValue());
         }
     }
 

--- a/pushy/src/test/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -76,60 +76,9 @@ public class ApnsPayloadBuilderTest {
         }
     }
 
-    @Test
-    public void testSetAlertTitle() {
-        final String alertTitle = "This is a test alert message.";
-
-        this.builder.setAlertTitle(alertTitle);
-
-        {
-            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
-
-            @SuppressWarnings("unchecked")
-            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
-
-            assertEquals(alertTitle, alert.get("title"));
-        }
-    }
-
-    @Test
-    public void testSetAlertSubTitle() {
-        final String alertSubtitle = "This is a test alert message.";
-
-        this.builder.setAlertSubtitle(alertSubtitle);
-
-        {
-            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
-
-            @SuppressWarnings("unchecked")
-            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
-
-            assertEquals(alertSubtitle, alert.get("subtitle"));
-        }
-    }
-
-    @Test
-    public void testSetAlertTitleAndBody() {
-        final String alertTitle = "This is a short alert title";
-        final String alertBody = "This is a longer alert body";
-
-        this.builder.setAlertBody(alertBody);
-        this.builder.setAlertTitle(alertTitle);
-
-        {
-            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
-
-            @SuppressWarnings("unchecked")
-            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
-
-            assertEquals(alertTitle, alert.get("title"));
-            assertEquals(alertBody, alert.get("body"));
-        }
-    }
-
     @SuppressWarnings("unchecked")
     @Test
-    public void testSetLocalizedAlertMessage() {
+    public void testSetLocalizedAlertBody() {
         final String alertKey = "test.alert";
         this.builder.setLocalizedAlertMessage(alertKey, null);
 
@@ -168,6 +117,38 @@ public class ApnsPayloadBuilderTest {
         this.builder.setLocalizedAlertMessage("Test", null);
     }
 
+    @Test
+    public void testSetAlertTitle() {
+        final String alertTitle = "This is a test alert message.";
+
+        this.builder.setAlertTitle(alertTitle);
+
+        {
+            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
+
+            assertEquals(alertTitle, alert.get("title"));
+        }
+    }
+
+    @Test
+    public void testSetLocalizedAlertTitle() {
+        final String localizedAlertTitleKey = "alert.title";
+
+        this.builder.setLocalizedAlertTitle(localizedAlertTitleKey, null);
+
+        {
+            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
+
+            assertEquals(localizedAlertTitleKey, alert.get("title-loc-key"));
+        }
+    }
+
     @Test(expected = IllegalStateException.class)
     public void testSetAlertTitleWithExistingLocalizedAlertTitle() {
         this.builder.setLocalizedAlertTitle("Test", null);
@@ -178,6 +159,69 @@ public class ApnsPayloadBuilderTest {
     public void testSetLocalizedAlertTitleWithExistingAlertTitle() {
         this.builder.setAlertTitle("Test");
         this.builder.setLocalizedAlertTitle("Test", null);
+    }
+
+    @Test
+    public void testSetAlertSubtitle() {
+        final String alertSubtitle = "This is a test alert message.";
+
+        this.builder.setAlertSubtitle(alertSubtitle);
+
+        {
+            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
+
+            assertEquals(alertSubtitle, alert.get("subtitle"));
+        }
+    }
+
+    @Test
+    public void testSetLocalizedAlertSubitle() {
+        final String localizedAlertSubtitleKey = "alert.subtitle";
+
+        this.builder.setLocalizedAlertSubtitle(localizedAlertSubtitleKey);
+
+        {
+            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
+
+            assertEquals(localizedAlertSubtitleKey, alert.get("subtitle-loc-key"));
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testSetAlertSubtitleWithExistingLocalizedAlertSubtitle() {
+        this.builder.setLocalizedAlertSubtitle("Test");
+        this.builder.setAlertSubtitle("Test");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testSetLocalizedAlertSubtitleWithExistingAlertSubtitle() {
+        this.builder.setAlertSubtitle("Test");
+        this.builder.setLocalizedAlertSubtitle("Test");
+    }
+
+    @Test
+    public void testSetAlertTitleAndBody() {
+        final String alertTitle = "This is a short alert title";
+        final String alertBody = "This is a longer alert body";
+
+        this.builder.setAlertBody(alertBody);
+        this.builder.setAlertTitle(alertTitle);
+
+        {
+            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
+
+            assertEquals(alertTitle, alert.get("title"));
+            assertEquals(alertBody, alert.get("body"));
+        }
     }
 
     @Test


### PR DESCRIPTION
This builds on the work by @ScienJus in #322. Beyond the initial changes (which added `subtitle` and `mutable-content`), this adds some docs and adds support for localized subtitles. Unfortunately, none of this is officially documented yet, so we just have to take our best guess.