### PR TITLE
Upgrade to Netty 4.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>1.1.33.Fork24</version>
+                <version>1.1.33.Fork26</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -82,7 +82,7 @@
     </licenses>
 
     <properties>
-        <netty.version>4.1.6.Final</netty.version>
+        <netty.version>4.1.8.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -106,7 +106,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.16</version>
                         <configuration>
-                            <argLine>${argLine.alpnAgent} -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dio.netty.leakDetectionLevel=PARANOID -ea</argLine>
+                            <argLine>${argLine.alpnAgent} -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -ea</argLine>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
This moves everything up to use the latest version of Netty and netty-tcnative. Regrettably, an [upstream design tradeoff](https://github.com/netty/netty/issues/6298) means that running test with aggressive leak detection is no longer viable as a "normal" testing thing. Still, the option is available if we need it on a case-by-case basis.

Sneaking this into 0.9.1 while we're resolving other release issues (see #416).