### PR TITLE
Re-restore reference-counted SSL providers

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsChannelFactory.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsChannelFactory.java
@@ -33,20 +33,26 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.AttributeKey;
+import io.netty.util.ReferenceCounted;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.PromiseNotifier;
 
+import java.io.Closeable;
 import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * An APNs channel factory creates new channels connected to an APNs server. Channels constructed by this factory are
  * intended for use in an {@link ApnsChannelPool}.
  */
-class ApnsChannelFactory implements PooledObjectFactory<Channel> {
+class ApnsChannelFactory implements PooledObjectFactory<Channel>, Closeable {
+
+    private final SslContext sslContext;
+    private final AtomicBoolean hasReleasedSslContext = new AtomicBoolean(false);
 
     private final Bootstrap bootstrapTemplate;
 
@@ -62,6 +68,12 @@ class ApnsChannelFactory implements PooledObjectFactory<Channel> {
                        final ProxyHandlerFactory proxyHandlerFactory, final int connectTimeoutMillis,
                        final long idlePingIntervalMillis, final long gracefulShutdownTimeoutMillis,
                        final InetSocketAddress apnsServerAddress, final EventLoopGroup eventLoopGroup) {
+
+        this.sslContext = sslContext;
+
+        if (this.sslContext instanceof ReferenceCounted) {
+            ((ReferenceCounted) this.sslContext).retain();
+        }
 
         this.bootstrapTemplate = new Bootstrap();
         this.bootstrapTemplate.group(eventLoopGroup);
@@ -206,5 +218,15 @@ class ApnsChannelFactory implements PooledObjectFactory<Channel> {
     public Future<Void> destroy(final Channel channel, final Promise<Void> promise) {
         channel.close().addListener(new PromiseNotifier<>(promise));
         return promise;
+    }
+
+    @Override
+    public void close() {
+
+        if (this.sslContext instanceof ReferenceCounted) {
+            if (this.hasReleasedSslContext.compareAndSet(false, true)) {
+                ((ReferenceCounted) this.sslContext).release();
+            }
+        }
     }
 }

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsChannelPool.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsChannelPool.java
@@ -29,6 +29,7 @@ import io.netty.util.concurrent.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.util.ArrayDeque;
 import java.util.HashSet;
 import java.util.Queue;
@@ -230,6 +231,13 @@ class ApnsChannelPool {
      * @return a {@code Future} that will be completed when all resources held by this pool have been released
      */
     public Future<Void> close() {
-        return this.allChannels.close();
+        return this.allChannels.close().addListener(new GenericFutureListener<Future<Void>>() {
+            @Override
+            public void operationComplete(final Future<Void> future) throws Exception {
+                if (ApnsChannelPool.this.channelFactory instanceof Closeable) {
+                    ((Closeable) ApnsChannelPool.this.channelFactory).close();
+                }
+            }
+        });
     }
 }

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
@@ -271,7 +271,7 @@ public class ApnsClient {
 
         // Since we're (maybe) going to clobber the main event loop group, we should have this promise use the global
         // event executor to notify listeners.
-        final Promise<Void> disconnectPromise = new DefaultPromise<>(GlobalEventExecutor.INSTANCE);
+        final Promise<Void> closePromise = new DefaultPromise<>(GlobalEventExecutor.INSTANCE);
 
         this.channelPool.close().addListener(new GenericFutureListener<Future<Void>>() {
 
@@ -282,15 +282,15 @@ public class ApnsClient {
 
                         @Override
                         public void operationComplete(final Future future) throws Exception {
-                            disconnectPromise.trySuccess(null);
+                            closePromise.trySuccess(null);
                         }
                     });
                 } else {
-                    disconnectPromise.trySuccess(null);
+                    closePromise.trySuccess(null);
                 }
             }
         });
 
-        return disconnectPromise;
+        return closePromise;
     }
 }

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientBuilder.java
@@ -30,6 +30,7 @@ import io.netty.handler.ssl.*;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
+import io.netty.util.ReferenceCounted;
 
 import javax.net.ssl.SSLException;
 import java.io.File;
