### PR TITLE
Temporarily revert to the finalized (non-reference-counted) native SSL provider (fixes #478)

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/SslUtil.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/SslUtil.java
@@ -49,7 +49,7 @@ class SslUtil {
         if (OpenSsl.isAvailable()) {
             if (OpenSsl.isAlpnSupported()) {
                 log.info("Native SSL provider is available and supports ALPN; will use native provider.");
-                sslProvider = SslProvider.OPENSSL_REFCNT;
+                sslProvider = SslProvider.OPENSSL;
             } else {
                 log.info("Native SSL provider is available, but does not support ALPN; will use JDK SSL provider.");
                 sslProvider = SslProvider.JDK;


### PR DESCRIPTION
As discussed in #478, our switch to Netty's reference-counted native SSL provider wasn't quite correct and has resulted in some memory leaks. This change goes back to the old non-reference-counted provider, but the longer-term plan is still to restructure things so we can more effectively manage reference-counted SSL resources and move back to the reference-counted provider.