### PR TITLE
Restore reference-counted SSL providers

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsChannelPool.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsChannelPool.java
@@ -29,6 +29,7 @@ import io.netty.util.concurrent.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.Queue;
@@ -230,6 +231,13 @@ class ApnsChannelPool {
      * @return a {@code Future} that will be completed when all resources held by this pool have been released
      */
     public Future<Void> close() {
-        return this.allChannels.close();
+        return this.allChannels.close().addListener(new GenericFutureListener<Future<Void>>() {
+            @Override
+            public void operationComplete(final Future<Void> future) throws Exception {
+                if (ApnsChannelPool.this.channelFactory instanceof Closeable) {
+                    ((Closeable) ApnsChannelPool.this.channelFactory).close();
+                }
+            }
+        });
     }
 }

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
@@ -271,7 +271,7 @@ public class ApnsClient {
 
         // Since we're (maybe) going to clobber the main event loop group, we should have this promise use the global
         // event executor to notify listeners.
-        final Promise<Void> disconnectPromise = new DefaultPromise<>(GlobalEventExecutor.INSTANCE);
+        final Promise<Void> closePromise = new DefaultPromise<>(GlobalEventExecutor.INSTANCE);
 
         this.channelPool.close().addListener(new GenericFutureListener<Future<Void>>() {
 
@@ -282,15 +282,15 @@ public class ApnsClient {
 
                         @Override
                         public void operationComplete(final Future future) throws Exception {
-                            disconnectPromise.trySuccess(null);
+                            closePromise.trySuccess(null);
                         }
                     });
                 } else {
-                    disconnectPromise.trySuccess(null);
+                    closePromise.trySuccess(null);
                 }
             }
         });
 
-        return disconnectPromise;
+        return closePromise;
     }
 }

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientBuilder.java
@@ -30,6 +30,7 @@ import io.netty.handler.ssl.*;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
+import io.netty.util.ReferenceCounted;
 
 import javax.net.ssl.SSLException;
 import java.io.File;
@@ -512,8 +513,15 @@ public class ApnsClientBuilder {
             sslContext = sslContextBuilder.build();
         }
 
-        return new ApnsClient(this.apnsServerAddress, sslContext, this.signingKey, this.proxyHandlerFactory,
-                this.connectionTimeoutMillis, this.idlePingIntervalMillis, this.gracefulShutdownTimeoutMillis,
-                this.concurrentConnections, this.metricsListener, this.eventLoopGroup);
+        final ApnsClient client = new ApnsClient(this.apnsServerAddress, sslContext, this.signingKey,
+                this.proxyHandlerFactory, this.connectionTimeoutMillis, this.idlePingIntervalMillis,
+                this.gracefulShutdownTimeoutMillis, this.concurrentConnections, this.metricsListener,
+                this.eventLoopGroup);
+
+        if (sslContext instanceof ReferenceCounted) {
+            ((ReferenceCounted) sslContext).release();
+        }
+
+        return client;
     }
 }

--- a/pushy/src/main/java/com/turo/pushy/apns/MockApnsServerBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/MockApnsServerBuilder.java
@@ -28,6 +28,7 @@ import io.netty.handler.ssl.*;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
+import io.netty.util.ReferenceCounted;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -314,6 +315,10 @@ public class MockApnsServerBuilder {
         final MockApnsServer server = new MockApnsServer(sslContext, this.eventLoopGroup);
         server.setEmulateInternalErrors(this.emulateInternalErrors);
         server.setEmulateExpiredFirstToken(this.emulateExpiredFirstToken);
+
+        if (sslContext instanceof ReferenceCounted) {
+            ((ReferenceCounted) sslContext).release();
+        }
 
         return server;
     }

--- a/pushy/src/main/java/com/turo/pushy/apns/SslUtil.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/SslUtil.java
@@ -49,7 +49,7 @@ class SslUtil {
         if (OpenSsl.isAvailable()) {
             if (OpenSsl.isAlpnSupported()) {
                 log.info("Native SSL provider is available and supports ALPN; will use native provider.");
-                sslProvider = SslProvider.OPENSSL;
+                sslProvider = SslProvider.OPENSSL_REFCNT;
             } else {
                 log.info("Native SSL provider is available, but does not support ALPN; will use JDK SSL provider.");
                 sslProvider = SslProvider.JDK;

--- a/pushy/src/test/java/com/turo/pushy/apns/ApnsClientBuilderTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/ApnsClientBuilderTest.java
@@ -57,22 +57,26 @@ public class ApnsClientBuilderTest {
     @Test
     public void testBuildClientWithPasswordProtectedP12File() throws Exception {
         // We're happy here as long as nothing throws an exception
-        new ApnsClientBuilder()
+        final ApnsClient client = new ApnsClientBuilder()
                 .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
                 .setEventLoopGroup(EVENT_LOOP_GROUP)
                 .setClientCredentials(new File(this.getClass().getResource(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME).toURI()), KEYSTORE_PASSWORD)
                 .build();
+
+        client.close().await();
     }
 
     @Test
     public void testBuildClientWithPasswordProtectedP12InputStream() throws Exception {
         // We're happy here as long as nothing throws an exception
         try (final InputStream p12InputStream = this.getClass().getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
-            new ApnsClientBuilder()
+            final ApnsClient client = new ApnsClientBuilder()
                     .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .build();
+
+            client.close().await();
         }
     }
 
@@ -91,11 +95,13 @@ public class ApnsClientBuilderTest {
             final PrivateKeyEntry privateKeyEntry =
                     P12Util.getFirstPrivateKeyEntryFromP12InputStream(p12InputStream, KEYSTORE_PASSWORD);
 
-            new ApnsClientBuilder()
+            final ApnsClient client = new ApnsClientBuilder()
                     .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .setClientCredentials((X509Certificate) privateKeyEntry.getCertificate(), privateKeyEntry.getPrivateKey(), KEYSTORE_PASSWORD)
                     .build();
+
+            client.close().await();
         }
     }
 
@@ -107,11 +113,13 @@ public class ApnsClientBuilderTest {
             final PrivateKeyEntry privateKeyEntry =
                     P12Util.getFirstPrivateKeyEntryFromP12InputStream(p12InputStream, KEYSTORE_PASSWORD);
 
-            new ApnsClientBuilder()
+            final ApnsClient client = new ApnsClientBuilder()
                     .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .setClientCredentials((X509Certificate) privateKeyEntry.getCertificate(), privateKeyEntry.getPrivateKey(), null)
                     .build();
+
+            client.close().await();
         }
     }
 
@@ -121,11 +129,13 @@ public class ApnsClientBuilderTest {
             final ApnsSigningKey signingKey = ApnsSigningKey.loadFromInputStream(p8InputStream, "TEAM_ID", "KEY_ID");
 
             // We're happy here as long as nothing explodes
-            new ApnsClientBuilder()
+            final ApnsClient client = new ApnsClientBuilder()
                     .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .setSigningKey(signingKey)
                     .build();
+
+            client.close().await();
         }
     }
 


### PR DESCRIPTION
With channel pooling (and the "you must always close the client" rule) introduced in #492, we now have a safe and reliable place to release reference-counted SSL contexts. This means that we can restore reference-counted SSL providers with a high degree of confidence that we're not causing resource leaks.

This closes #502.