### PR TITLE
Fix outdated docs for `ApnsClient#close()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,14 +154,11 @@ An example:
 
 ```java
 final ApnsClient apnsClient = new ApnsClientBuilder()
-        .setSigningKey(ApnsSigningKey.loadFromPkcs8File(new File("/path/to/key.p8"),
-                "TEAMID1234", "KEYID67890"))
-        .setProxyHandlerFactory(new Socks5ProxyHandlerFactory(
-            new InetSocketAddress("my.proxy.com", 1080), "username", "password"))
-        .build();
-
-final Future<Void> connectFuture = apnsClient.connect(ApnsClient.DEVELOPMENT_APNS_HOST);
-connectFuture.await();
+    .setSigningKey(ApnsSigningKey.loadFromPkcs8File(new File("/path/to/key.p8"),
+            "TEAMID1234", "KEYID67890"))
+    .setProxyHandlerFactory(new Socks5ProxyHandlerFactory(
+        new InetSocketAddress("my.proxy.com", 1080), "username", "password"))
+    .build();
 ```
 
 ## Logging

--- a/pushy/src/test/java/com/turo/pushy/apns/ApnsClientTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/ApnsClientTest.java
@@ -313,7 +313,13 @@ public class ApnsClientTest {
     }
 
     @Test
-    public void testReconnectionAfterClose() throws Exception {
+    public void testRepeatedClose() throws Exception {
+        assertTrue(this.tokenAuthenticationClient.close().await().isSuccess());
+        assertTrue(this.tokenAuthenticationClient.close().await().isSuccess());
+    }
+
+    @Test
+    public void testSendNotificationAfterClose() throws Exception {
         this.tokenAuthenticationClient.close().await();
 
         final SimpleApnsPushNotification pushNotification =


### PR DESCRIPTION
This fixes two documentation issues reported on the mailing list:

1. [`ApnsClient#close()` docs refer to old, single-connection model](https://groups.google.com/d/msg/pushy-apns/1bypS48Eao8/QFO2Z08sCAAJ)
2. [The README still makes reference to the old `ApnsClient#connect()` method](https://groups.google.com/d/msg/pushy-apns/z9T4R5BThPY/iVdjMuV-CAAJ)

I added a couple tests and simplified some closure logic while I was at it. This fixes #528.