### PR TITLE
Drop superfluous connection voodoo

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -253,19 +253,11 @@ public class ApnsClient {
                             context.pipeline().addLast(new IdleStateHandler(0, 0, PING_IDLE_TIME_MILLIS, TimeUnit.MILLISECONDS));
                             context.pipeline().addLast(apnsClientHandler);
 
-                            // Add this to the end of the queue so any events enqueued by the client handler happen
-                            // before we declare victory.
-                            context.channel().eventLoop().submit(new Runnable() {
+                            final ChannelPromise connectionReadyPromise = ApnsClient.this.connectionReadyPromise;
 
-                                @Override
-                                public void run() {
-                                    final ChannelPromise connectionReadyPromise = ApnsClient.this.connectionReadyPromise;
-
-                                    if (connectionReadyPromise != null) {
-                                        connectionReadyPromise.trySuccess();
-                                    }
-                                }
-                            });
+                            if (connectionReadyPromise != null) {
+                                connectionReadyPromise.trySuccess();
+                            }
                         } else {
                             log.error("Unexpected protocol: {}", protocol);
                             context.close();

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -271,17 +271,6 @@ public class ApnsClient {
                             context.close();
                         }
                     }
-
-                    @Override
-                    protected void handshakeFailure(final ChannelHandlerContext context, final Throwable cause) throws Exception {
-                        final ChannelPromise connectionReadyPromise = ApnsClient.this.connectionReadyPromise;
-
-                        if (connectionReadyPromise != null) {
-                            connectionReadyPromise.tryFailure(cause);
-                        }
-
-                        super.handshakeFailure(context, cause);
-                    }
                 });
             }
         });

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -259,8 +259,7 @@ public class ApnsClient {
                                 connectionReadyPromise.trySuccess();
                             }
                         } else {
-                            log.error("Unexpected protocol: {}", protocol);
-                            context.close();
+                            throw new IllegalArgumentException("Unexpected protocol: " + protocol);
                         }
                     }
                 });

--- a/pushy/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
+++ b/pushy/src/test/java/com/relayrides/pushy/apns/ApnsClientTest.java
@@ -305,6 +305,19 @@ public class ApnsClientTest {
     }
 
     @Test
+    public void testConnectToUntrustedServer() throws Exception {
+        final ApnsClient cautiousClient = new ApnsClientBuilder()
+                .setEventLoopGroup(EVENT_LOOP_GROUP)
+                .build();
+
+        final Future<Void> connectFuture = cautiousClient.connect(HOST, PORT).await();
+
+        assertFalse(connectFuture.isSuccess());
+
+        cautiousClient.disconnect().await();
+    }
+
+    @Test
     public void testReconnectionAfterClose() throws Exception {
         assertTrue(this.tlsAuthenticationClient.isConnected());
         assertTrue(this.tlsAuthenticationClient.disconnect().await().isSuccess());


### PR DESCRIPTION
Over time, a number of weird twists and turns got baked into the `ApnsClient` connection process. On fresh examination, it looks like they don't actually solve any problems right now. It may be that they were never necessary and got superstitiously-coupled with other fixes, or that the problems they once fixed have been resolved upstream. Either way, we can simplify the connection process quite a bit without any loss of functionality by removing some of these wrinkles.