### PR TITLE
Use reference-counted native SSL provider

### DIFF
--- a/pushy/src/main/java/com/relayrides/pushy/apns/SslUtil.java
+++ b/pushy/src/main/java/com/relayrides/pushy/apns/SslUtil.java
@@ -27,7 +27,7 @@ class SslUtil {
         if (OpenSsl.isAvailable()) {
             if (OpenSsl.isAlpnSupported()) {
                 log.info("Native SSL provider is available and supports ALPN; will use native provider.");
-                sslProvider = SslProvider.OPENSSL;
+                sslProvider = SslProvider.OPENSSL_REFCNT;
             } else {
                 log.info("Native SSL provider is available, but does not support ALPN; will use JDK SSL provider.");
                 sslProvider = SslProvider.JDK;


### PR DESCRIPTION
This change moves us to a reference-counted flavor of the native SSL provider when possible. This should reduce direct memory usage with no a priori downside.