### PR TITLE
Use IntObjectMap to cut down on boxing/GC pressure

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
@@ -33,6 +33,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http2.*;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.AsciiString;
+import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.concurrent.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,15 +43,14 @@ import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameListener, Http2Connection.Listener {
 
-    private final Map<Integer, ApnsPushNotification> unattachedPushNotificationsByStreamId = new HashMap<>();
-    private final Map<Integer, Promise<PushNotificationResponse<ApnsPushNotification>>> unattachedResponsePromisesByStreamId = new HashMap<>();
+    private final Map<Integer, ApnsPushNotification> unattachedPushNotificationsByStreamId = new IntObjectHashMap<>();
+    private final Map<Integer, Promise<PushNotificationResponse<ApnsPushNotification>>> unattachedResponsePromisesByStreamId = new IntObjectHashMap<>();
 
     private final Http2Connection.PropertyKey pushNotificationPropertyKey;
     private final Http2Connection.PropertyKey responseHeadersPropertyKey;


### PR DESCRIPTION
This is not the biggest of deals, but we can use a sliiiiiiightly more efficient data structure for tracking push notifications and response promises that have not yet been attached to HTTP/2 streams.

Benchmarks for `ApnsClientBenchmark.testSendNotifications`:

### Before

```
(concurrentConnections)  (notificationCount)  Mode  Cnt  Score   Error  Units
                      1                10000    ss   40  0.329 ± 0.012   s/op
                      4                10000    ss   40  0.345 ± 0.049   s/op
                      8                10000    ss   40  0.321 ± 0.022   s/op
```

### After

```
(concurrentConnections)  (notificationCount)  Mode  Cnt  Score   Error  Units
                      1                10000    ss   40  0.329 ± 0.010   s/op
                      4                10000    ss   40  0.292 ± 0.018   s/op
                      8                10000    ss   40  0.297 ± 0.023   s/op
```

The results are promising, but almost suspiciously so. I might try again with more forks on a better-controlled machine, but I think the moral of the story here is that we're not obviously making things worse.