### PR TITLE
Print names of tests when running tests via Maven

### DIFF
--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -133,6 +133,12 @@
                         <version>2.16</version>
                         <configuration>
                             <argLine>${argLine.alpnAgent} -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -ea</argLine>
+                            <properties>
+                                <property>
+                                    <name>listener</name>
+                                    <value>com.turo.pushy.apns.PrintTestNameRunListener</value>
+                                </property>
+                            </properties>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pushy/src/test/java/com/turo/pushy/apns/PrintTestNameRunListener.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/PrintTestNameRunListener.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2013-2017 Turo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.turo.pushy.apns;
+
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunListener;
+
+/**
+ * A simple test run listener that prints the names of tests when they start. When running tests via Maven, this can be
+ * helpful for understanding where console output is coming from or, in the unlikely event of a test hang, which test
+ * stalled out.
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ */
+public class PrintTestNameRunListener extends RunListener {
+
+    @Override
+    public void testStarted(final Description description) throws Exception {
+        System.out.println("\t" + description.getMethodName());
+    }
+}


### PR DESCRIPTION
This change introduces a very simple [`RunListener`](http://junit.org/junit4/javadoc/latest/org/junit/runner/notification/RunListener.html) that prints the names of tests when they start. When running tests in Maven (which is what Travis does), this can be really handy for figuring out where console output is coming from or, if tests hang, figuring out which test in a class stalled out.

This should have no effect outside of Maven.