### PR TITLE
Drop alpn-api as a dependency

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -45,10 +45,6 @@
             <artifactId>netty-tcnative-boringssl-static</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.alpn</groupId>
-            <artifactId>alpn-api</artifactId>
-        </dependency>
     </dependencies>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -53,14 +53,6 @@
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.alpn</groupId>
-                <artifactId>alpn-api</artifactId>
-                <version>1.1.3.v20160715</version>
-                <!-- Provided by alpn-boot; see
-              http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html#alpn-understanding -->
-                <scope>provided</scope>
-            </dependency>
             <!-- Test dependencies -->
             <dependency>
                 <groupId>junit</groupId>

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -37,10 +37,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.alpn</groupId>
-            <artifactId>alpn-api</artifactId>
-        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
It appears that we don't need it now that we depend on netty-tcnative by default.