@@ -512,8 +513,15 @@ public class ApnsClientBuilder {
             sslContext = sslContextBuilder.build();
         }
 
-        return new ApnsClient(this.apnsServerAddress, sslContext, this.signingKey, this.proxyHandlerFactory,
-                this.connectionTimeoutMillis, this.idlePingIntervalMillis, this.gracefulShutdownTimeoutMillis,
-                this.concurrentConnections, this.metricsListener, this.eventLoopGroup);
+        final ApnsClient client = new ApnsClient(this.apnsServerAddress, sslContext, this.signingKey,
+                this.proxyHandlerFactory, this.connectionTimeoutMillis, this.idlePingIntervalMillis,
+                this.gracefulShutdownTimeoutMillis, this.concurrentConnections, this.metricsListener,
+                this.eventLoopGroup);
+
+        if (sslContext instanceof ReferenceCounted) {
+            ((ReferenceCounted) sslContext).release();
+        }
+
+        return client;
     }
 }

--- a/pushy/src/main/java/com/turo/pushy/apns/MockApnsServer.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/MockApnsServer.java
@@ -37,6 +37,7 @@ import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.util.ReferenceCounted;
 import io.netty.util.concurrent.*;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -45,6 +46,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -63,6 +65,9 @@ import java.util.regex.Pattern;
  */
 public class MockApnsServer {
 
+    private final SslContext sslContext;
+    private final AtomicBoolean hasReleasedSslContext = new AtomicBoolean(false);
+
     private final ServerBootstrap bootstrap;
     private final boolean shouldShutDownEventLoopGroup;
 
@@ -79,6 +84,12 @@ public class MockApnsServer {
     public static final long AUTHENTICATION_TOKEN_EXPIRATION_MILLIS = TimeUnit.HOURS.toMillis(1);
 
     protected MockApnsServer(final SslContext sslContext, final EventLoopGroup eventLoopGroup) {
+        this.sslContext = sslContext;
+
+        if (this.sslContext instanceof ReferenceCounted) {
+            ((ReferenceCounted) this.sslContext).retain();
+        }
+
         this.bootstrap = new ServerBootstrap();
 
         if (eventLoopGroup != null) {
@@ -279,14 +290,24 @@ public class MockApnsServer {
 
                 @Override
                 public void operationComplete(final Future future) throws Exception {
-                    assert disconnectFuture instanceof DefaultPromise;
-                    ((DefaultPromise<Void>) disconnectFuture).trySuccess(null);
+                    ((Promise<Void>) disconnectFuture).trySuccess(null);
                 }
             });
         } else {
             // We're done once we've closed all the channels, so we can return the closure future directly.
             disconnectFuture = channelCloseFuture;
         }
+
+        disconnectFuture.addListener(new GenericFutureListener<Future<Void>>() {
+            @Override
+            public void operationComplete(final Future<Void> future) throws Exception {
+                if (MockApnsServer.this.sslContext instanceof ReferenceCounted) {
+                    if (MockApnsServer.this.hasReleasedSslContext.compareAndSet(false, true)) {
+                        ((ReferenceCounted) MockApnsServer.this.sslContext).release();
+                    }
+                }
+            }
+        });
 
         return disconnectFuture;
     }

--- a/pushy/src/main/java/com/turo/pushy/apns/MockApnsServerBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/MockApnsServerBuilder.java
@@ -28,6 +28,7 @@ import io.netty.handler.ssl.*;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
+import io.netty.util.ReferenceCounted;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -314,6 +315,10 @@ public class MockApnsServerBuilder {
         final MockApnsServer server = new MockApnsServer(sslContext, this.eventLoopGroup);
         server.setEmulateInternalErrors(this.emulateInternalErrors);
         server.setEmulateExpiredFirstToken(this.emulateExpiredFirstToken);
+
+        if (sslContext instanceof ReferenceCounted) {
+            ((ReferenceCounted) sslContext).release();
+        }
 
         return server;
     }

--- a/pushy/src/main/java/com/turo/pushy/apns/SslUtil.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/SslUtil.java
@@ -49,7 +49,7 @@ class SslUtil {
         if (OpenSsl.isAvailable()) {
             if (OpenSsl.isAlpnSupported()) {
                 log.info("Native SSL provider is available and supports ALPN; will use native provider.");
-                sslProvider = SslProvider.OPENSSL;
+                sslProvider = SslProvider.OPENSSL_REFCNT;
             } else {
                 log.info("Native SSL provider is available, but does not support ALPN; will use JDK SSL provider.");
                 sslProvider = SslProvider.JDK;

--- a/pushy/src/test/java/com/turo/pushy/apns/ApnsClientBuilderTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/ApnsClientBuilderTest.java
@@ -57,22 +57,26 @@ public class ApnsClientBuilderTest {
     @Test
     public void testBuildClientWithPasswordProtectedP12File() throws Exception {
         // We're happy here as long as nothing throws an exception
-        new ApnsClientBuilder()
+        final ApnsClient client = new ApnsClientBuilder()
                 .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
                 .setEventLoopGroup(EVENT_LOOP_GROUP)
                 .setClientCredentials(new File(this.getClass().getResource(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME).toURI()), KEYSTORE_PASSWORD)
                 .build();
+
+        client.close().await();
     }
 
     @Test
     public void testBuildClientWithPasswordProtectedP12InputStream() throws Exception {
         // We're happy here as long as nothing throws an exception
         try (final InputStream p12InputStream = this.getClass().getResourceAsStream(SINGLE_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
-            new ApnsClientBuilder()
+            final ApnsClient client = new ApnsClientBuilder()
                     .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .build();
+
+            client.close().await();
         }
     }
 
@@ -91,11 +95,13 @@ public class ApnsClientBuilderTest {
             final PrivateKeyEntry privateKeyEntry =
                     P12Util.getFirstPrivateKeyEntryFromP12InputStream(p12InputStream, KEYSTORE_PASSWORD);
 
-            new ApnsClientBuilder()
+            final ApnsClient client = new ApnsClientBuilder()
                     .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .setClientCredentials((X509Certificate) privateKeyEntry.getCertificate(), privateKeyEntry.getPrivateKey(), KEYSTORE_PASSWORD)
                     .build();
+
+            client.close().await();
         }
     }
 
@@ -107,11 +113,13 @@ public class ApnsClientBuilderTest {
             final PrivateKeyEntry privateKeyEntry =
                     P12Util.getFirstPrivateKeyEntryFromP12InputStream(p12InputStream, KEYSTORE_PASSWORD);
 
-            new ApnsClientBuilder()
+            final ApnsClient client = new ApnsClientBuilder()
                     .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .setClientCredentials((X509Certificate) privateKeyEntry.getCertificate(), privateKeyEntry.getPrivateKey(), null)
                     .build();
+
+            client.close().await();
         }
     }
 
@@ -121,11 +129,13 @@ public class ApnsClientBuilderTest {
             final ApnsSigningKey signingKey = ApnsSigningKey.loadFromInputStream(p8InputStream, "TEAM_ID", "KEY_ID");
 
             // We're happy here as long as nothing explodes
-            new ApnsClientBuilder()
+            final ApnsClient client = new ApnsClientBuilder()
                     .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
                     .setEventLoopGroup(EVENT_LOOP_GROUP)
                     .setSigningKey(signingKey)
                     .build();
+
+            client.close().await();
         }
     }
 


### PR DESCRIPTION
It is with considerable embarrassment that I open this pull request. I accidentally merged #515 into the `channel_pool` branch instead of `master`, and so v0.11.0 does _not_ contain reference-counted SSL providers after all. This change rectifies the situation. Again.

Please accept my sincere apologies for the goof.