### PR TITLE
Prefer dictionary representation for alerts (closes #390)

### DIFF
--- a/pushy/src/test/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -61,7 +61,16 @@ public class ApnsPayloadBuilderTest {
         {
             final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
 
-            // The alert property should be a string if all we're specifying is a literal alert message
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
+
+            assertEquals(alertBody, alert.get("body"));
+        }
+
+        this.builder.setPreferStringRepresentationForAlerts(true);
+
+        {
+            final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
             assertEquals(alertBody, aps.get("alert"));
         }
 
@@ -410,7 +419,10 @@ public class ApnsPayloadBuilderTest {
         this.builder.setAlertBody(shortAlertMessage);
         final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithMaximumLength(Integer.MAX_VALUE));
 
-        assertEquals(shortAlertMessage, aps.get("alert"));
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
+
+        assertEquals(shortAlertMessage, alert.get("body"));
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
As discussed in #390, APNs now prefers that we send simple alerts as dictionaries rather than strings. There was some discussion of adding an optional "represent as string" flag, which would allow us to save 8 bytes out of a 4096-byte payload in some cases. My wager is that the complexity just isn't worth it, though.