### PR TITLE
Update to Netty 4.1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,3 @@
-# Workaround for Travis CI issue 5227, which results in a buffer overflow
-# caused by Java when running the build on OpenJDK.
-# https://github.com/travis-ci/travis-ci/issues/5227
-before_install:
-    - cat /etc/hosts # optionally check the content *before*
-    - sudo hostname "$(hostname | cut -c1-63)"
-    - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
-    - cat /etc/hosts # optionally check the content *after*
 language: java
 jdk:
     - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>2.0.3.Final</version>
+                <version>2.0.5.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>
@@ -106,7 +106,7 @@
     </licenses>
 
     <properties>
-        <netty.version>4.1.12.Final</netty.version>
+        <netty.version>4.1.14.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
I'd like to take this all the way up to 4.1.15, but going straight to 4.1.15 led to failing/hanging tests, and so some more investigation is needed. I suspect this has something to do with the new HTTP/2 sub-channel API, but am not yet sure.