### PR TITLE
Retry notifications on stream reset (fixes #476)

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
@@ -343,7 +343,14 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
     }
 
     @Override
-    public void onRstStreamRead(final ChannelHandlerContext ctx, final int streamId, final long errorCode) throws Http2Exception {
+    public void onRstStreamRead(final ChannelHandlerContext context, final int streamId, final long errorCode) throws Http2Exception {
+        if (errorCode == Http2Error.REFUSED_STREAM.code()) {
+            // This can happen if the server reduces MAX_CONCURRENT_STREAMS while we already have notifications in
+            // flight. We may get multiple RST_STREAM frames per stream since we send multiple frames (HEADERS and
+            // DATA) for each push notification, but we should only get one REFUSED_STREAM error; the rest should all be
+            // STREAM_CLOSED.
+            this.retryPushNotificationFromStream(context, streamId);
+        }
     }
 
     @Override


### PR DESCRIPTION
As discussed in #476, production APNs servers seem to drastically reduce `MAX_CONCURRENT_STREAMS` when something goes wrong (particularly when an authentication token expires). The reduction in streams means that streams that were already in flight might get refused with an `RST_STREM` frame from the server.

This change retries notifications when we get an `RST_STREAM` frame from the server, which fixes #476.