### PR TITLE
Add support for HTTP/2 frame logging

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
@@ -28,6 +28,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.concurrent.*;
 import org.slf4j.Logger;
@@ -127,10 +128,11 @@ public class ApnsClient {
     }
 
     protected ApnsClient(final InetSocketAddress apnsServerAddress, final SslContext sslContext,
-                         final ApnsSigningKey signingKey,  final ProxyHandlerFactory proxyHandlerFactory,
+                         final ApnsSigningKey signingKey, final ProxyHandlerFactory proxyHandlerFactory,
                          final int connectTimeoutMillis, final long idlePingIntervalMillis,
                          final long gracefulShutdownTimeoutMillis, final int concurrentConnections,
-                         final ApnsClientMetricsListener metricsListener, final EventLoopGroup eventLoopGroup) {
+                         final ApnsClientMetricsListener metricsListener, final Http2FrameLogger frameLogger,
+                         final EventLoopGroup eventLoopGroup) {
 
         if (eventLoopGroup != null) {
             this.eventLoopGroup = eventLoopGroup;
@@ -142,7 +144,9 @@ public class ApnsClient {
 
         this.metricsListener = metricsListener != null ? metricsListener : new NoopApnsClientMetricsListener();
 
-        final ApnsChannelFactory channelFactory = new ApnsChannelFactory(sslContext, signingKey, proxyHandlerFactory, connectTimeoutMillis, idlePingIntervalMillis, gracefulShutdownTimeoutMillis, apnsServerAddress, this.eventLoopGroup);
+        final ApnsChannelFactory channelFactory = new ApnsChannelFactory(sslContext, signingKey, proxyHandlerFactory,
+                connectTimeoutMillis, idlePingIntervalMillis, gracefulShutdownTimeoutMillis, frameLogger,
+                apnsServerAddress, this.eventLoopGroup);
 
         final ApnsChannelPoolMetricsListener channelPoolMetricsListener = new ApnsChannelPoolMetricsListener() {
 

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientBuilder.java
@@ -25,6 +25,7 @@ package com.turo.pushy.apns;
 import com.turo.pushy.apns.auth.ApnsSigningKey;
 import com.turo.pushy.apns.proxy.ProxyHandlerFactory;
 import io.netty.channel.EventLoopGroup;
+import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.*;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
@@ -75,6 +76,8 @@ public class ApnsClientBuilder {
     private int connectionTimeoutMillis;
     private long idlePingIntervalMillis = DEFAULT_PING_IDLE_TIME_MILLIS;
     private long gracefulShutdownTimeoutMillis;
+
+    private Http2FrameLogger frameLogger;
 
     /**
      * The default idle time in milliseconds after which the client will send a PING frame to the APNs server.
@@ -465,6 +468,25 @@ public class ApnsClientBuilder {
     }
 
     /**
+     * Sets the HTTP/2 frame logger for the client under construction. HTTP/2 frame loggers log all HTTP/2 frames sent
+     * to or from the client to the logging system of your choice via SLF4J. Frame logging is extremely verbose and is
+     * recommended only for debugging purposes.
+     *
+     * @param frameLogger the frame logger to be used by the client under construction or {@code null} if the client
+     * should not log individual HTTP/2 frames
+     *
+     * @return a reference to this builder
+     *
+     * @see <a href="https://www.slf4j.org/">SLF4J</a>
+     *
+     * @since 0.12
+     */
+    public ApnsClientBuilder setFrameLogger(final Http2FrameLogger frameLogger) {
+        this.frameLogger = frameLogger;
+        return this;
+    }
+
+    /**
      * Constructs a new {@link ApnsClient} with the previously-set configuration.
      *
      * @return a new ApnsClient instance with the previously-set configuration
@@ -516,7 +538,7 @@ public class ApnsClientBuilder {
         final ApnsClient client = new ApnsClient(this.apnsServerAddress, sslContext, this.signingKey,
                 this.proxyHandlerFactory, this.connectionTimeoutMillis, this.idlePingIntervalMillis,
                 this.gracefulShutdownTimeoutMillis, this.concurrentConnections, this.metricsListener,
-                this.eventLoopGroup);
+                this.frameLogger, this.eventLoopGroup);
 
         if (sslContext instanceof ReferenceCounted) {
             ((ReferenceCounted) sslContext).release();

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
@@ -107,6 +107,16 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
         }
 
         @Override
+        public ApnsClientHandlerBuilder frameLogger(final Http2FrameLogger frameLogger) {
+            return super.frameLogger(frameLogger);
+        }
+
+        @Override
+        public Http2FrameLogger frameLogger() {
+            return super.frameLogger();
+        }
+
+        @Override
         protected final boolean isServer() {
             return false;
         }


### PR DESCRIPTION
I'm hoping most people won't need this, but it seems reasonable to have an easy way to turn on HTTP/2 frame logging just in case. This change adds an option to include an HTTP/2 frame logger when building `ApnsClient` instances.