### PR TITLE
Gracefully handle channel acquisition attempts after channel pools have closed

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsChannelPool.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsChannelPool.java
@@ -89,7 +89,7 @@ class ApnsChannelPool {
      * @param executor the executor on which listeners for acquisition/release promises will be called
      * @param metricsListener an optional listener for metrics describing the performance and behavior of the pool
      */
-    public ApnsChannelPool(final PooledObjectFactory<Channel> channelFactory, final int capacity, final OrderedEventExecutor executor, final ApnsChannelPoolMetricsListener metricsListener) {
+    ApnsChannelPool(final PooledObjectFactory<Channel> channelFactory, final int capacity, final OrderedEventExecutor executor, final ApnsChannelPoolMetricsListener metricsListener) {
         this.channelFactory = channelFactory;
         this.capacity = capacity;
         this.executor = executor;
@@ -111,7 +111,7 @@ class ApnsChannelPool {
      *
      * @see ApnsChannelPool#release(Channel)
      */
-    public Future<Channel> acquire() {
+    Future<Channel> acquire() {
         final Promise<Channel> acquirePromise = new DefaultPromise<>(this.executor);
 
         if (this.executor.inEventLoop()) {
@@ -184,7 +184,7 @@ class ApnsChannelPool {
      *
      * @param channel the channel to return to the pool
      */
-    public void release(final Channel channel) {
+    void release(final Channel channel) {
         if (this.executor.inEventLoop()) {
             this.releaseWithinEventExecutor(channel);
         } else {

--- a/pushy/src/test/java/com/turo/pushy/apns/ApnsChannelPoolTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/ApnsChannelPoolTest.java
@@ -192,4 +192,23 @@ public class ApnsChannelPoolTest {
         assertEquals(1, this.metricsListener.getConnectionsRemoved());
         assertEquals(0, this.metricsListener.getConnectionsFailed());
     }
+
+    @Test
+    public void testAcquireFromClosedPool() throws Exception {
+        this.pool.close().await();
+
+        final Future<Channel> acquireFuture = this.pool.acquire().await();
+        assertFalse(acquireFuture.isSuccess());
+    }
+
+    @Test
+    public void testPendingAcquisitionsDuringPoolClosure() throws Exception {
+        final Future<Channel> firstFuture = this.pool.acquire().await();
+        final Future<Channel> secondFuture = this.pool.acquire();
+
+        this.pool.close().await();
+
+        assertTrue(secondFuture.await(1000));
+        assertFalse(secondFuture.isSuccess());
+    }
 }

--- a/pushy/src/test/java/com/turo/pushy/apns/ApnsChannelPoolTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/ApnsChannelPoolTest.java
@@ -204,11 +204,14 @@ public class ApnsChannelPoolTest {
     @Test
     public void testPendingAcquisitionsDuringPoolClosure() throws Exception {
         final Future<Channel> firstFuture = this.pool.acquire().await();
-        final Future<Channel> secondFuture = this.pool.acquire();
+
+        assertTrue(firstFuture.isSuccess());
+
+        final Future<Channel> pendingFuture = this.pool.acquire();
 
         this.pool.close().await();
 
-        assertTrue(secondFuture.await(1000));
-        assertFalse(secondFuture.isSuccess());
+        assertTrue(pendingFuture.await(1000));
+        assertFalse(pendingFuture.isSuccess());
     }
 }


### PR DESCRIPTION
This fixes #524 by (as @Tielancy suggested) explicitly keeping track of a connection pool's closure state and failing acquisition attempts when and after a pool closes. The changes are easiest to read with [whitespace-only changes hidden](https://github.com/relayrides/pushy/pull/527/files?w=1).