### PR TITLE
Update to Netty 4.1.16/netty-tcnative 2.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>2.0.5.Final</version>
+                <version>2.0.6.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>
@@ -106,7 +106,7 @@
     </licenses>
 
     <properties>
-        <netty.version>4.1.14.Final</netty.version>
+        <netty.version>4.1.16.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
This takes us up from Netty 4.1.14 to Netty 4.1.16 to pick up the latest bug fixes and pave the way to (maybe?) using the new sub-channel HTTP/2 API.