### PR TITLE
Expand docs for `ApnsPayloadBuilder#addCustomProperty`

### DIFF
--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -85,6 +85,7 @@
                     <show>public</show>
                     <links>
                         <link>http://netty.io/4.1/api/</link>
+                        <link>https://google.github.io/gson/apidocs/</link>
                     </links>
                 </configuration>
             </plugin>

--- a/pushy/src/main/java/com/turo/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/util/ApnsPayloadBuilder.java
@@ -98,8 +98,7 @@ public class ApnsPayloadBuilder {
     private static final Gson GSON = new GsonBuilder().serializeNulls().disableHtmlEscaping().create();
 
     /**
-     * The name of the iOS default push notification sound
-     * ({@value ApnsPayloadBuilder#DEFAULT_SOUND_FILENAME}).
+     * The name of the iOS default push notification sound.
      *
      * @see ApnsPayloadBuilder#setSoundFileName(String)
      */
@@ -517,10 +516,18 @@ public class ApnsPayloadBuilder {
      * identifying when the provider sent the notification. Any action associated with an alert message should not be
      * destructive—for example, it should not delete data on the device.</blockquote>
      *
+     * <p>The value for the property is serialized to JSON by <a href="https://github.com/google/gson">Gson</a>. For
+     * a detailed explanation of how Gson serializes Java objects to JSON, please see the
+     * <a href="https://github.com/google/gson/blob/master/UserGuide.md#TOC-Using-Gson">Gson User Guide</a>.</p>
+     *
      * @param key the key of the custom property in the payload object
      * @param value the value of the custom property
      *
      * @return a reference to this payload builder
+     *
+     * @see Gson#toJson(Object)
+     * @see <a href="https://github.com/google/gson/blob/master/UserGuide.md#TOC-Using-Gson">Gson User Guide - Using
+     * Gson</a>
      */
     public ApnsPayloadBuilder addCustomProperty(final String key, final Object value) {
         this.customProperties.put(key, value);


### PR DESCRIPTION
This closes #545 by providing links to the [Gson user's guide](https://github.com/google/gson/blob/master/UserGuide.md), which explains in detail how objects are serialized to JSON. This should remove any ambiguity about what happens when non-primitive objects are passed as values to `ApnsPayloadBuilder#addCustomProperty(String, Object)`.