### PR TITLE
Drop write timeout

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -30,7 +30,6 @@ import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.timeout.IdleStateHandler;
-import io.netty.handler.timeout.WriteTimeoutHandler;
 import io.netty.resolver.DefaultAddressResolverGroup;
 import io.netty.resolver.NoopAddressResolverGroup;
 import io.netty.util.concurrent.*;
@@ -96,7 +95,6 @@ public class ApnsClient {
 
     private final ApnsSigningKey signingKey;
 
-    private long writeTimeoutMillis = DEFAULT_WRITE_TIMEOUT_MILLIS;
     private Long gracefulShutdownTimeoutMillis;
 
     private volatile ChannelPromise connectionReadyPromise;
@@ -106,13 +104,6 @@ public class ApnsClient {
 
     private ApnsClientMetricsListener metricsListener = new NoopMetricsListener();
     private final AtomicLong nextNotificationId = new AtomicLong(0);
-
-    /**
-     * The default write timeout, in milliseconds.
-     *
-     * @since 0.6
-     */
-    public static final long DEFAULT_WRITE_TIMEOUT_MILLIS = 20_000;
 
     /**
      * The hostname for the production APNs gateway.
@@ -181,10 +172,6 @@ public class ApnsClient {
 
                 if (proxyHandlerFactory != null) {
                     pipeline.addFirst(proxyHandlerFactory.createProxyHandler());
-                }
-
-                if (ApnsClient.this.writeTimeoutMillis > 0) {
-                    pipeline.addLast(new WriteTimeoutHandler(ApnsClient.this.writeTimeoutMillis, TimeUnit.MILLISECONDS));
                 }
 
                 pipeline.addLast(sslContext.newHandler(channel.alloc()));
@@ -271,28 +258,6 @@ public class ApnsClient {
     protected void setProxyHandlerFactory(final ProxyHandlerFactory proxyHandlerFactory) {
         this.proxyHandlerFactory = proxyHandlerFactory;
         this.bootstrap.resolver(proxyHandlerFactory == null ? DefaultAddressResolverGroup.INSTANCE : NoopAddressResolverGroup.INSTANCE);
-    }
-
-    /**
-     * <p>Sets the write timeout for this client. If an attempt to send a notification to the APNs server takes longer
-     * than the given timeout, the connection will be closed (and automatically reconnected later). Note that write
-     * timeouts refer to the amount of time taken to <em>send</em> a notification to the server, and not the time taken
-     * by the server to process and respond to a notification.</p>
-     *
-     * <p>Write timeouts should generally be set before starting a connection attempt. Changes to a client's write
-     * timeout will take effect after the next connection attempt; changes made to an already-connected client will have
-     * no immediate effect.</p>
-     *
-     * <p>By default, clients have a write timeout of
-     * {@value com.relayrides.pushy.apns.ApnsClient#DEFAULT_WRITE_TIMEOUT_MILLIS} milliseconds.</p>
-     *
-     * @param writeTimeoutMillis the write timeout for this client in milliseconds; if zero, write attempts will never
-     * time out
-     *
-     * @since 0.6
-     */
-    protected void setWriteTimeout(final long writeTimeoutMillis) {
-        this.writeTimeoutMillis = writeTimeoutMillis;
     }
 
     /**

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClient.java
@@ -143,7 +143,6 @@ public class ApnsClient {
 
     private static final long INITIAL_RECONNECT_DELAY_SECONDS = 1; // second
     private static final long MAX_RECONNECT_DELAY_SECONDS = 60; // seconds
-    static final int PING_IDLE_TIME_MILLIS = 60_000; // milliseconds
 
     private static final Logger log = LoggerFactory.getLogger(ApnsClient.class);
 
@@ -200,7 +199,7 @@ public class ApnsClient {
                                 }
                             }
 
-                            context.pipeline().addLast(new IdleStateHandler(0, 0, PING_IDLE_TIME_MILLIS, TimeUnit.MILLISECONDS));
+                            context.pipeline().addLast(new IdleStateHandler(0, 0, ApnsClientHandler.PING_IDLE_TIME_MILLIS, TimeUnit.MILLISECONDS));
                             context.pipeline().addLast(apnsClientHandler);
 
                             final ChannelPromise connectionReadyPromise = ApnsClient.this.connectionReadyPromise;

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientBuilder.java
@@ -69,9 +69,6 @@ public class ApnsClientBuilder {
     private Long connectionTimeout;
     private TimeUnit connectionTimeoutUnit;
 
-    private Long writeTimeout;
-    private TimeUnit writeTimeoutUnit;
-
     private Long gracefulShutdownTimeout;
     private TimeUnit gracefulShutdownTimeoutUnit;
 
@@ -330,29 +327,6 @@ public class ApnsClientBuilder {
     }
 
     /**
-     * <p>Sets the write timeout for the client to build. If an attempt to send a notification to the APNs server takes
-     * longer than the given timeout, the connection will be closed (and automatically reconnected later). Note that
-     * write timeouts refer to the amount of time taken to <em>send</em> a notification to the server, and not the time
-     * taken by the server to process and respond to a notification.</p>
-     *
-     * <p>By default, clients have a write timeout of
-     * {@value com.relayrides.pushy.apns.ApnsClient#DEFAULT_WRITE_TIMEOUT_MILLIS} milliseconds.</p>
-     *
-     * @param writeTimeout the write timeout for the client under construction
-     * @param timeoutUnit the time unit for the given timeout
-     *
-     * @return a reference to this builder
-     *
-     * @since 0.8
-     */
-    public ApnsClientBuilder setWriteTimeout(final long writeTimeout, final TimeUnit timeoutUnit) {
-        this.writeTimeout = writeTimeout;
-        this.writeTimeoutUnit = timeoutUnit;
-
-        return this;
-    }
-
-    /**
      * Sets the amount of time clients should wait for in-progress requests to complete before closing a connection
      * during a graceful shutdown.
      *
@@ -425,10 +399,6 @@ public class ApnsClientBuilder {
 
         if (this.connectionTimeout != null) {
             apnsClient.setConnectionTimeout((int) this.connectionTimeoutUnit.toMillis(this.connectionTimeout));
-        }
-
-        if (this.writeTimeout != null) {
-            apnsClient.setWriteTimeout(this.writeTimeoutUnit.toMillis(this.writeTimeout));
         }
 
         if (this.gracefulShutdownTimeout != null) {

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
@@ -53,10 +53,10 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
 
     private final String authority;
 
-    private long nextPingId = new Random().nextLong();
     private ScheduledFuture<?> pingTimeoutFuture;
 
-    private static final int PING_TIMEOUT = 30; // seconds
+    static final int PING_IDLE_TIME_MILLIS = 60_000; // milliseconds
+    private static final int PING_TIMEOUT_MILLIS = PING_IDLE_TIME_MILLIS / 2;
 
     private static final String APNS_PATH_PREFIX = "/3/device/";
     private static final AsciiString APNS_EXPIRATION_HEADER = new AsciiString("apns-expiration");
@@ -231,32 +231,30 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
     @Override
     public void userEventTriggered(final ChannelHandlerContext context, final Object event) throws Exception {
         if (event instanceof IdleStateEvent) {
-            assert PING_TIMEOUT < ApnsClient.PING_IDLE_TIME_MILLIS;
-
             log.trace("Sending ping due to inactivity.");
 
-            final ByteBuf pingDataBuffer = context.alloc().ioBuffer(8, 8);
-            pingDataBuffer.writeLong(this.nextPingId++);
+            final ByteBuf pingDataBuffer = context.alloc().ioBuffer(Long.SIZE, Long.SIZE);
+            pingDataBuffer.writeLong(System.currentTimeMillis());
 
             this.encoder().writePing(context, false, pingDataBuffer, context.newPromise()).addListener(new GenericFutureListener<ChannelFuture>() {
 
                 @Override
                 public void operationComplete(final ChannelFuture future) throws Exception {
-                    if (future.isSuccess()) {
-                        ApnsClientHandler.this.pingTimeoutFuture = future.channel().eventLoop().schedule(new Runnable() {
-
-                            @Override
-                            public void run() {
-                                log.debug("Closing channel due to ping timeout.");
-                                future.channel().close();
-                            }
-                        }, PING_TIMEOUT, TimeUnit.SECONDS);
-                    } else {
+                    if (!future.isSuccess()) {
                         log.debug("Failed to write PING frame.", future.cause());
                         future.channel().close();
                     }
                 }
             });
+
+            this.pingTimeoutFuture = context.channel().eventLoop().schedule(new Runnable() {
+
+                @Override
+                public void run() {
+                    log.debug("Closing channel due to ping timeout.");
+                    context.channel().close();
+                }
+            }, PING_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
             this.flush(context);
         }

--- a/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/ApnsClientHandler.java
@@ -30,7 +30,6 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http2.*;
 import io.netty.handler.timeout.IdleStateEvent;
-import io.netty.handler.timeout.WriteTimeoutException;
 import io.netty.util.AsciiString;
 import io.netty.util.concurrent.*;
 import org.slf4j.Logger;
@@ -263,16 +262,6 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
         }
 
         super.userEventTriggered(context, event);
-    }
-
-    @Override
-    public void exceptionCaught(final ChannelHandlerContext context, final Throwable cause) throws Exception {
-        if (cause instanceof WriteTimeoutException) {
-            log.debug("Closing connection due to write timeout.");
-            context.close();
-        } else {
-            log.warn("APNs client pipeline caught an exception.", cause);
-        }
     }
 
     @Override


### PR DESCRIPTION
As discussed in #433, it seems increasingly clear that a write timeout—or at least how we're reacting to a write timeout—isn't very helpful. This change drops write timeouts entirely; we'll replace them with something more helpful in a follow-up pull request.

Two options for a replacement come to mind:

1. We could add a high/low water mark system for unresolved push notifications. We'd allow callers to register listeners when the water marks are crossed, but wouldn't take action beyond that (instead allowing callers to decide how and when to back off).
2. We could add per-notification timeouts. This would be a little more complex, and could lead to weird situations where we'd say a notification had timed out, but it ultimately got accepted by the server.

Opinions from the audience?