### PR TITLE
Update to Netty 4.1.10/netty-tcnative 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>2.0.0.Final</version>
+                <version>2.0.1.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>
@@ -92,7 +92,7 @@
     </licenses>
 
     <properties>
-        <netty.version>4.1.9.Final</netty.version>
+        <netty.version>4.1.10.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
This updates to the latest versions of Netty and netty-tcnative.