### PR TITLE
[add]support retry mechanism when acquiring channel or sending notification fail

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
@@ -98,7 +98,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
     private static final IllegalStateException CLIENT_CLOSED_EXCEPTION =
             new IllegalStateException("Client has been closed and can no longer send push notifications.");
 
-    // can be a parameter of construct method
+    // can be a parameter of construct method;must set maxRetryCount to prevent from OOM
     private final int maxRetryCount = 3;
 
     private static final Exception CAN_NOT_ACQUIRE_CHANNEL_OR_WRITE_WITH_RETRY =

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
@@ -102,7 +102,7 @@ public class ApnsClient<T extends ApnsPushNotification> {
     private final int maxRetryCount = 3;
 
     private static final Exception CAN_NOT_ACQUIRE_CHANNEL_OR_WRITE_WITH_RETRY =
-            new ApnsServerException("can not acquire channel with retry.");
+            new ApnsServerException("can not acquire channel or write with retry.");
 
     private final Queue<PushNotificationPromise<T, PushNotificationResponse<T>>> retryPromises = new ArrayDeque<>();
 

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
@@ -31,6 +31,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http2.*;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.AsciiString;
@@ -239,6 +240,7 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
                 .method(HttpMethod.POST.asciiName())
                 .authority(this.authority)
                 .path(APNS_PATH_PREFIX + pushNotification.getToken())
+                .scheme(HttpScheme.HTTPS.name())
                 .addInt(APNS_EXPIRATION_HEADER, pushNotification.getExpiration() == null ? 0 : (int) (pushNotification.getExpiration().getTime() / 1000));
 
         if (pushNotification.getCollapseId() != null) {

--- a/pushy/src/main/java/com/turo/pushy/apns/PushNotificationPromise.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/PushNotificationPromise.java
@@ -8,14 +8,21 @@ class PushNotificationPromise<P extends ApnsPushNotification, V> extends Default
 
     private final P pushNotification;
 
+    // save retry count
+    private int retryCount;
+
     PushNotificationPromise(final EventExecutor eventExecutor, final P pushNotification) {
         super(eventExecutor);
-
+        retryCount = 0;
         this.pushNotification = pushNotification;
     }
 
     @Override
     public P getPushNotification() {
         return this.pushNotification;
+    }
+
+    public int retryAndGet() {
+        return ++retryCount;
     }
 }

--- a/pushy/src/test/java/com/turo/pushy/apns/ApnsClientTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/ApnsClientTest.java
@@ -370,7 +370,7 @@ public class ApnsClientTest {
         final MockApnsServer server = this.buildServer(expireFirstTokenHandlerFactory);
 
         final TestMetricsListener metricsListener = new TestMetricsListener();
-        final ApnsClient client = this.buildTokenAuthenticationClient(metricsListener);
+        final ApnsClient<SimpleApnsPushNotification> client = this.buildTokenAuthenticationClient(metricsListener);
 
         try {
             server.start(PORT).await();
@@ -545,7 +545,7 @@ public class ApnsClientTest {
                 new SimpleApnsPushNotification(DEVICE_TOKEN, TOPIC, PAYLOAD);
 
         final MockApnsServer server = this.buildServer(handlerFactory);
-        final ApnsClient client = useTokenAuthentication ?
+        final ApnsClient<SimpleApnsPushNotification> client = useTokenAuthentication ?
                 this.buildTokenAuthenticationClient() : this.buildTlsAuthenticationClient();
 
         try {
@@ -615,7 +615,7 @@ public class ApnsClientTest {
         final MockApnsServer server = this.buildServer(new AcceptAllPushNotificationHandlerFactory());
 
         final TestMetricsListener metricsListener = new TestMetricsListener();
-        final ApnsClient client = useTokenAuthentication ?
+        final ApnsClient<SimpleApnsPushNotification> client = useTokenAuthentication ?
                 this.buildTokenAuthenticationClient(metricsListener) : this.buildTlsAuthenticationClient(metricsListener);
 
         try {

--- a/pushy/src/test/java/com/turo/pushy/apns/ApnsClientTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/ApnsClientTest.java
@@ -339,7 +339,7 @@ public class ApnsClientTest {
                 this.topicsByVerificationKey);
 
         final MockApnsServer server = this.buildServer(handlerFactory);
-        final ApnsClient client = useTokenAuthentication ?
+        final ApnsClient<SimpleApnsPushNotification> client = useTokenAuthentication ?
                 this.buildTokenAuthenticationClient() : this.buildTlsAuthenticationClient();
 
         try {


### PR DESCRIPTION
add code to ApnsClient class:
1. add a queue to save the PushNotificationPromise if send it fail
2. add a period task to consume PushNotificationPromise in the queue