### PR TITLE
Moooooooore Travis updates!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,11 @@ before_install:
 language: java
 jdk:
     - oraclejdk8
-    - oraclejdk7
     - openjdk7
 env:
     - PUSHY_SSL_PROVIDER=jdk
     - PUSHY_SSL_PROVIDER=native
 matrix:
     exclude:
-        - jdk: oraclejdk7
-          env: PUSHY_SSL_PROVIDER=jdk
         - jdk: openjdk7
           env: PUSHY_SSL_PROVIDER=jdk


### PR DESCRIPTION
According to https://github.com/travis-ci/travis-ci/issues/7884 (which is still open, so maybe it isn't final?), it looks like Travis has dropped support for `oraclejdk7`. This pull request drops `oraclejdk7` from our testing matrix. That doesn't feel great, but we still get Java 7 coverage via `openjdk7` and still get Oracle JDK coverage via `oraclejdk8`.