### PR TITLE
Introduce an application-specific `PushNotificationFuture`

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/PushNotificationPromise.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/PushNotificationPromise.java
@@ -1,0 +1,21 @@
+package com.turo.pushy.apns;
+
+import com.turo.pushy.apns.util.concurrent.PushNotificationFuture;
+import io.netty.util.concurrent.DefaultPromise;
+import io.netty.util.concurrent.EventExecutor;
+
+class PushNotificationPromise<P extends ApnsPushNotification, V> extends DefaultPromise<V> implements PushNotificationFuture<P, V> {
+
+    private final P pushNotification;
+
+    PushNotificationPromise(final EventExecutor eventExecutor, final P pushNotification) {
+        super(eventExecutor);
+
+        this.pushNotification = pushNotification;
+    }
+
+    @Override
+    public P getPushNotification() {
+        return this.pushNotification;
+    }
+}

--- a/pushy/src/main/java/com/turo/pushy/apns/util/concurrent/PushNotificationFuture.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/util/concurrent/PushNotificationFuture.java
@@ -1,0 +1,22 @@
+package com.turo.pushy.apns.util.concurrent;
+
+import com.turo.pushy.apns.ApnsPushNotification;
+import io.netty.util.concurrent.Future;
+
+/**
+ * A push notification future represents the result an operation on a push notification.
+ *
+ * @param <P> the type of push notification sent
+ * @param <V> the type of value returned by the operation
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ */
+public interface PushNotificationFuture<P extends ApnsPushNotification, V> extends Future<V> {
+
+    /**
+     * Returns the push notification to which the operation represented by this future applies.
+     *
+     * @return the push notification to which the operation represented by this future applies
+     */
+    P getPushNotification();
+}

--- a/pushy/src/main/java/com/turo/pushy/apns/util/concurrent/PushNotificationResponseListener.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/util/concurrent/PushNotificationResponseListener.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2013-2017 Turo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.turo.pushy.apns.util.concurrent;
+
+import com.turo.pushy.apns.ApnsPushNotification;
+import com.turo.pushy.apns.PushNotificationResponse;
+import io.netty.util.concurrent.GenericFutureListener;
+
+/**
+ * A type-specific convenience interface for listening for the result of an attempt to send a push notification.
+ *
+ * @param <T> the type of push notification sent
+ *
+ * @see com.turo.pushy.apns.ApnsClient#sendNotification(ApnsPushNotification)
+ */
+public interface PushNotificationResponseListener<T extends ApnsPushNotification>
+        extends GenericFutureListener<PushNotificationFuture<T, PushNotificationResponse<T>>> {
+}

--- a/pushy/src/main/java/com/turo/pushy/apns/util/concurrent/package-info.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/util/concurrent/package-info.java
@@ -20,32 +20,9 @@
  * THE SOFTWARE.
  */
 
-package com.turo.pushy.apns;
-
-import io.netty.util.concurrent.Promise;
-
 /**
- * A for-internal-use-only ttuple of a push notification and a {@link Promise} to be notified with the outcome of the
- * attempt to send the notification.
+ * Contains application-specific interfaces for working with asynchronous push notification operations.
  *
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
- *
- * @since 0.10
  */
-class PushNotificationAndResponsePromise {
-    private final ApnsPushNotification pushNotification;
-    private final Promise<PushNotificationResponse<ApnsPushNotification>> responsePromise;
-
-    public PushNotificationAndResponsePromise(final ApnsPushNotification pushNotification, final Promise<PushNotificationResponse<ApnsPushNotification>> responsePromise) {
-        this.pushNotification = pushNotification;
-        this.responsePromise = responsePromise;
-    }
-
-    public ApnsPushNotification getPushNotification() {
-        return this.pushNotification;
-    }
-
-    public Promise<PushNotificationResponse<ApnsPushNotification>> getResponsePromise() {
-        return this.responsePromise;
-    }
-}
+package com.turo.pushy.apns.util.concurrent;


### PR DESCRIPTION
This closes #439 by introducing an application-specific `PushNotificationFuture`. The idea is that the push notification will always be associated with the future, so callers can get the original push notification even if the future fails. I'm opening this pull request to gather feedback on the approach.

One thing I like about this is that it's very application-specific and simplifies some internal plumbing a little (goodbye, `PushNotificationAndResponsePromise`). The main thing I dislike about this specific approach, though, is that we wind up with `SendPushNotificationFuture<T>`, but then `sendPushNotificationFuture.get()` returns something other than `T`. That feels confusing, and I'm concerned it'd be hard to communicate to users how to get details of the response.

Another approach I tried was to have `PushNotificationFuture<P, V> implements Future<V>`. That approach is basically fine; it makes the return type of the future clearer, but feels a lot more verbose and puts us in a position of maybe over-generalizing an application-specific concept.

What do you all think?