### PR TITLE
Add a backpressure mechanism for channel writes

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientBuilder.java
@@ -34,6 +34,8 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLException;
 
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.WriteBufferWaterMark;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,6 +87,9 @@ public class ApnsClientBuilder {
 
     private Long gracefulShutdownTimeout;
     private TimeUnit gracefulShutdownTimeoutUnit;
+
+    private ByteBufAllocator byteBufferAllocator;
+    private WriteBufferWaterMark channelWriteBufferWaterMark;
 
     private static final Logger log = LoggerFactory.getLogger(ApnsClientBuilder.class);
 
@@ -349,6 +354,34 @@ public class ApnsClientBuilder {
     }
 
     /**
+     * Sets the buffer allocator for the underlying netty channel
+     *
+     * @param byteBufferAllocator the buffer allocator to use for the underlying netty channel
+     *
+     * @return a reference to this builder
+     *
+     * @since 0.9
+     */
+    public ApnsClientBuilder setByteBufferAllocator(ByteBufAllocator byteBufferAllocator) {
+        this.byteBufferAllocator = byteBufferAllocator;
+        return this;
+    }
+
+    /**
+     * Sets the buffer usage watermark range for the underlying netty channel
+     *
+     * @param writeBufferWatermark the watermark range used in the underlying netty channel
+     *
+     * @return a reference to this builder
+     *
+     * @since 0.9
+     */
+    public ApnsClientBuilder setChannelWriteBufferWatermark(WriteBufferWaterMark writeBufferWatermark) {
+        this.channelWriteBufferWaterMark = writeBufferWatermark;
+        return this;
+    }
+
+    /**
      * Constructs a new {@link ApnsClient} with the previously-set configuration.
      *
      * @return a new ApnsClient instance with the previously-set configuration
@@ -414,6 +447,14 @@ public class ApnsClientBuilder {
 
         if (this.gracefulShutdownTimeout != null) {
             apnsClient.setGracefulShutdownTimeout(this.gracefulShutdownTimeoutUnit.toMillis(this.gracefulShutdownTimeout));
+        }
+
+        if (this.byteBufferAllocator != null) {
+            apnsClient.setBufferAllocator(byteBufferAllocator);
+        }
+
+        if (this.channelWriteBufferWaterMark != null) {
+            apnsClient.setChannelWriteBufferWatermark(channelWriteBufferWaterMark);
         }
 
         return apnsClient;

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ClientBusyException.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ClientBusyException.java
@@ -1,0 +1,49 @@
+/* Copyright (c) 2013-2016 RelayRides
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE. */
+
+package com.relayrides.pushy.apns;
+
+/**
+ * An exception thrown to indicate that a notification could not be sent because the client was busy. This is intended
+ * to signal backpressure from the channel associated with this client
+ *
+ * @author <a href="https://github.com/stepheno">Oskar Stephens</a>
+ *
+ * @since 0.9
+ */
+public class ClientBusyException extends IllegalStateException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with no message.
+     */
+    public ClientBusyException() {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the given message.
+     *
+     * @param message a short, human-readable explanation of the cause of this exception
+     */
+    public ClientBusyException(final String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
* Checks the status of `Channel.isWritable()` before attempting to write a
notification to the channel. If `isWritable()` returns false, return a new failed
future with a cause of `ClientBusyException`. The presence of this exception is
a signal to back off write attempts until the underlying channel has sucessfully returned
to its low water mark
* Adds `ApnsClientBuilder#setChannelWriteBufferWatermark` for setting
 the channel watermark levels
* Adds `ApnsClientBuilder#setByteBufferAllocator` for setting the buffer
 allocator of the netty channel