### PR TITLE
Update to Netty 4.1.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>2.0.6.Final</version>
+                <version>2.0.7.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>
@@ -106,7 +106,7 @@
     </licenses>
 
     <properties>
-        <netty.version>4.1.16.Final</netty.version>
+        <netty.version>4.1.17.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
This brings us up to the [latest version of Netty](http://netty.io/news/2017/11/08/4-0-53-Final-4-1-17-Final.html) and netty-tcnative. One fix that really stands out to me is https://github.com/netty/netty/pull/7338, particularly given #425. @yanggz01 if you're feeling adventurous and want to give this a try, I'd love to hear if it helps.

Thanks!