### PR TITLE
add DynamicInetProvider to get ip of gateway dynamiclly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,11 @@
                 <version>1.10</version>
             </dependency>
             <dependency>
+        	<groupId>dnsjava</groupId>
+        	<artifactId>dnsjava</artifactId>
+        	<version>2.1.7</version>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -72,6 +72,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
         </dependency>
+        <dependency>
+        	<groupId>dnsjava</groupId>
+        	<artifactId>dnsjava</artifactId>
+        	<version>2.1.7</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -25,7 +25,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>pushy</artifactId>
-    <version>0.11.3</version>
     <name>Pushy</name>
 
     <parent>
@@ -75,7 +74,6 @@
         <dependency>
         	<groupId>dnsjava</groupId>
         	<artifactId>dnsjava</artifactId>
-        	<version>2.1.7</version>
         </dependency>
     </dependencies>
 

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
@@ -33,7 +33,6 @@ import io.netty.util.concurrent.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -126,7 +125,7 @@ public class ApnsClient {
         }
     }
 
-    protected ApnsClient(final InetSocketAddress apnsServerAddress, final SslContext sslContext,
+    protected ApnsClient(final ApnsInetProvider apnsInetProvider, final SslContext sslContext,
                          final ApnsSigningKey signingKey,  final ProxyHandlerFactory proxyHandlerFactory,
                          final int connectTimeoutMillis, final long idlePingIntervalMillis,
                          final long gracefulShutdownTimeoutMillis, final int concurrentConnections,
@@ -142,7 +141,7 @@ public class ApnsClient {
 
         this.metricsListener = metricsListener != null ? metricsListener : new NoopApnsClientMetricsListener();
 
-        final ApnsChannelFactory channelFactory = new ApnsChannelFactory(sslContext, signingKey, proxyHandlerFactory, connectTimeoutMillis, idlePingIntervalMillis, gracefulShutdownTimeoutMillis, apnsServerAddress, this.eventLoopGroup);
+        final ApnsChannelFactory channelFactory = new ApnsChannelFactory(sslContext, signingKey, proxyHandlerFactory, connectTimeoutMillis, idlePingIntervalMillis, gracefulShutdownTimeoutMillis, apnsInetProvider, this.eventLoopGroup);
 
         final ApnsChannelPoolMetricsListener channelPoolMetricsListener = new ApnsChannelPoolMetricsListener() {
 

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientBuilder.java
@@ -37,7 +37,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetSocketAddress;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.PrivateKey;
@@ -52,7 +51,7 @@ import java.util.concurrent.TimeUnit;
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
  */
 public class ApnsClientBuilder {
-    private InetSocketAddress apnsServerAddress;
+    private ApnsInetProvider apnsInetProvider;
 
     private X509Certificate clientCertificate;
     private PrivateKey privateKey;
@@ -157,7 +156,12 @@ public class ApnsClientBuilder {
      * @since 0.11
      */
     public ApnsClientBuilder setApnsServer(final String hostname, final int port) {
-        this.apnsServerAddress = new InetSocketAddress(hostname, port);
+        this.apnsInetProvider = new SimpleInetProvider(hostname, port);
+        return this;
+    }
+    
+    public ApnsClientBuilder setApnsServerProvider(ApnsInetProvider provider) {
+        this.apnsInetProvider = provider;
         return this;
     }
 
@@ -474,8 +478,8 @@ public class ApnsClientBuilder {
      * @since 0.8
      */
     public ApnsClient build() throws SSLException {
-        if (this.apnsServerAddress == null) {
-            throw new IllegalStateException("No APNs server address specified.");
+        if (this.apnsInetProvider == null) {
+            throw new IllegalStateException("No APNs server provider specified.");
         }
 
         if (this.clientCertificate == null && this.privateKey == null && this.signingKey == null) {
@@ -513,7 +517,7 @@ public class ApnsClientBuilder {
             sslContext = sslContextBuilder.build();
         }
 
-        final ApnsClient client = new ApnsClient(this.apnsServerAddress, sslContext, this.signingKey,
+        final ApnsClient client = new ApnsClient(this.apnsInetProvider, sslContext, this.signingKey,
                 this.proxyHandlerFactory, this.connectionTimeoutMillis, this.idlePingIntervalMillis,
                 this.gracefulShutdownTimeoutMillis, this.concurrentConnections, this.metricsListener,
                 this.eventLoopGroup);

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsInetProvider.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsInetProvider.java
@@ -1,0 +1,13 @@
+package com.turo.pushy.apns;
+
+import java.net.InetSocketAddress;
+
+/**
+ * interface for getting inetaddress for ApnsClient
+ * we can implement several ways to get it:
+ * static(simple), dynamic, or with performance detection(not implement yet)
+ * @author hblzxsj
+ */
+public interface ApnsInetProvider {
+    public InetSocketAddress getInetAddress();
+}

--- a/pushy/src/main/java/com/turo/pushy/apns/DynamicInetProvider.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/DynamicInetProvider.java
@@ -1,0 +1,170 @@
+package com.turo.pushy.apns;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.xbill.DNS.Lookup;
+import org.xbill.DNS.Name;
+import org.xbill.DNS.Record;
+import org.xbill.DNS.SimpleResolver;
+import org.xbill.DNS.TextParseException;
+import org.xbill.DNS.Type;
+
+/**
+ * for creating new connections dynamicly to different gateways
+ * 
+ * for DEMO
+ * DynamicInetProvider provider = new DynamicInetProvider("api.push.apple.com", ApnsClientBuilder.DEFAULT_APNS_PORT);
+ * provider.addDnsServer("114.114.114.114");
+ * provider.addDnsServer("223.5.5.5");
+ * provider.addDnsServer("180.76.76.76");
+ * provider.start();
+ * try {
+ *     Thread.sleep(5000); //wait for fetching address async
+ * } catch (InterruptedException e1) {
+ * }
+ * int count = 8;
+ * while(count -- > 0) {
+ *     System.out.println(provider.getInetAddress());
+ * }
+ * 
+ * @author hblzxsj
+ *
+ */
+public class DynamicInetProvider implements ApnsInetProvider {
+    String host;
+    int port;
+    HostnameResolver resolver;
+    boolean shouldStop = false;
+    Map<String, Long> hostMap;
+    List<String> hostList;
+    List<SimpleResolver> dnsServers;
+    int ttl = 300;
+    int fetchInterval = 60;
+    
+    class HostnameResolver extends Thread {
+        
+        public HostnameResolver() {
+            super();
+            setDaemon(true);
+        }
+        
+        @Override
+        public void run() {
+            HashSet<String> ipList = new HashSet<>();
+            Name name;
+            try {
+                name = new Name(host);
+            } catch (TextParseException e1) {
+                throw new RuntimeException("hostname format illegal");
+            }
+            Lookup lookup = new Lookup(name, Type.A);
+            lookup.setCache(null);
+            Record[] records;
+            while (!shouldStop) {
+                ipList.clear();
+                for (SimpleResolver resolver : dnsServers) {
+                    lookup.setResolver(resolver);
+                    records = lookup.run();
+                    if (records == null || records.length == 0) {
+                        continue;
+                    }
+                    for (Record record : records) {
+                        ipList.add(record.rdataToString());
+                    }
+                }
+                synchronized (hostList) {
+                    long now = System.currentTimeMillis();
+                    for (String ip : ipList) {
+                        hostMap.put(ip, now);
+                        if (!hostList.contains(ip)) {
+                            hostList.add(ip);
+                        }
+                    }
+                    //remove expires
+                    Iterator<Entry<String, Long>> iterator = hostMap.entrySet().iterator();
+                    while (iterator.hasNext()) {
+                        Entry<String, Long> entry = iterator.next();
+                        if (now - entry.getValue() > ttl * 1000) {
+                            hostList.remove(entry.getKey());
+                            iterator.remove();
+                        }
+                    }
+                }
+                try {
+                    int counter = fetchInterval;
+                    while (counter -- > 0) {
+                        sleep(1000);
+                        if (shouldStop) {
+                            break;
+                        }
+                    }
+                } catch (InterruptedException e) {
+                }
+            }
+        }
+    }
+    
+    public DynamicInetProvider(String host, int port) {
+        this.host = host;
+        this.port = port;
+        this.resolver = new HostnameResolver();
+        this.hostMap = new HashMap<>(100);
+        this.hostList = new ArrayList<>();
+        this.dnsServers = new ArrayList<>();
+    }
+
+    @Override
+    public InetSocketAddress getInetAddress() {
+        if (hostMap.size() < 1) {
+            //fail back
+            return new InetSocketAddress(host, port);
+        }
+        synchronized (hostList) {
+            int index = (int) (Math.random() * hostList.size());
+            return new InetSocketAddress(hostList.get(index), port);
+        }
+    }
+    
+    public void addDnsServer(String host) {
+        try {
+            dnsServers.add(new SimpleResolver(host));
+        } catch (UnknownHostException e) {
+        }
+    }
+    
+    public void start() {
+        this.resolver.start();
+    }
+    
+    public String[] getHostList() {
+        return hostList.toArray(new String[] {});
+    }
+
+    public void shutdown() {
+        shouldStop = true;
+    }
+    
+    /**
+     * set the expire time in seconds of the ip records
+     * @param ttl
+     */
+    public void setTTL(int ttl) {
+        this.ttl = ttl;
+    }
+
+    /**
+     * set the interval in seconds between trying to retrieve new ips from dns 
+     * @param fetchInterval
+     */
+    public void setFetchInterval(int fetchInterval) {
+        this.fetchInterval = fetchInterval;
+    }
+
+}

--- a/pushy/src/main/java/com/turo/pushy/apns/SimpleInetProvider.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/SimpleInetProvider.java
@@ -1,0 +1,17 @@
+package com.turo.pushy.apns;
+
+import java.net.InetSocketAddress;
+
+public class SimpleInetProvider implements ApnsInetProvider {
+    private InetSocketAddress address;
+    
+    public SimpleInetProvider(String host, int port) {
+        address = new InetSocketAddress(host, port);
+    }
+
+    @Override
+    public InetSocketAddress getInetAddress() {
+        return address;
+    }
+
+}


### PR DESCRIPTION
provide two implementation by default:

- SimpleInetProvider
totally same as previous
- DynamicInetProvider
can load ip list periodly from dns servers given. maybe about 70~100 ip in list after several minutes running.

we improve the performance from 4 ~ 20k to 30 ~ 38k per node with the time reducing from 40 ~ 55 mins to less than 14 mins. 4.18m tokens with 5 2cores/4g nodes.

our config:
ipush.threadnum = 6 //io threads in nettty
ipush.connections = 128 //concurance
ipush.qps = 5000 //how many msgs remaining waiting for "completion notification", we will not add more to netty when we reach this.


before dynamic:

<img width="1173" alt="2017-11-26 12 48 20" src="https://user-images.githubusercontent.com/17573073/33237214-23b6851e-d2a8-11e7-96ea-ee8d99a45fd9.png">
<img width="1177" alt="2017-11-26 12 48 53" src="https://user-images.githubusercontent.com/17573073/33237220-58537cbe-d2a8-11e7-94d1-5604926ea5c7.png">


after dynamically

<img width="1159" alt="2017-11-26 12 47 45" src="https://user-images.githubusercontent.com/17573073/33237212-1155aa8a-d2a8-11e7-9f59-5857accac30a.png">

several days during optimizing:

<img width="913" alt="2017-11-26 12 51 34" src="https://user-images.githubusercontent.com/17573073/33237227-a45fced2-d2a8-11e7-9d37-3d2e659e80a4.png">
