### PR TITLE
Restore Travis CI hostname workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
+# Workaround for Travis CI issue 5227, which results in a buffer overflow
+# caused by Java when running the build on OpenJDK.
+# https://github.com/travis-ci/travis-ci/issues/5227
+before_install:
+    - cat /etc/hosts # optionally check the content *before*
+    - sudo hostname "$(hostname | cut -c1-63)"
+    - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+    - cat /etc/hosts # optionally check the content *after*
 language: java
 jdk:
     - oraclejdk8


### PR DESCRIPTION
A while back, we added a workaround for some weird Travis CI issues. Travis fixed those issues upstream, and so we removed the workaround. Now those issues are back, and it's time to un-remove the workaround.

This has all happened before and this will all happen again.