### PR TITLE
Update to Netty 4.1.11/netty-tcnative 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>2.0.0.Final</version>
+                <version>2.0.1.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>
@@ -84,7 +84,7 @@
     </licenses>
 
     <properties>
-        <netty.version>4.1.9.Final</netty.version>
+        <netty.version>4.1.11.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
This is a follow-up to #460 now that [Netty 4.1.11 is out](http://netty.io/news/2017/05/12/4-0-47-Final-4-1-11-Final.html) and is working with Java 7 again.