### PR TITLE
Move channel closure logic from `close` to `channelInactive`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
-# Workaround for Travis CI issue 5227, which results in a buffer overflow
-# caused by Java when running the build on OpenJDK.
-# https://github.com/travis-ci/travis-ci/issues/5227
-before_install:
-    - cat /etc/hosts # optionally check the content *before*
-    - sudo hostname "$(hostname | cut -c1-63)"
-    - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
-    - cat /etc/hosts # optionally check the content *after*
 language: java
+dist: trusty
+sudo: required
 jdk:
     - oraclejdk8
     - oraclejdk7

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
@@ -274,11 +274,11 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
     }
 
     @Override
-    public void close(final ChannelHandlerContext context, final ChannelPromise promise) throws Exception {
-        super.close(context, promise);
+    public void channelInactive(final ChannelHandlerContext context) {
+        assert context.executor().inEventLoop();
 
         final ClientNotConnectedException clientNotConnectedException =
-                new ClientNotConnectedException("Client disconnected unexpectedly.");
+                new ClientNotConnectedException("Client disconnected before receiving a response from the APNs server.");
 
         for (final Promise<PushNotificationResponse<ApnsPushNotification>> responsePromise : this.responsePromises.values()) {
             responsePromise.tryFailure(clientNotConnectedException);


### PR DESCRIPTION
This change moves the "fail all unresolved notifications" logic from the channel handler's `close` method to the `channelInactive` method. This should solve two problems at once:

1. `close` appears to be called only when we deliberately/cleanly close the channel, and it won't be called in cases of abnormal channel closure. `channelInactive`, on the other hand, should be called regardless. This fixes #480.
2. `close` can be called from outside of the channel's event loop, which means that past assumptions about serial executions were wrong and we could wind up with concurrent modification issues. Moving to `channelInactive` puts everything inside the event loop, which resolves #479.