### PR TITLE
Introduce mock server listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,9 @@ If you plan to use Pushy inside an application container (like Tomcat), you may 
 
 Pushy includes a mock APNs server that callers may use in integration tests and benchmarks. It is not necessary to use a mock server (or any related classes) in normal operation.
 
-To build a mock server, callers should use a `MockApnsServerBuilder`. All servers require a `PushNotificationHandler` (built by a `PushNotificationHandlerFactory` provided to the builder) that decides whether the mock server will accept or reject each incoming push notification. Pushy includes an `AcceptAllPushNotificationHandlerFactory` that is helpful for benchmarking and a `ValidatingPushNotificationHandlerFactory` that may be helpful for integration testing.
+To build a mock server, callers should use a [`MockApnsServerBuilder`](http://relayrides.github.io/pushy/apidocs/0.12/com/turo/pushy/apns/server/MockApnsServerBuilder.html). All servers require a [`PushNotificationHandler`](http://relayrides.github.io/pushy/apidocs/0.12/com/turo/pushy/apns/server/PushNotificationHandler.html) (built by a [`PushNotificationHandlerFactory`](http://relayrides.github.io/pushy/apidocs/0.12/com/turo/pushy/apns/server/PushNotificationHandlerFactory.html) provided to the builder) that decides whether the mock server will accept or reject each incoming push notification. Pushy includes an `AcceptAllPushNotificationHandlerFactory` that is helpful for benchmarking and a `ValidatingPushNotificationHandlerFactory` that may be helpful for integration testing.
+
+Callers may also provide a [`MockApnsServerListener`](http://relayrides.github.io/pushy/apidocs/0.12/com/turo/pushy/apns/server/MockApnsServerListener.html) when building a mock server; listeners are notified whenever the mock server accepts or rejects a notification from a client.
 
 ## License and status
 

--- a/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServer.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServer.java
@@ -52,7 +52,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * {@link ValidatingPushNotificationHandlerFactory} that constructs handlers that emulate the behavior of a real APNs
  * server (but do not actually deliver push notifications to destination devices) and an
  * {@link AcceptAllPushNotificationHandlerFactory} that constructs handlers that unconditionally accept push
- * notifications.</p>
+ * notifications. Additionally, callers may specify a {@link MockApnsServerListener} that will be notified when
+ * notifications are accepted or rejected by the server.</p>
  *
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
  *
@@ -69,7 +70,9 @@ public class MockApnsServer {
     private ChannelGroup allChannels;
 
     MockApnsServer(final SslContext sslContext, final PushNotificationHandlerFactory handlerFactory,
-                   final int maxConcurrentStreams, final EventLoopGroup eventLoopGroup) {
+                   final MockApnsServerListener listener, final int maxConcurrentStreams,
+                   final EventLoopGroup eventLoopGroup) {
+
         this.sslContext = sslContext;
 
         if (this.sslContext instanceof ReferenceCounted) {
@@ -104,6 +107,7 @@ public class MockApnsServer {
                             final MockApnsServerHandler serverHandler = new MockApnsServerHandler.MockApnsServerHandlerBuilder()
                                     .pushNotificationHandler(pushNotificationHandler)
                                     .initialSettings(Http2Settings.defaultSettings().maxConcurrentStreams(maxConcurrentStreams))
+                                    .listener(listener)
                                     .build();
 
                             context.pipeline().addLast(serverHandler);

--- a/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerBuilder.java
@@ -68,6 +68,8 @@ public class MockApnsServerBuilder {
 
     private PushNotificationHandlerFactory handlerFactory;
 
+    private MockApnsServerListener listener;
+
     private EventLoopGroup eventLoopGroup;
 
     private int maxConcurrentStreams = DEFAULT_MAX_CONCURRENT_STREAMS;
@@ -273,6 +275,11 @@ public class MockApnsServerBuilder {
         }
 
         this.maxConcurrentStreams = maxConcurrentStreams;
+        return this;
+    }
+
+    public MockApnsServerBuilder setListener(final MockApnsServerListener listener) {
+        this.listener = listener;
         return this;
     }
 

--- a/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerBuilder.java
@@ -259,6 +259,22 @@ public class MockApnsServerBuilder {
     }
 
     /**
+     * Sets the listener to be notified when notifications are accepted or rejected by the server under construction. If
+     * not set or if {@code null}, the server will not notify a listener when notifications are accepted or rejected.
+     *
+     * @param listener the listener to be used by the server under construction
+     *
+     * @return a reference to this builder
+     *
+     * @since 0.12
+     */
+    public MockApnsServerBuilder setListener(final MockApnsServerListener listener) {
+        this.listener = listener;
+        return this;
+    }
+
+
+    /**
      * Sets the maximum number of concurrent HTTP/2 streams allowed by the server under construction. By default,
      * mock servers will have a concurrent stream limit of {@value DEFAULT_MAX_CONCURRENT_STREAMS}.
      *
@@ -275,11 +291,6 @@ public class MockApnsServerBuilder {
         }
 
         this.maxConcurrentStreams = maxConcurrentStreams;
-        return this;
-    }
-
-    public MockApnsServerBuilder setListener(final MockApnsServerListener listener) {
-        this.listener = listener;
         return this;
     }
 
@@ -346,7 +357,7 @@ public class MockApnsServerBuilder {
             sslContext = sslContextBuilder.build();
         }
 
-        final MockApnsServer server = new MockApnsServer(sslContext, this.handlerFactory, this.maxConcurrentStreams, this.eventLoopGroup);
+        final MockApnsServer server = new MockApnsServer(sslContext, this.handlerFactory, this.listener, this.maxConcurrentStreams, this.eventLoopGroup);
 
         if (sslContext instanceof ReferenceCounted) {
             ((ReferenceCounted) sslContext).release();

--- a/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerHandler.java
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeUnit;
 class MockApnsServerHandler extends Http2ConnectionHandler implements Http2FrameListener {
 
     private final PushNotificationHandler pushNotificationHandler;
+    private final MockApnsServerListener listener;
 
     private final Http2Connection.PropertyKey headersPropertyKey;
     private final Http2Connection.PropertyKey payloadPropertyKey;
@@ -64,9 +65,15 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
     public static class MockApnsServerHandlerBuilder extends AbstractHttp2ConnectionHandlerBuilder<MockApnsServerHandler, MockApnsServerHandler.MockApnsServerHandlerBuilder> {
 
         private PushNotificationHandler pushNotificationHandler;
+        private MockApnsServerListener listener;
 
         MockApnsServerHandlerBuilder pushNotificationHandler(final PushNotificationHandler pushNotificationHandler) {
             this.pushNotificationHandler = pushNotificationHandler;
+            return this;
+        }
+
+        MockApnsServerHandlerBuilder listener(final MockApnsServerListener listener) {
+            this.listener = listener;
             return this;
         }
 
@@ -77,7 +84,7 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
 
         @Override
         public MockApnsServerHandler build(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings) {
-            final MockApnsServerHandler handler = new MockApnsServerHandler(decoder, encoder, initialSettings, this.pushNotificationHandler);
+            final MockApnsServerHandler handler = new MockApnsServerHandler(decoder, encoder, initialSettings, this.pushNotificationHandler, this.listener);
             this.frameListener(handler);
             return handler;
         }
@@ -142,7 +149,8 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
         }
     }
 
-    protected static class ErrorPayload {
+    @SuppressWarnings("unused")
+    private static class ErrorPayload {
         private final String reason;
         private final Date timestamp;
 
@@ -150,20 +158,24 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
             this.reason = reason;
             this.timestamp = timestamp;
         }
+    }
 
-        String getReason() {
-            return this.reason;
+    private static final class NoopMockApnsServerListener implements MockApnsServerListener {
+
+        @Override
+        public void handlePushNotificationAccepted(final Http2Headers headers, final ByteBuf payload) {
         }
 
-        Date getTimestamp() {
-            return this.timestamp;
+        @Override
+        public void handlePushNotificationRejected(final Http2Headers headers, final ByteBuf payload, final RejectionReason rejectionReason, final Date deviceTokenExpirationTimestamp) {
         }
     }
 
     MockApnsServerHandler(final Http2ConnectionDecoder decoder,
                           final Http2ConnectionEncoder encoder,
                           final Http2Settings initialSettings,
-                          final PushNotificationHandler pushNotificationHandler) {
+                          final PushNotificationHandler pushNotificationHandler,
+                          final MockApnsServerListener listener) {
 
         super(decoder, encoder, initialSettings);
 
@@ -171,10 +183,11 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
         this.payloadPropertyKey = this.connection().newKey();
 
         this.pushNotificationHandler = pushNotificationHandler;
+        this.listener = listener != null ? listener : new NoopMockApnsServerListener();
     }
 
     @Override
-    public int onDataRead(final ChannelHandlerContext context, final int streamId, final ByteBuf data, final int padding, final boolean endOfStream) throws Http2Exception {
+    public int onDataRead(final ChannelHandlerContext context, final int streamId, final ByteBuf data, final int padding, final boolean endOfStream) {
         final int bytesProcessed = data.readableBytes() + padding;
 
         final Http2Stream stream = this.connection().stream(streamId);
@@ -193,7 +206,7 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
     }
 
     @Override
-    public void onHeadersRead(final ChannelHandlerContext context, final int streamId, final Http2Headers headers, final int padding, final boolean endOfStream) throws Http2Exception {
+    public void onHeadersRead(final ChannelHandlerContext context, final int streamId, final Http2Headers headers, final int padding, final boolean endOfStream) {
         final Http2Stream stream = this.connection().stream(streamId);
         stream.setProperty(this.headersPropertyKey, headers);
 
@@ -204,49 +217,49 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
 
     @Override
     public void onHeadersRead(final ChannelHandlerContext ctx, final int streamId, final Http2Headers headers, final int streamDependency,
-                              final short weight, final boolean exclusive, final int padding, final boolean endOfStream) throws Http2Exception {
+                              final short weight, final boolean exclusive, final int padding, final boolean endOfStream) {
 
         this.onHeadersRead(ctx, streamId, headers, padding, endOfStream);
     }
 
     @Override
-    public void onPriorityRead(final ChannelHandlerContext ctx, final int streamId, final int streamDependency, final short weight, final boolean exclusive) throws Http2Exception {
+    public void onPriorityRead(final ChannelHandlerContext ctx, final int streamId, final int streamDependency, final short weight, final boolean exclusive) {
     }
 
     @Override
-    public void onRstStreamRead(final ChannelHandlerContext ctx, final int streamId, final long errorCode) throws Http2Exception {
+    public void onRstStreamRead(final ChannelHandlerContext ctx, final int streamId, final long errorCode) {
     }
 
     @Override
-    public void onSettingsAckRead(final ChannelHandlerContext ctx) throws Http2Exception {
+    public void onSettingsAckRead(final ChannelHandlerContext ctx) {
     }
 
     @Override
-    public void onSettingsRead(final ChannelHandlerContext ctx, final Http2Settings settings) throws Http2Exception {
+    public void onSettingsRead(final ChannelHandlerContext ctx, final Http2Settings settings) {
     }
 
     @Override
-    public void onPingRead(final ChannelHandlerContext ctx, final ByteBuf data) throws Http2Exception {
+    public void onPingRead(final ChannelHandlerContext ctx, final ByteBuf data) {
     }
 
     @Override
-    public void onPingAckRead(final ChannelHandlerContext ctx, final ByteBuf data) throws Http2Exception {
+    public void onPingAckRead(final ChannelHandlerContext ctx, final ByteBuf data) {
     }
 
     @Override
-    public void onPushPromiseRead(final ChannelHandlerContext ctx, final int streamId, final int promisedStreamId, final Http2Headers headers, final int padding) throws Http2Exception {
+    public void onPushPromiseRead(final ChannelHandlerContext ctx, final int streamId, final int promisedStreamId, final Http2Headers headers, final int padding) {
     }
 
     @Override
-    public void onGoAwayRead(final ChannelHandlerContext ctx, final int lastStreamId, final long errorCode, final ByteBuf debugData) throws Http2Exception {
+    public void onGoAwayRead(final ChannelHandlerContext ctx, final int lastStreamId, final long errorCode, final ByteBuf debugData) {
     }
 
     @Override
-    public void onWindowUpdateRead(final ChannelHandlerContext ctx, final int streamId, final int windowSizeIncrement) throws Http2Exception {
+    public void onWindowUpdateRead(final ChannelHandlerContext ctx, final int streamId, final int windowSizeIncrement) {
     }
 
     @Override
-    public void onUnknownFrame(final ChannelHandlerContext ctx, final byte frameType, final int streamId, final Http2Flags flags, final ByteBuf payload) throws Http2Exception {
+    public void onUnknownFrame(final ChannelHandlerContext ctx, final byte frameType, final int streamId, final Http2Flags flags, final ByteBuf payload) {
     }
 
     private void handleEndOfStream(final ChannelHandlerContext context, final Http2Stream stream) {
@@ -256,14 +269,18 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
 
         try {
             this.pushNotificationHandler.handlePushNotification(headers, payload);
+
             this.write(context, new AcceptNotificationResponse(stream.id()), writePromise);
+            this.listener.handlePushNotificationAccepted(headers, payload);
         } catch (final RejectedNotificationException e) {
             final Date deviceTokenExpirationTimestamp = e instanceof UnregisteredDeviceTokenException ?
                     ((UnregisteredDeviceTokenException) e).getDeviceTokenExpirationTimestamp() : null;
 
             this.write(context, new RejectNotificationResponse(stream.id(), e.getApnsId(), e.getRejectionReason(), deviceTokenExpirationTimestamp), writePromise);
+            this.listener.handlePushNotificationRejected(headers, payload, e.getRejectionReason(), deviceTokenExpirationTimestamp);
         } catch (final Exception e) {
             this.write(context, new InternalServerErrorResponse(stream.id()), writePromise);
+            this.listener.handlePushNotificationRejected(headers, payload, RejectionReason.INTERNAL_SERVER_ERROR, null);
         } finally {
             if (stream.getProperty(this.payloadPropertyKey) != null) {
                 ((ByteBuf) stream.getProperty(this.payloadPropertyKey)).release();

--- a/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerListener.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerListener.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2013-2017 Turo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.turo.pushy.apns.server;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http2.Http2Headers;
+
+import java.util.Date;
+
+/**
+ * <p>Mock APNs server listeners are notified when push notifications are accepted or rejected by a
+ * {@link MockApnsServer}. Listeners have no effect on a server's handling of push notifications, and are designed for
+ * use in integration testing.</p>
+ *
+ * <p>Note that the mock server's decision to accept or reject a push notification is controlled by its
+ * {@link PushNotificationHandler}. As a result, notifications accepted by a mock server might be rejected by a real
+ * APNs server or vice versa. Notifications passed to listeners may have missing, incomplete, or nonsense data
+ * regardless of whether they were accepted or rejected, and callers should use appropriate caution. Parsing
+ * notification headers/payloads into {@link com.turo.pushy.apns.ApnsPushNotification} instances is the responsibility
+ * of the caller, and callers may with to subclass {@link ParsingMockApnsServerListenerAdapter} if they need to work
+ * with {@code ApnsPushNotification} instances instead of raw headers and byte buffers.</p>
+ *
+ * @see MockApnsServerBuilder#setListener(MockApnsServerListener)
+ * @see ParsingMockApnsServerListenerAdapter
+ *
+ * @since 0.12
+ */
+public interface MockApnsServerListener {
+
+    /**
+     * Indicates that a push notification has been accepted by the mock server.
+     *
+     * @param headers the notification's HTTP/2 headers
+     * @param payload the notification's payload
+     */
+    void handlePushNotificationAccepted(Http2Headers headers, ByteBuf payload);
+
+    /**
+     * Indicates that a push notification has been rejected by the mock server.
+     *
+     * @param headers the notification's HTTP/2 headers
+     * @param payload the notification's payload
+     * @param rejectionReason the reason the push notification was rejected by the mock server
+     * @param deviceTokenExpirationTimestamp the time at which the push notification's destination device token expired;
+     * may be {@code null} if the token has not expired
+     */
+    void handlePushNotificationRejected(Http2Headers headers, ByteBuf payload, RejectionReason rejectionReason, Date deviceTokenExpirationTimestamp);
+}

--- a/pushy/src/main/java/com/turo/pushy/apns/server/ParsingMockApnsServerListenerAdapter.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/ParsingMockApnsServerListenerAdapter.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2013-2018 Turo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.turo.pushy.apns.server;
+
+import com.turo.pushy.apns.ApnsPushNotification;
+import com.turo.pushy.apns.DeliveryPriority;
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.util.AsciiString;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+/**
+ * <p>A parsing APNs server listener is an abstract base class that parses HTTP/2 headers and payload byte buffers from
+ * a mock APNs server into {@link ApnsPushNotification} instances for easier handling.</p>
+ *
+ * <p>Note that the mock server's decision to accept or reject a push notification is controlled by its
+ * {@link PushNotificationHandler}. As a result, notifications accepted by a mock server might be rejected by a real
+ * APNs server or vice versa. Push notifications parsed by this class may have missing, incomplete, or nonsense data
+ * regardless of whether they were accepted or rejected, and callers should use appropriate caution.</p>
+ *
+ * @see MockApnsServerBuilder#setListener(MockApnsServerListener)
+ *
+ * @since 0.12
+ */
+public abstract class ParsingMockApnsServerListenerAdapter implements MockApnsServerListener {
+
+    private static class LenientApnsPushNotification implements ApnsPushNotification {
+        private final String token;
+        private final String payload;
+        private final Date invalidationTime;
+        private final DeliveryPriority priority;
+        private final String topic;
+        private final String collapseId;
+
+        private LenientApnsPushNotification(final String token, final String topic, final String payload, final Date invalidationTime, final DeliveryPriority priority, final String collapseId) {
+            this.token = token;
+            this.payload = payload;
+            this.invalidationTime = invalidationTime;
+            this.priority = priority;
+            this.topic = topic;
+            this.collapseId = collapseId;
+        }
+
+        @Override
+        public String getToken() {
+            return this.token;
+        }
+
+        @Override
+        public String getPayload() {
+            return this.payload;
+        }
+
+        @Override
+        public Date getExpiration() {
+            return this.invalidationTime;
+        }
+
+        @Override
+        public DeliveryPriority getPriority() {
+            return this.priority;
+        }
+
+        @Override
+        public String getTopic() {
+            return this.topic;
+        }
+
+        @Override
+        public String getCollapseId() {
+            return this.collapseId;
+        }
+    }
+
+    private static final String APNS_PATH_PREFIX = "/3/device/";
+    private static final AsciiString APNS_TOPIC_HEADER = new AsciiString("apns-topic");
+    private static final AsciiString APNS_PRIORITY_HEADER = new AsciiString("apns-priority");
+    private static final AsciiString APNS_EXPIRATION_HEADER = new AsciiString("apns-expiration");
+    private static final AsciiString APNS_COLLAPSE_ID_HEADER = new AsciiString("apns-collapse-id");
+
+    public void handlePushNotificationAccepted(final Http2Headers headers, final ByteBuf payload) {
+        this.handlePushNotificationAccepted(parsePushNotification(headers, payload));
+    }
+
+    protected abstract void handlePushNotificationAccepted(final ApnsPushNotification pushNotification);
+
+    public void handlePushNotificationRejected(final Http2Headers headers, final ByteBuf payload, final RejectionReason rejectionReason, final Date deviceTokenExpirationTimestamp) {
+        this.handlePushNotificationRejected(parsePushNotification(headers, payload), rejectionReason, deviceTokenExpirationTimestamp);
+    }
+
+    protected abstract void handlePushNotificationRejected(final ApnsPushNotification pushNotification, final RejectionReason rejectionReason, final Date deviceTokenExpirationTimestamp);
+
+    private static ApnsPushNotification parsePushNotification(final Http2Headers headers, final ByteBuf payload) {
+        final String deviceToken;
+        {
+            final CharSequence pathSequence = headers.get(Http2Headers.PseudoHeaderName.PATH.value());
+
+            if (pathSequence != null) {
+                final String pathString = pathSequence.toString();
+
+                deviceToken = pathString.startsWith(APNS_PATH_PREFIX) ? pathString.substring(APNS_PATH_PREFIX.length()) : null;
+            } else {
+                deviceToken = null;
+            }
+        }
+
+        final String topic;
+        {
+            final CharSequence topicSequence = headers.get(APNS_TOPIC_HEADER);
+            topic = topicSequence != null ? topicSequence.toString() : null;
+        }
+
+        final DeliveryPriority deliveryPriority;
+        {
+            final Integer priorityCode = headers.getInt(APNS_PRIORITY_HEADER);
+
+            DeliveryPriority priorityFromCode;
+
+            try {
+                priorityFromCode = priorityCode != null ? DeliveryPriority.getFromCode(priorityCode) : null;
+            }  catch (final IllegalArgumentException e) {
+                priorityFromCode = null;
+            }
+
+            deliveryPriority = priorityFromCode;
+        }
+
+        final Date expiration;
+        {
+            final Integer expirationTimestamp = headers.getInt(APNS_EXPIRATION_HEADER);
+            expiration = expirationTimestamp != null ? new Date(expirationTimestamp * 1000) : null;
+        }
+
+        final String collapseId;
+        {
+            final CharSequence collapseIdSequence = headers.get(APNS_COLLAPSE_ID_HEADER);
+            collapseId = collapseIdSequence != null ? collapseIdSequence.toString() : null;
+        }
+
+        // One challenge here is that we don't actually know that a push notification is valid, even if it's
+        // accepted by the push notification handler (since we might be using a handler that blindly accepts
+        // everything), so we want to use a lenient push notification implementation.
+        return new LenientApnsPushNotification(
+                deviceToken,
+                topic,
+                payload != null ? payload.toString(StandardCharsets.UTF_8) : null,
+                expiration,
+                deliveryPriority,
+                collapseId);
+    }
+}

--- a/pushy/src/main/java/com/turo/pushy/apns/server/ParsingMockApnsServerListenerAdapter.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/ParsingMockApnsServerListenerAdapter.java
@@ -100,17 +100,49 @@ public abstract class ParsingMockApnsServerListenerAdapter implements MockApnsSe
     private static final AsciiString APNS_EXPIRATION_HEADER = new AsciiString("apns-expiration");
     private static final AsciiString APNS_COLLAPSE_ID_HEADER = new AsciiString("apns-collapse-id");
 
+    /**
+     * Parses a push notification accepted by a mock APNs server into an {@link ApnsPushNotification} instance for
+     * further processing by
+     * {@link ParsingMockApnsServerListenerAdapter#handlePushNotificationAccepted(ApnsPushNotification)}.
+     *
+     * @param headers the notification's HTTP/2 headers
+     * @param payload the notification's payload
+     */
     public void handlePushNotificationAccepted(final Http2Headers headers, final ByteBuf payload) {
         this.handlePushNotificationAccepted(parsePushNotification(headers, payload));
     }
 
-    protected abstract void handlePushNotificationAccepted(final ApnsPushNotification pushNotification);
+    /**
+     * Handles a parsed push notification accepted by a mock server. Note that any field of the parsed push notification
+     * may be {@code null}.
+     *
+     * @param pushNotification the notification accepted by the server
+     */
+    public abstract void handlePushNotificationAccepted(final ApnsPushNotification pushNotification);
 
+    /**
+     * Parses a push notification rejected by a mock APNs server into an {@link ApnsPushNotification} instance for
+     * further processing by
+     * {@link ParsingMockApnsServerListenerAdapter#handlePushNotificationRejected(ApnsPushNotification, RejectionReason, Date)}.
+     *
+     * @param headers the notification's HTTP/2 headers
+     * @param payload the notification's payload
+     * @param rejectionReason the reason the push notification was rejected by the mock server
+     * @param deviceTokenExpirationTimestamp the time at which the push notification's destination device token expired;
+     */
     public void handlePushNotificationRejected(final Http2Headers headers, final ByteBuf payload, final RejectionReason rejectionReason, final Date deviceTokenExpirationTimestamp) {
         this.handlePushNotificationRejected(parsePushNotification(headers, payload), rejectionReason, deviceTokenExpirationTimestamp);
     }
 
-    protected abstract void handlePushNotificationRejected(final ApnsPushNotification pushNotification, final RejectionReason rejectionReason, final Date deviceTokenExpirationTimestamp);
+    /**
+     * Handles a parsed push notification accepted by a mock server. Note that any field of the parsed push notification
+     * may be {@code null}.
+     *
+     * @param pushNotification the push notification rejected by the server
+     * @param rejectionReason the reason the push notification was rejected by the mock server
+     * @param deviceTokenExpirationTimestamp the time at which the push notification's destination device token expired;
+     */
+    public abstract void handlePushNotificationRejected(final ApnsPushNotification pushNotification, final RejectionReason rejectionReason, final Date deviceTokenExpirationTimestamp);
 
     private static ApnsPushNotification parsePushNotification(final Http2Headers headers, final ByteBuf payload) {
         final String deviceToken;

--- a/pushy/src/test/java/com/turo/pushy/apns/AbstractClientServerTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/AbstractClientServerTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2013-2018 Turo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.turo.pushy.apns;
+
+import com.turo.pushy.apns.auth.ApnsSigningKey;
+import com.turo.pushy.apns.auth.ApnsVerificationKey;
+import com.turo.pushy.apns.auth.KeyPairUtil;
+import com.turo.pushy.apns.server.MockApnsServer;
+import com.turo.pushy.apns.server.MockApnsServerBuilder;
+import com.turo.pushy.apns.server.PushNotificationHandlerFactory;
+import com.turo.pushy.apns.util.ApnsPayloadBuilder;
+import io.netty.channel.nio.NioEventLoopGroup;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import javax.net.ssl.SSLException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyPair;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.util.*;
+
+public class AbstractClientServerTest {
+
+    protected static NioEventLoopGroup EVENT_LOOP_GROUP;
+
+    protected static final String CA_CERTIFICATE_FILENAME = "/ca.pem";
+    protected static final String SERVER_CERTIFICATES_FILENAME = "/server-certs.pem";
+    protected static final String SERVER_KEY_FILENAME = "/server-key.pem";
+
+    protected static final String MULTI_TOPIC_CLIENT_KEYSTORE_FILENAME = "/multi-topic-client.p12";
+    protected static final String KEYSTORE_PASSWORD = "pushy-test";
+
+    protected static final String HOST = "localhost";
+    protected static final int PORT = 8443;
+
+    protected static final String TEAM_ID = "team-id";
+    protected static final String KEY_ID = "key-id";
+    protected static final String TOPIC = "com.relayrides.pushy";
+    protected static final String DEVICE_TOKEN = generateRandomDeviceToken();
+    protected static final String PAYLOAD = generateRandomPayload();
+
+    protected static final Map<String, Set<String>> DEVICE_TOKENS_BY_TOPIC =
+            Collections.singletonMap(TOPIC, Collections.singleton(DEVICE_TOKEN));
+
+    protected static final Map<String, Date> EXPIRATION_TIMESTAMPS_BY_DEVICE_TOKEN = Collections.emptyMap();
+
+    protected static final int TOKEN_LENGTH = 32; // bytes
+
+    protected ApnsSigningKey signingKey;
+    protected Map<String, ApnsVerificationKey> verificationKeysByKeyId;
+    protected Map<ApnsVerificationKey, Set<String>> topicsByVerificationKey;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        // We want enough threads so we can be confident that the client and server are running on different threads and
+        // we can accurately simulate race conditions. Two threads seems like an obvious choice, but there are some
+        // tests where we have multiple clients and servers in play, and it's good to have some extra room in those
+        // cases.
+        EVENT_LOOP_GROUP = new NioEventLoopGroup(4);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        final KeyPair keyPair = KeyPairUtil.generateKeyPair();
+
+        this.signingKey = new ApnsSigningKey(KEY_ID, TEAM_ID, (ECPrivateKey) keyPair.getPrivate());
+        final ApnsVerificationKey verificationKey =
+                new ApnsVerificationKey(KEY_ID, TEAM_ID, (ECPublicKey) keyPair.getPublic());
+
+        this.verificationKeysByKeyId = Collections.singletonMap(KEY_ID, verificationKey);
+        this.topicsByVerificationKey = Collections.singletonMap(verificationKey, Collections.singleton(TOPIC));
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() throws Exception {
+        EVENT_LOOP_GROUP.shutdownGracefully().await();
+    }
+
+    protected ApnsClient buildTlsAuthenticationClient() throws IOException {
+        return this.buildTlsAuthenticationClient(null);
+    }
+
+    protected ApnsClient buildTlsAuthenticationClient(final ApnsClientMetricsListener metricsListener) throws IOException {
+        try (final InputStream p12InputStream = getClass().getResourceAsStream(MULTI_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
+            return new ApnsClientBuilder()
+                    .setApnsServer(HOST, PORT)
+                    .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
+                    .setTrustedServerCertificateChain(getClass().getResourceAsStream(CA_CERTIFICATE_FILENAME))
+                    .setEventLoopGroup(EVENT_LOOP_GROUP)
+                    .setMetricsListener(metricsListener)
+                    .build();
+        }
+    }
+
+    protected ApnsClient buildTokenAuthenticationClient() throws SSLException {
+        return this.buildTokenAuthenticationClient(null);
+    }
+
+    protected ApnsClient buildTokenAuthenticationClient(final ApnsClientMetricsListener metricsListener) throws SSLException {
+        return new ApnsClientBuilder()
+                .setApnsServer(HOST, PORT)
+                .setTrustedServerCertificateChain(getClass().getResourceAsStream(CA_CERTIFICATE_FILENAME))
+                .setSigningKey(this.signingKey)
+                .setEventLoopGroup(EVENT_LOOP_GROUP)
+                .setMetricsListener(metricsListener)
+                .build();
+    }
+
+    protected MockApnsServer buildServer(final PushNotificationHandlerFactory handlerFactory) throws SSLException {
+        return new MockApnsServerBuilder()
+                .setServerCredentials(getClass().getResourceAsStream(SERVER_CERTIFICATES_FILENAME), getClass().getResourceAsStream(SERVER_KEY_FILENAME), null)
+                .setTrustedClientCertificateChain(getClass().getResourceAsStream(CA_CERTIFICATE_FILENAME))
+                .setEventLoopGroup(EVENT_LOOP_GROUP)
+                .setHandlerFactory(handlerFactory)
+                .build();
+    }
+
+    protected static String generateRandomDeviceToken() {
+        final byte[] tokenBytes = new byte[TOKEN_LENGTH];
+        new Random().nextBytes(tokenBytes);
+
+        final StringBuilder builder = new StringBuilder(TOKEN_LENGTH * 2);
+
+        for (final byte b : tokenBytes) {
+            builder.append(String.format("%02x", b));
+        }
+
+        return builder.toString();
+    }
+
+    protected static String generateRandomPayload() {
+        final ApnsPayloadBuilder payloadBuilder = new ApnsPayloadBuilder();
+        payloadBuilder.setAlertBody(UUID.randomUUID().toString());
+
+        return payloadBuilder.buildWithDefaultMaximumLength();
+    }
+}

--- a/pushy/src/test/java/com/turo/pushy/apns/AbstractClientServerTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/AbstractClientServerTest.java
@@ -27,6 +27,7 @@ import com.turo.pushy.apns.auth.ApnsVerificationKey;
 import com.turo.pushy.apns.auth.KeyPairUtil;
 import com.turo.pushy.apns.server.MockApnsServer;
 import com.turo.pushy.apns.server.MockApnsServerBuilder;
+import com.turo.pushy.apns.server.MockApnsServerListener;
 import com.turo.pushy.apns.server.PushNotificationHandlerFactory;
 import com.turo.pushy.apns.util.ApnsPayloadBuilder;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -130,11 +131,16 @@ public class AbstractClientServerTest {
     }
 
     protected MockApnsServer buildServer(final PushNotificationHandlerFactory handlerFactory) throws SSLException {
+        return this.buildServer(handlerFactory, null);
+    }
+
+    protected MockApnsServer buildServer(final PushNotificationHandlerFactory handlerFactory, final MockApnsServerListener listener) throws SSLException {
         return new MockApnsServerBuilder()
                 .setServerCredentials(getClass().getResourceAsStream(SERVER_CERTIFICATES_FILENAME), getClass().getResourceAsStream(SERVER_KEY_FILENAME), null)
                 .setTrustedClientCertificateChain(getClass().getResourceAsStream(CA_CERTIFICATE_FILENAME))
                 .setEventLoopGroup(EVENT_LOOP_GROUP)
                 .setHandlerFactory(handlerFactory)
+                .setListener(listener)
                 .build();
     }
 

--- a/pushy/src/test/java/com/turo/pushy/apns/server/MockApnsServerTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/server/MockApnsServerTest.java
@@ -22,39 +22,28 @@
 
 package com.turo.pushy.apns.server;
 
+import com.turo.pushy.apns.AbstractClientServerTest;
 import io.netty.channel.nio.NioEventLoopGroup;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class MockApnsServerTest {
-
-    private static final String SERVER_CERTIFICATES_FILENAME = "/server-certs.pem";
-    private static final String SERVER_KEY_FILENAME = "/server-key.pem";
-
-    private static final int PORT = 8443;
-
-    private MockApnsServer server;
-
-    @Before
-    public void setUp() throws Exception {
-        this.server = new MockApnsServerBuilder()
-                .setServerCredentials(MockApnsServerTest.class.getResourceAsStream(SERVER_CERTIFICATES_FILENAME), MockApnsServerTest.class.getResourceAsStream(SERVER_KEY_FILENAME), null)
-                .setHandlerFactory(new AcceptAllPushNotificationHandlerFactory())
-                .build();
-    }
+public class MockApnsServerTest extends AbstractClientServerTest {
 
     @Test
     public void testStartAndShutdown() throws Exception {
-        assertTrue(this.server.start(PORT).await().isSuccess());
-        assertTrue(this.server.shutdown().await().isSuccess());
+        final MockApnsServer server = this.buildServer(new AcceptAllPushNotificationHandlerFactory());
+
+        assertTrue(server.start(PORT).await().isSuccess());
+        assertTrue(server.shutdown().await().isSuccess());
     }
 
     @Test
     public void testShutdownBeforeStart() throws Exception {
-        assertTrue(this.server.shutdown().await().isSuccess());
+        final MockApnsServer server = this.buildServer(new AcceptAllPushNotificationHandlerFactory());
+
+        assertTrue(server.shutdown().await().isSuccess());
     }
 
     @Test
@@ -64,7 +53,7 @@ public class MockApnsServerTest {
         try {
 
             final MockApnsServer providedGroupServer = new MockApnsServerBuilder()
-                    .setServerCredentials(MockApnsServerTest.class.getResourceAsStream(SERVER_CERTIFICATES_FILENAME), MockApnsServerTest.class.getResourceAsStream(SERVER_KEY_FILENAME), null)
+                    .setServerCredentials(getClass().getResourceAsStream(SERVER_CERTIFICATES_FILENAME), getClass().getResourceAsStream(SERVER_KEY_FILENAME), null)
                     .setHandlerFactory(new AcceptAllPushNotificationHandlerFactory())
                     .setEventLoopGroup(eventLoopGroup)
                     .build();
@@ -74,7 +63,7 @@ public class MockApnsServerTest {
 
             assertFalse(eventLoopGroup.isShutdown());
         } finally {
-            eventLoopGroup.shutdownGracefully();
+            eventLoopGroup.shutdownGracefully().await();
         }
     }
 
@@ -85,7 +74,7 @@ public class MockApnsServerTest {
         try {
 
             final MockApnsServer providedGroupServer = new MockApnsServerBuilder()
-                    .setServerCredentials(MockApnsServerTest.class.getResourceAsStream(SERVER_CERTIFICATES_FILENAME), MockApnsServerTest.class.getResourceAsStream(SERVER_KEY_FILENAME), null)
+                    .setServerCredentials(getClass().getResourceAsStream(SERVER_CERTIFICATES_FILENAME), getClass().getResourceAsStream(SERVER_KEY_FILENAME), null)
                     .setHandlerFactory(new AcceptAllPushNotificationHandlerFactory())
                     .setEventLoopGroup(eventLoopGroup)
                     .build();
@@ -95,7 +84,7 @@ public class MockApnsServerTest {
             assertTrue(providedGroupServer.start(PORT).await().isSuccess());
             assertTrue(providedGroupServer.shutdown().await().isSuccess());
         } finally {
-            eventLoopGroup.shutdownGracefully();
+            eventLoopGroup.shutdownGracefully().await();
         }
     }
 }

--- a/pushy/src/test/java/com/turo/pushy/apns/server/MockApnsServerTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/server/MockApnsServerTest.java
@@ -23,13 +23,75 @@
 package com.turo.pushy.apns.server;
 
 import com.turo.pushy.apns.AbstractClientServerTest;
+import com.turo.pushy.apns.ApnsClient;
+import com.turo.pushy.apns.ApnsPushNotification;
+import com.turo.pushy.apns.PushNotificationResponse;
+import com.turo.pushy.apns.util.SimpleApnsPushNotification;
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.util.concurrent.Future;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import javax.net.ssl.SSLSession;
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
 
 public class MockApnsServerTest extends AbstractClientServerTest {
+
+    private static class TestMockApnsServerListener extends ParsingMockApnsServerListenerAdapter {
+
+        private final AtomicInteger acceptedNotifications = new AtomicInteger(0);
+        private final AtomicInteger rejectedNotifications = new AtomicInteger(0);
+
+        private ApnsPushNotification mostRecentPushNotification;
+        private RejectionReason mostRecentRejectionReason;
+        private Date mostRecentDeviceTokenExpiration;
+
+        @Override
+        public void handlePushNotificationAccepted(final ApnsPushNotification pushNotification) {
+            this.mostRecentPushNotification = pushNotification;
+            this.mostRecentRejectionReason = null;
+            this.mostRecentDeviceTokenExpiration = null;
+
+            this.acceptedNotifications.incrementAndGet();
+
+            synchronized (this.acceptedNotifications) {
+                this.acceptedNotifications.notifyAll();
+            }
+        }
+
+        public void waitForNonZeroAcceptedNotifications() throws InterruptedException {
+            synchronized (this.acceptedNotifications) {
+                while (this.acceptedNotifications.get() == 0) {
+                    this.acceptedNotifications.wait();
+                }
+            }
+        }
+
+        @Override
+        public void handlePushNotificationRejected(final ApnsPushNotification pushNotification, final RejectionReason rejectionReason, final Date deviceTokenExpirationTimestamp) {
+            this.mostRecentPushNotification = pushNotification;
+            this.mostRecentRejectionReason = rejectionReason;
+            this.mostRecentDeviceTokenExpiration = deviceTokenExpirationTimestamp;
+
+            this.rejectedNotifications.incrementAndGet();
+
+            synchronized (this.rejectedNotifications) {
+                this.rejectedNotifications.notifyAll();
+            }
+        }
+
+        public void waitForNonZeroRejectedNotifications() throws InterruptedException {
+            synchronized (this.rejectedNotifications) {
+                while (this.rejectedNotifications.get() == 0) {
+                    this.rejectedNotifications.wait();
+                }
+            }
+        }
+    }
 
     @Test
     public void testStartAndShutdown() throws Exception {
@@ -85,6 +147,154 @@ public class MockApnsServerTest extends AbstractClientServerTest {
             assertTrue(providedGroupServer.shutdown().await().isSuccess());
         } finally {
             eventLoopGroup.shutdownGracefully().await();
+        }
+    }
+
+    @Test
+    public void testListenerAcceptedNotification() throws Exception {
+        final TestMockApnsServerListener listener = new TestMockApnsServerListener();
+
+        final MockApnsServer server = this.buildServer(new AcceptAllPushNotificationHandlerFactory(), listener);
+        final ApnsClient client = this.buildTokenAuthenticationClient();
+
+        try {
+            server.start(PORT).await();
+
+            final SimpleApnsPushNotification pushNotification = new SimpleApnsPushNotification(DEVICE_TOKEN, TOPIC, PAYLOAD);
+
+            final PushNotificationResponse<SimpleApnsPushNotification> response =
+                    client.sendNotification(pushNotification).get();
+
+            assertTrue(response.isAccepted());
+
+            listener.waitForNonZeroAcceptedNotifications();
+
+            assertEquals(pushNotification.getToken(), listener.mostRecentPushNotification.getToken());
+            assertEquals(pushNotification.getTopic(), listener.mostRecentPushNotification.getTopic());
+            assertEquals(pushNotification.getPayload(), listener.mostRecentPushNotification.getPayload());
+        } finally {
+            client.close().await();
+            server.shutdown().await();
+        }
+    }
+
+    @Test
+    public void testListenerRejectedNotification() throws Exception {
+        final TestMockApnsServerListener listener = new TestMockApnsServerListener();
+
+        final MockApnsServer server = this.buildServer(new PushNotificationHandlerFactory() {
+
+            @Override
+            public PushNotificationHandler buildHandler(final SSLSession sslSession) {
+                return new PushNotificationHandler() {
+
+                    @Override
+                    public void handlePushNotification(final Http2Headers headers, final ByteBuf payload) throws RejectedNotificationException {
+                        throw new RejectedNotificationException(RejectionReason.BAD_DEVICE_TOKEN, null);
+                    }
+                };
+            }
+        }, listener);
+
+
+        final ApnsClient client = this.buildTokenAuthenticationClient();
+
+        try {
+            server.start(PORT).await();
+
+            final SimpleApnsPushNotification pushNotification = new SimpleApnsPushNotification(DEVICE_TOKEN, TOPIC, PAYLOAD);
+
+            final PushNotificationResponse<SimpleApnsPushNotification> response =
+                    client.sendNotification(pushNotification).get();
+
+            assertFalse(response.isAccepted());
+
+            listener.waitForNonZeroRejectedNotifications();
+
+            assertEquals(RejectionReason.BAD_DEVICE_TOKEN, listener.mostRecentRejectionReason);
+            assertNull(listener.mostRecentDeviceTokenExpiration);
+        } finally {
+            client.close().await();
+            server.shutdown().await();
+        }
+    }
+
+    @Test
+    public void testListenerRejectedNotificationWithExpiration() throws Exception {
+        final TestMockApnsServerListener listener = new TestMockApnsServerListener();
+        final Date expiration = new Date();
+
+        final MockApnsServer server = this.buildServer(new PushNotificationHandlerFactory() {
+            @Override
+            public PushNotificationHandler buildHandler(final SSLSession sslSession) {
+                return new PushNotificationHandler() {
+
+                    @Override
+                    public void handlePushNotification(final Http2Headers headers, final ByteBuf payload) throws RejectedNotificationException {
+                        throw new UnregisteredDeviceTokenException(expiration, null);
+                    }
+                };
+            }
+        }, listener);
+
+        final ApnsClient client = this.buildTokenAuthenticationClient();
+
+        try {
+            server.start(PORT).await();
+
+            final SimpleApnsPushNotification pushNotification = new SimpleApnsPushNotification(DEVICE_TOKEN, TOPIC, PAYLOAD);
+
+            final PushNotificationResponse<SimpleApnsPushNotification> response =
+                    client.sendNotification(pushNotification).get();
+
+            assertFalse(response.isAccepted());
+
+            listener.waitForNonZeroRejectedNotifications();
+
+            assertEquals(RejectionReason.UNREGISTERED, listener.mostRecentRejectionReason);
+            assertEquals(expiration, listener.mostRecentDeviceTokenExpiration);
+        } finally {
+            client.close().await();
+            server.shutdown().await();
+        }
+    }
+
+    @Test
+    public void testListenerInternalServerError() throws Exception {
+        final TestMockApnsServerListener listener = new TestMockApnsServerListener();
+
+        final MockApnsServer server = this.buildServer(new PushNotificationHandlerFactory() {
+
+            @Override
+            public PushNotificationHandler buildHandler(final SSLSession sslSession) {
+                return new PushNotificationHandler() {
+
+                    @Override
+                    public void handlePushNotification(final Http2Headers headers, final ByteBuf payload) {
+                        throw new RuntimeException("Everything is terrible.");
+                    }
+                };
+            }
+        }, listener);
+
+        final ApnsClient client = this.buildTokenAuthenticationClient();
+
+        try {
+            server.start(PORT).await();
+
+            final SimpleApnsPushNotification pushNotification = new SimpleApnsPushNotification(DEVICE_TOKEN, TOPIC, PAYLOAD);
+
+            final Future<PushNotificationResponse<SimpleApnsPushNotification>> sendFuture =
+                    client.sendNotification(pushNotification).await();
+
+            assertFalse(sendFuture.isSuccess());
+
+            listener.waitForNonZeroRejectedNotifications();
+
+            assertEquals(RejectionReason.INTERNAL_SERVER_ERROR, listener.mostRecentRejectionReason);
+        } finally {
+            client.close().await();
+            server.shutdown().await();
         }
     }
 }

--- a/pushy/src/test/java/com/turo/pushy/apns/server/ParsingMockApnsServerListenerAdapterTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/server/ParsingMockApnsServerListenerAdapterTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2013-2018 Turo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.turo.pushy.apns.server;
+
+import com.turo.pushy.apns.ApnsPushNotification;
+import com.turo.pushy.apns.DeliveryPriority;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.util.AsciiString;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ParsingMockApnsServerListenerAdapterTest {
+
+    private static final String APNS_PATH_PREFIX = "/3/device/";
+    private static final AsciiString APNS_TOPIC_HEADER = new AsciiString("apns-topic");
+    private static final AsciiString APNS_PRIORITY_HEADER = new AsciiString("apns-priority");
+    private static final AsciiString APNS_EXPIRATION_HEADER = new AsciiString("apns-expiration");
+    private static final AsciiString APNS_COLLAPSE_ID_HEADER = new AsciiString("apns-collapse-id");
+
+    private static class TestParsingMockApnsServerListener extends ParsingMockApnsServerListenerAdapter {
+
+        private ApnsPushNotification mostRecentPushNotification;
+        private RejectionReason mostRecentRejectionReason;
+        private Date mostRecentDeviceTokenExpiration;
+
+        @Override
+        public void handlePushNotificationAccepted(final ApnsPushNotification pushNotification) {
+            this.mostRecentPushNotification = pushNotification;
+            this.mostRecentRejectionReason = null;
+            this.mostRecentDeviceTokenExpiration = null;
+        }
+
+        @Override
+        public void handlePushNotificationRejected(final ApnsPushNotification pushNotification, final RejectionReason rejectionReason, final Date deviceTokenExpirationTimestamp) {
+            this.mostRecentPushNotification = pushNotification;
+            this.mostRecentRejectionReason = rejectionReason;
+            this.mostRecentDeviceTokenExpiration = deviceTokenExpirationTimestamp;
+        }
+    }
+
+    @Test
+    public void testHandlePushNotificationAccepted() {
+        final TestParsingMockApnsServerListener listener = new TestParsingMockApnsServerListener();
+
+        {
+            final String token = "test-token";
+
+            final Http2Headers headers = new DefaultHttp2Headers().path(APNS_PATH_PREFIX + token);
+
+            listener.handlePushNotificationAccepted(headers, null);
+
+            assertEquals(token, listener.mostRecentPushNotification.getToken());
+            assertNull(listener.mostRecentPushNotification.getTopic());
+            assertNull(listener.mostRecentPushNotification.getPriority());
+            assertNull(listener.mostRecentPushNotification.getExpiration());
+            assertNull(listener.mostRecentPushNotification.getCollapseId());
+            assertNull(listener.mostRecentPushNotification.getPayload());
+        }
+
+        {
+            final String topic = "test-topic";
+
+            final Http2Headers headers = new DefaultHttp2Headers().add(APNS_TOPIC_HEADER, topic);
+
+            listener.handlePushNotificationAccepted(headers, null);
+
+            assertNull(listener.mostRecentPushNotification.getToken());
+            assertEquals(topic, listener.mostRecentPushNotification.getTopic());
+            assertNull(listener.mostRecentPushNotification.getPriority());
+            assertNull(listener.mostRecentPushNotification.getExpiration());
+            assertNull(listener.mostRecentPushNotification.getCollapseId());
+            assertNull(listener.mostRecentPushNotification.getPayload());
+        }
+
+        {
+            final DeliveryPriority priority = DeliveryPriority.CONSERVE_POWER;
+
+            final Http2Headers headers = new DefaultHttp2Headers().addInt(APNS_PRIORITY_HEADER, priority.getCode());
+
+            listener.handlePushNotificationAccepted(headers, null);
+
+            assertNull(listener.mostRecentPushNotification.getToken());
+            assertNull(listener.mostRecentPushNotification.getTopic());
+            assertEquals(priority, listener.mostRecentPushNotification.getPriority());
+            assertNull(listener.mostRecentPushNotification.getExpiration());
+            assertNull(listener.mostRecentPushNotification.getCollapseId());
+            assertNull(listener.mostRecentPushNotification.getPayload());
+        }
+
+        {
+            final Date expiration = new Date(1_000_000_000);
+
+            final Http2Headers headers = new DefaultHttp2Headers().addInt(APNS_EXPIRATION_HEADER, (int) (expiration.getTime() / 1000));
+
+            listener.handlePushNotificationAccepted(headers, null);
+
+            assertNull(listener.mostRecentPushNotification.getToken());
+            assertNull(listener.mostRecentPushNotification.getTopic());
+            assertNull(listener.mostRecentPushNotification.getPriority());
+            assertEquals(expiration, listener.mostRecentPushNotification.getExpiration());
+            assertNull(listener.mostRecentPushNotification.getCollapseId());
+            assertNull(listener.mostRecentPushNotification.getPayload());
+        }
+
+        {
+            final String collapseId = "collapse-id";
+
+            final Http2Headers headers = new DefaultHttp2Headers().add(APNS_COLLAPSE_ID_HEADER, collapseId);
+
+            listener.handlePushNotificationAccepted(headers, null);
+
+            assertNull(listener.mostRecentPushNotification.getToken());
+            assertNull(listener.mostRecentPushNotification.getTopic());
+            assertNull(listener.mostRecentPushNotification.getPriority());
+            assertNull(listener.mostRecentPushNotification.getExpiration());
+            assertEquals(collapseId, listener.mostRecentPushNotification.getCollapseId());
+            assertNull(listener.mostRecentPushNotification.getPayload());
+        }
+
+        {
+            final String payload = "A test payload!";
+
+            final Http2Headers headers = new DefaultHttp2Headers();
+
+            final ByteBuf payloadBuffer = ByteBufUtil.writeUtf8(UnpooledByteBufAllocator.DEFAULT, payload);
+
+            try {
+                listener.handlePushNotificationAccepted(headers, payloadBuffer);
+
+                assertNull(listener.mostRecentPushNotification.getToken());
+                assertNull(listener.mostRecentPushNotification.getTopic());
+                assertNull(listener.mostRecentPushNotification.getPriority());
+                assertNull(listener.mostRecentPushNotification.getExpiration());
+                assertNull(listener.mostRecentPushNotification.getCollapseId());
+                assertEquals(payload, listener.mostRecentPushNotification.getPayload());
+            } finally {
+                payloadBuffer.release();
+            }
+        }
+    }
+
+    @Test
+    public void testHandlePushNotificationRejected() {
+        final TestParsingMockApnsServerListener listener = new TestParsingMockApnsServerListener();
+
+        {
+            final RejectionReason rejectionReason = RejectionReason.BAD_DEVICE_TOKEN;
+
+            listener.handlePushNotificationRejected(new DefaultHttp2Headers(), null, rejectionReason, null);
+            assertEquals(rejectionReason, listener.mostRecentRejectionReason);
+            assertNull(listener.mostRecentDeviceTokenExpiration);
+        }
+
+        {
+            final RejectionReason rejectionReason = RejectionReason.BAD_PRIORITY;
+            final Date deviceTokenExpiration = new Date();
+
+            listener.handlePushNotificationRejected(new DefaultHttp2Headers(), null, rejectionReason, deviceTokenExpiration);
+            assertEquals(rejectionReason, listener.mostRecentRejectionReason);
+            assertEquals(deviceTokenExpiration, listener.mostRecentDeviceTokenExpiration);
+        }
+    }
+}


### PR DESCRIPTION
This closes #417 by introducing mock server listeners that are notified when a mock server accepts or rejects a push notification. This is very much a work in progress, but because it was a specific feature request, I wanted to share an early draft to gather feedback. @ebabani @kdubb, I'd be particularly curious about what you think of this approach.

~Depends on #526.~

TODO:

- [x] Tests
- [x] Documentation
- [x] No-op listener pattern?
- [x] Use `ApnsHeaderUtil` in more places (or drop it?)