### PR TITLE
Cancel scheduled reconnect task during disconnecting ApnsClient

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -76,6 +76,7 @@ import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.SucceededFuture;
+import io.netty.util.concurrent.ScheduledFuture;
 
 /**
  * <p>An APNs client sends push notifications to the APNs gateway. Clients authenticate themselves to APNs servers in
@@ -137,6 +138,7 @@ public class ApnsClient {
 
     private volatile ChannelPromise connectionReadyPromise;
     private volatile ChannelPromise reconnectionPromise;
+    private ScheduledFuture scheduledReconnectFuture;
     private long reconnectDelaySeconds = INITIAL_RECONNECT_DELAY_SECONDS;
 
     private final Map<ApnsPushNotification, Promise<PushNotificationResponse<ApnsPushNotification>>> responsePromises = new IdentityHashMap<>();
@@ -469,7 +471,7 @@ public class ApnsClient {
                                 if (ApnsClient.this.reconnectionPromise != null) {
                                     log.debug("Disconnected. Next automatic reconnection attempt in {} seconds.", ApnsClient.this.reconnectDelaySeconds);
 
-                                    future.channel().eventLoop().schedule(new Runnable() {
+                                    scheduledReconnectFuture = future.channel().eventLoop().schedule(new Runnable() {
 
                                         @Override
                                         public void run() {
@@ -986,6 +988,9 @@ public class ApnsClient {
 
         synchronized (this.bootstrap) {
             this.reconnectionPromise = null;
+            if (scheduledReconnectFuture != null) {
+                scheduledReconnectFuture.cancel(true);
+            }
 
             final Future<Void> channelCloseFuture;
 

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -471,7 +471,7 @@ public class ApnsClient {
                                 if (ApnsClient.this.reconnectionPromise != null) {
                                     log.debug("Disconnected. Next automatic reconnection attempt in {} seconds.", ApnsClient.this.reconnectDelaySeconds);
 
-                                    scheduledReconnectFuture = future.channel().eventLoop().schedule(new Runnable() {
+                                    ApnsClient.this.scheduledReconnectFuture = future.channel().eventLoop().schedule(new Runnable() {
 
                                         @Override
                                         public void run() {
@@ -988,8 +988,8 @@ public class ApnsClient {
 
         synchronized (this.bootstrap) {
             this.reconnectionPromise = null;
-            if (scheduledReconnectFuture != null) {
-                scheduledReconnectFuture.cancel(true);
+            if (this.scheduledReconnectFuture != null) {
+                this.scheduledReconnectFuture.cancel(true);
             }
 
             final Future<Void> channelCloseFuture;


### PR DESCRIPTION
Hi, Dear jchambers, 
I think we should cancel the scheduled reconnect task during disconnecting ApnsClient, otherwise we could have a leaking APNs connection which may never be closed. WDYT? 