### PR TITLE
Move response promise handling into the client handler

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/PushNotificationAndResponsePromise.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/PushNotificationAndResponsePromise.java
@@ -1,0 +1,29 @@
+package com.relayrides.pushy.apns;
+
+import io.netty.util.concurrent.Promise;
+
+/**
+ * A for-internal-use-only ttuple of a push notification and a {@link Promise} to be notified with the outcome of the
+ * attempt to send the notification.
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ *
+ * @since 0.10
+ */
+class PushNotificationAndResponsePromise {
+    private final ApnsPushNotification pushNotification;
+    private final Promise<PushNotificationResponse<ApnsPushNotification>> responsePromise;
+
+    public PushNotificationAndResponsePromise(final ApnsPushNotification pushNotification, final Promise<PushNotificationResponse<ApnsPushNotification>> responsePromise) {
+        this.pushNotification = pushNotification;
+        this.responsePromise = responsePromise;
+    }
+
+    public ApnsPushNotification getPushNotification() {
+        return this.pushNotification;
+    }
+
+    public Promise<PushNotificationResponse<ApnsPushNotification>> getResponsePromise() {
+        return this.responsePromise;
+    }
+}

--- a/pushy/src/main/java/com/relayrides/pushy/apns/PushNotificationStillPendingException.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/PushNotificationStillPendingException.java
@@ -1,0 +1,13 @@
+package com.relayrides.pushy.apns;
+
+/**
+ * An exception that indicates that an attempt to send a notification failed because the same notification has already
+ * been sent, but has not yet been resolved.
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ *
+ * @since 0.10
+ */
+public class PushNotificationStillPendingException extends Exception {
+    private static final long serialVersionUID = 1L;
+}


### PR DESCRIPTION
This moves response promise handling from the `ApnsClient` into the `ApnsClientHandler`. In the single-channel case, this doesn't make much of a difference, but it does remove an obstacle to multi-channel operation, as discussed in #399.