### PR TITLE
Check for null before checking argument array length (fixes #428)

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilder.java
@@ -161,7 +161,7 @@ public class ApnsPayloadBuilder {
      */
     public ApnsPayloadBuilder setLocalizedAlertMessage(final String localizedAlertKey, final String... alertArguments) {
         this.localizedAlertKey = localizedAlertKey;
-        this.localizedAlertArguments = alertArguments.length > 0 ? alertArguments : null;
+        this.localizedAlertArguments = (alertArguments != null && alertArguments.length > 0) ? alertArguments : null;
 
         this.alertBody = null;
 
@@ -206,7 +206,7 @@ public class ApnsPayloadBuilder {
      */
     public ApnsPayloadBuilder setLocalizedAlertTitle(final String localizedAlertTitleKey, final String... alertTitleArguments) {
         this.localizedAlertTitleKey = localizedAlertTitleKey;
-        this.localizedAlertTitleArguments = alertTitleArguments.length > 0 ? alertTitleArguments : null;
+        this.localizedAlertTitleArguments = (alertTitleArguments != null && alertTitleArguments.length > 0) ? alertTitleArguments : null;
 
         this.alertTitle = null;
 
@@ -250,7 +250,7 @@ public class ApnsPayloadBuilder {
      */
     public ApnsPayloadBuilder setLocalizedAlertSubtitle(final String localizedAlertSubtitleKey, final String... alertSubtitleArguments) {
         this.localizedAlertSubtitleKey = localizedAlertSubtitleKey;
-        this.localizedAlertSubtitleArguments = alertSubtitleArguments.length > 0 ? alertSubtitleArguments : null;
+        this.localizedAlertSubtitleArguments = (alertSubtitleArguments != null && alertSubtitleArguments.length > 0) ? alertSubtitleArguments : null;
 
         this.alertSubtitle = null;
 

--- a/pushy/src/test/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/relayrides/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -108,6 +108,9 @@ public class ApnsPayloadBuilderTest {
             assertNull(alert.get("body"));
         }
 
+        // We're happy here as long as nothing explodes
+        this.builder.setLocalizedAlertMessage(alertKey, null);
+
         final String[] alertArgs = new String[] { "Moose", "helicopter" };
         this.builder.setLocalizedAlertMessage(alertKey, alertArgs);
 
@@ -121,7 +124,6 @@ public class ApnsPayloadBuilderTest {
             assertEquals(alertArgs.length, argsArray.size());
             assertTrue(argsArray.containsAll(java.util.Arrays.asList(alertArgs)));
         }
-
     }
 
     @Test
@@ -160,6 +162,9 @@ public class ApnsPayloadBuilderTest {
             assertNull(alert.get("title-loc-args"));
             assertNull(alert.get("title"));
         }
+
+        // We're happy here as long as nothing explodes
+        this.builder.setLocalizedAlertTitle(localizedAlertTitleKey, null);
 
         final String[] alertArgs = new String[] { "Moose", "helicopter" };
         this.builder.setLocalizedAlertTitle(localizedAlertTitleKey, alertArgs);
@@ -214,6 +219,9 @@ public class ApnsPayloadBuilderTest {
             assertNull(alert.get("subtitle-loc-args"));
             assertNull(alert.get("subtitle"));
         }
+
+        // We're happy here as long as nothing explodes
+        this.builder.setLocalizedAlertSubtitle(subtitleKey, null);
 
         final String[] subtitleArgs = new String[] { "Moose", "helicopter" };
         this.builder.setLocalizedAlertSubtitle(subtitleKey, subtitleArgs);


### PR DESCRIPTION
Oops. This should fix the embarrassing `NullPointerException` reported in #428.