### PR TITLE
Add client and server support for `apns-id` headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If you don't use Maven (or something else that understands Maven dependencies, l
 - [Apache Commons Codec 1.10](https://commons.apache.org/proper/commons-codec/)
 - [gson 2.6](https://github.com/google/gson)
 - [slf4j 1.7](http://www.slf4j.org/) (and possibly an SLF4J binding, as described in the [logging](#logging) section below)
+- [fast-uuid 0.1](https://github.com/jchambers/fast-uuid)
 
 Pushy itself requires Java 7 or newer to build and run.
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
                 <version>2.0.7.Final</version>
             </dependency>
             <dependency>
+                <groupId>com.eatthepath</groupId>
+                <artifactId>fast-uuid</artifactId>
+                <version>0.1</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>2.8.0</version>

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -48,6 +48,10 @@
             <artifactId>netty-tcnative-boringssl-static</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.eatthepath</groupId>
+            <artifactId>fast-uuid</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
@@ -65,7 +65,6 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
     private static final AsciiString APNS_TOPIC_HEADER = new AsciiString("apns-topic");
     private static final AsciiString APNS_PRIORITY_HEADER = new AsciiString("apns-priority");
     private static final AsciiString APNS_COLLAPSE_ID_HEADER = new AsciiString("apns-collapse-id");
-
     private static final AsciiString APNS_ID_HEADER = new AsciiString("apns-id");
 
     private static final int INITIAL_PAYLOAD_BUFFER_CAPACITY = 4096;
@@ -256,6 +255,10 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
             headers.add(APNS_TOPIC_HEADER, pushNotification.getTopic());
         }
 
+        if (pushNotification.getApnsId() != null) {
+            headers.add(APNS_ID_HEADER, pushNotification.getApnsId().toString());
+        }
+
         return headers;
     }
 
@@ -369,7 +372,13 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
 
     private static UUID getApnsIdFromHeaders(final Http2Headers headers) {
         final CharSequence apnsIdSequence = headers.get(APNS_ID_HEADER);
-        return apnsIdSequence != null ? UUID.fromString(apnsIdSequence.toString()) : null;
+
+        try {
+            return apnsIdSequence != null ? UUID.fromString(apnsIdSequence.toString()) : null;
+        } catch (final IllegalArgumentException e) {
+            log.error("Failed to parse `apns-id` header: {}", apnsIdSequence, e);
+            return null;
+        }
     }
 
     @Override

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
@@ -22,6 +22,7 @@
 
 package com.turo.pushy.apns;
 
+import com.eatthepath.uuid.FastUUID;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.turo.pushy.apns.util.DateAsTimeSinceEpochTypeAdapter;
@@ -256,7 +257,7 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
         }
 
         if (pushNotification.getApnsId() != null) {
-            headers.add(APNS_ID_HEADER, pushNotification.getApnsId().toString());
+            headers.add(APNS_ID_HEADER, FastUUID.toString(pushNotification.getApnsId()));
         }
 
         return headers;
@@ -374,7 +375,7 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
         final CharSequence apnsIdSequence = headers.get(APNS_ID_HEADER);
 
         try {
-            return apnsIdSequence != null ? UUID.fromString(apnsIdSequence.toString()) : null;
+            return apnsIdSequence != null ? FastUUID.parseUUID(apnsIdSequence) : null;
         } catch (final IllegalArgumentException e) {
             log.error("Failed to parse `apns-id` header: {}", apnsIdSequence, e);
             return null;

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsPushNotification.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsPushNotification.java
@@ -22,14 +22,18 @@
 
 package com.turo.pushy.apns;
 
-import java.util.Date;
-
 import com.turo.pushy.apns.util.ApnsPayloadBuilder;
+
+import java.util.Date;
+import java.util.UUID;
 
 /**
  * <p>A push notification that can be sent through the Apple Push Notification service (APNs). Push notifications have a
  * token that identifies the device to which it should be sent, a topic (generally the bundle ID of the receiving app),
  * a JSON payload, and (optionally) a time at which the notification is invalid and should no longer be delivered.</p>
+ *
+ * <p>Push notifications may also include a unique identifier that will be echoed in responses from the APNs server. If
+ * no identifier is provided, the server will assign an identifier automatically.</p>
  *
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
  *
@@ -38,6 +42,7 @@ import com.turo.pushy.apns.util.ApnsPayloadBuilder;
  *      Local and Remote Notification Programming Guide - Apple Push Notification Service</a>
  *
  * @see ApnsPayloadBuilder
+ * @see PushNotificationResponse#getApnsId()
  *
  * @since 0.1
  */
@@ -101,4 +106,14 @@ public interface ApnsPushNotification {
      * @since 0.8.1
      */
     String getCollapseId();
+
+    /**
+     * Returns the canonical identifier for this push notification. The APNs server will include the given identifier in
+     * all responses related to this push notification. If no identifier is provided, the server will assign a unique
+     * identifier automatically.
+     *
+     * @return a unique identifier for this notification; may be {@code null}, in which case the APNs server will assign
+     * an identifier automatically
+     */
+    UUID getApnsId();
 }

--- a/pushy/src/main/java/com/turo/pushy/apns/PushNotificationResponse.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/PushNotificationResponse.java
@@ -23,6 +23,7 @@
 package com.turo.pushy.apns;
 
 import java.util.Date;
+import java.util.UUID;
 
 /**
  * A response from the APNs gateway indicating whether a notification was accepted or rejected.
@@ -52,6 +53,13 @@ public interface PushNotificationResponse<T extends ApnsPushNotification> {
      * @since 0.5
      */
     boolean isAccepted();
+
+    /**
+     * Returns the ID assigned to this push notification by the APNs server.
+     *
+     * @return the ID assigned to this push notification by the APNs server
+     */
+    UUID getApnsId();
 
     /**
      * Returns the reason for rejection reported by the APNs gateway. If the notification was accepted, the rejection

--- a/pushy/src/main/java/com/turo/pushy/apns/SimplePushNotificationResponse.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/SimplePushNotificationResponse.java
@@ -23,6 +23,7 @@
 package com.turo.pushy.apns;
 
 import java.util.Date;
+import java.util.UUID;
 
 /**
  * A trivial and immutable implementation of the {@link PushNotificationResponse} interface.
@@ -32,12 +33,14 @@ import java.util.Date;
 class SimplePushNotificationResponse<T extends ApnsPushNotification> implements PushNotificationResponse<T> {
     private final T pushNotification;
     private final boolean success;
+    private final UUID apnsId;
     private final String rejectionReason;
     private final Date tokenExpirationTimestamp;
 
-    public SimplePushNotificationResponse(final T pushNotification, final boolean success, final String rejectionReason, final Date tokenExpirationTimestamp) {
+    SimplePushNotificationResponse(final T pushNotification, final boolean success, final UUID apnsId, final String rejectionReason, final Date tokenExpirationTimestamp) {
         this.pushNotification = pushNotification;
         this.success = success;
+        this.apnsId = apnsId;
         this.rejectionReason = rejectionReason;
         this.tokenExpirationTimestamp = tokenExpirationTimestamp;
     }
@@ -53,6 +56,11 @@ class SimplePushNotificationResponse<T extends ApnsPushNotification> implements 
     }
 
     @Override
+    public UUID getApnsId() {
+        return this.apnsId;
+    }
+
+    @Override
     public String getRejectionReason() {
         return this.rejectionReason;
     }
@@ -62,21 +70,14 @@ class SimplePushNotificationResponse<T extends ApnsPushNotification> implements 
         return this.tokenExpirationTimestamp;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder();
-        builder.append("SimplePushNotificationResponse [pushNotification=");
-        builder.append(this.pushNotification);
-        builder.append(", success=");
-        builder.append(this.success);
-        builder.append(", rejectionReason=");
-        builder.append(this.rejectionReason);
-        builder.append(", tokenExpirationTimestamp=");
-        builder.append(this.tokenExpirationTimestamp);
-        builder.append("]");
-        return builder.toString();
+        return "SimplePushNotificationResponse{" +
+                "pushNotification=" + pushNotification +
+                ", success=" + success +
+                ", apnsId=" + apnsId +
+                ", rejectionReason='" + rejectionReason + '\'' +
+                ", tokenExpirationTimestamp=" + tokenExpirationTimestamp +
+                '}';
     }
 }

--- a/pushy/src/main/java/com/turo/pushy/apns/SimplePushNotificationResponse.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/SimplePushNotificationResponse.java
@@ -22,6 +22,8 @@
 
 package com.turo.pushy.apns;
 
+import com.eatthepath.uuid.FastUUID;
+
 import java.util.Date;
 import java.util.UUID;
 
@@ -75,7 +77,7 @@ class SimplePushNotificationResponse<T extends ApnsPushNotification> implements 
         return "SimplePushNotificationResponse{" +
                 "pushNotification=" + pushNotification +
                 ", success=" + success +
-                ", apnsId=" + apnsId +
+                ", apnsId=" + (apnsId != null ? FastUUID.toString(apnsId) : null) +
                 ", rejectionReason='" + rejectionReason + '\'' +
                 ", tokenExpirationTimestamp=" + tokenExpirationTimestamp +
                 '}';

--- a/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerHandler.java
@@ -264,7 +264,17 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
         final UUID apnsId;
         {
             final CharSequence apnsIdSequence = headers.get(APNS_ID_HEADER);
-            apnsId = apnsIdSequence != null ? UUID.fromString(apnsIdSequence.toString()) : UUID.randomUUID();
+
+            UUID apnsIdFromHeaders;
+
+            try {
+                apnsIdFromHeaders = apnsIdSequence != null ? UUID.fromString(apnsIdSequence.toString()) : UUID.randomUUID();
+            } catch (final IllegalArgumentException e) {
+                log.error("Failed to parse `apns-id` header: {}", apnsIdSequence, e);
+                apnsIdFromHeaders = UUID.randomUUID();
+            }
+
+            apnsId = apnsIdFromHeaders;
         }
 
         try {

--- a/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerHandler.java
@@ -22,6 +22,7 @@
 
 package com.turo.pushy.apns.server;
 
+import com.eatthepath.uuid.FastUUID;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.turo.pushy.apns.util.DateAsTimeSinceEpochTypeAdapter;
@@ -268,7 +269,7 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
             UUID apnsIdFromHeaders;
 
             try {
-                apnsIdFromHeaders = apnsIdSequence != null ? UUID.fromString(apnsIdSequence.toString()) : UUID.randomUUID();
+                apnsIdFromHeaders = apnsIdSequence != null ? FastUUID.parseUUID(apnsIdSequence) : UUID.randomUUID();
             } catch (final IllegalArgumentException e) {
                 log.error("Failed to parse `apns-id` header: {}", apnsIdSequence, e);
                 apnsIdFromHeaders = UUID.randomUUID();
@@ -307,7 +308,7 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
 
             final Http2Headers headers = new DefaultHttp2Headers()
                     .status(HttpResponseStatus.OK.codeAsText())
-                    .add(APNS_ID_HEADER, acceptNotificationResponse.getApnsId().toString());
+                    .add(APNS_ID_HEADER, FastUUID.toString(acceptNotificationResponse.getApnsId()));
 
             this.encoder().writeHeaders(context, acceptNotificationResponse.getStreamId(), headers, 0, true, writePromise);
 
@@ -318,7 +319,7 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
             final Http2Headers headers = new DefaultHttp2Headers()
                     .status(rejectNotificationResponse.getErrorReason().getHttpResponseStatus().codeAsText())
                     .add(HttpHeaderNames.CONTENT_TYPE, "application/json")
-                    .add(APNS_ID_HEADER, rejectNotificationResponse.getApnsId().toString());
+                    .add(APNS_ID_HEADER, FastUUID.toString(rejectNotificationResponse.getApnsId()));
 
             final byte[] payloadBytes;
             {
@@ -345,7 +346,7 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
 
             final Http2Headers headers = new DefaultHttp2Headers()
                     .status(HttpResponseStatus.INTERNAL_SERVER_ERROR.codeAsText())
-                    .add(APNS_ID_HEADER, internalServerErrorResponse.getApnsId().toString());
+                    .add(APNS_ID_HEADER, FastUUID.toString(internalServerErrorResponse.getApnsId()));
 
             this.encoder().writeHeaders(context, internalServerErrorResponse.getStreamId(), headers, 0, true, writePromise);
 

--- a/pushy/src/main/java/com/turo/pushy/apns/server/ParsingMockApnsServerListenerAdapter.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/ParsingMockApnsServerListenerAdapter.java
@@ -22,6 +22,7 @@
 
 package com.turo.pushy.apns.server;
 
+import com.eatthepath.uuid.FastUUID;
 import com.turo.pushy.apns.ApnsPushNotification;
 import com.turo.pushy.apns.DeliveryPriority;
 import io.netty.buffer.ByteBuf;
@@ -165,7 +166,7 @@ public abstract class ParsingMockApnsServerListenerAdapter implements MockApnsSe
             UUID apnsIdFromHeaders;
 
             try {
-                apnsIdFromHeaders = apnsIdSequence != null ? UUID.fromString(apnsIdSequence.toString()) : null;
+                apnsIdFromHeaders = apnsIdSequence != null ? FastUUID.parseUUID(apnsIdSequence) : null;
             } catch (final IllegalArgumentException e) {
                 log.error("Failed to parse `apns-id` header: {}", apnsIdSequence, e);
                 apnsIdFromHeaders = null;

--- a/pushy/src/main/java/com/turo/pushy/apns/server/RejectedNotificationException.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/RejectedNotificationException.java
@@ -23,7 +23,6 @@
 package com.turo.pushy.apns.server;
 
 import java.util.Objects;
-import java.util.UUID;
 
 /**
  * An exception thrown by {@link PushNotificationHandler} instances to indicate that a push notification should be
@@ -34,28 +33,19 @@ import java.util.UUID;
  */
 public class RejectedNotificationException extends Exception {
     private final RejectionReason errorReason;
-    private final UUID apnsId;
 
     /**
      * Constructs a new rejected notification exception with the given rejection reason and notification identifier.
      *
      * @param rejectionReason the reason for the rejection
-     * @param apnsId the notification identifier provided by the client that sent the notification; may be {@code null}
-     * if the client did not provide an identifier or the identifier was invalid, in which case a server-generated
-     * identifier will be used instead
      */
-    public RejectedNotificationException(final RejectionReason rejectionReason, final UUID apnsId) {
+    public RejectedNotificationException(final RejectionReason rejectionReason) {
         Objects.requireNonNull(rejectionReason, "Error reason must not be null.");
 
         this.errorReason = rejectionReason;
-        this.apnsId = apnsId != null ? apnsId : UUID.randomUUID();
     }
 
     RejectionReason getRejectionReason() {
         return errorReason;
-    }
-
-    UUID getApnsId() {
-        return apnsId;
     }
 }

--- a/pushy/src/main/java/com/turo/pushy/apns/server/TlsAuthenticationValidatingPushNotificationHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/TlsAuthenticationValidatingPushNotificationHandler.java
@@ -45,7 +45,7 @@ class TlsAuthenticationValidatingPushNotificationHandler extends ValidatingPushN
     }
 
     @Override
-    protected void verifyAuthentication(final Http2Headers headers, final UUID apnsId) throws RejectedNotificationException {
+    protected void verifyAuthentication(final Http2Headers headers) throws RejectedNotificationException {
         final String topic;
         {
             final CharSequence topicSequence = headers.get(APNS_TOPIC_HEADER);
@@ -53,7 +53,7 @@ class TlsAuthenticationValidatingPushNotificationHandler extends ValidatingPushN
         }
 
         if (!this.allowedTopics.contains(topic)) {
-            throw new RejectedNotificationException(RejectionReason.BAD_TOPIC, apnsId);
+            throw new RejectedNotificationException(RejectionReason.BAD_TOPIC);
         }
     }
 }

--- a/pushy/src/main/java/com/turo/pushy/apns/server/TokenAuthenticationValidatingPushNotificationHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/TokenAuthenticationValidatingPushNotificationHandler.java
@@ -35,7 +35,6 @@ import java.security.SignatureException;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 class TokenAuthenticationValidatingPushNotificationHandler extends ValidatingPushNotificationHandler {
@@ -60,7 +59,7 @@ class TokenAuthenticationValidatingPushNotificationHandler extends ValidatingPus
     }
 
     @Override
-    protected void verifyAuthentication(final Http2Headers headers, final UUID apnsId) throws RejectedNotificationException {
+    protected void verifyAuthentication(final Http2Headers headers) throws RejectedNotificationException {
         final String base64EncodedAuthenticationToken;
         {
             final CharSequence authorizationSequence = headers.get(APNS_AUTHORIZATION_HEADER);
@@ -71,15 +70,15 @@ class TokenAuthenticationValidatingPushNotificationHandler extends ValidatingPus
                 if (authorizationString.startsWith("bearer")) {
                     base64EncodedAuthenticationToken = authorizationString.substring("bearer".length()).trim();
                 } else {
-                    throw new RejectedNotificationException(RejectionReason.MISSING_PROVIDER_TOKEN, apnsId);
+                    throw new RejectedNotificationException(RejectionReason.MISSING_PROVIDER_TOKEN);
                 }
             } else {
-                throw new RejectedNotificationException(RejectionReason.MISSING_PROVIDER_TOKEN, apnsId);
+                throw new RejectedNotificationException(RejectionReason.MISSING_PROVIDER_TOKEN);
             }
         }
 
         if (base64EncodedAuthenticationToken.trim().length() == 0) {
-            throw new RejectedNotificationException(RejectionReason.MISSING_PROVIDER_TOKEN, apnsId);
+            throw new RejectedNotificationException(RejectionReason.MISSING_PROVIDER_TOKEN);
         }
 
         final AuthenticationToken authenticationToken;
@@ -87,19 +86,19 @@ class TokenAuthenticationValidatingPushNotificationHandler extends ValidatingPus
         try {
             authenticationToken = new AuthenticationToken(base64EncodedAuthenticationToken);
         } catch (final IllegalArgumentException e) {
-            throw new RejectedNotificationException(RejectionReason.INVALID_PROVIDER_TOKEN, apnsId);
+            throw new RejectedNotificationException(RejectionReason.INVALID_PROVIDER_TOKEN);
         }
 
         final ApnsVerificationKey verificationKey = this.verificationKeysByKeyId.get(authenticationToken.getKeyId());
 
         // Have we ever heard of the key in question?
         if (verificationKey == null) {
-            throw new RejectedNotificationException(RejectionReason.INVALID_PROVIDER_TOKEN, apnsId);
+            throw new RejectedNotificationException(RejectionReason.INVALID_PROVIDER_TOKEN);
         }
 
         try {
             if (!authenticationToken.verifySignature(verificationKey)) {
-                throw new RejectedNotificationException(RejectionReason.INVALID_PROVIDER_TOKEN, apnsId);
+                throw new RejectedNotificationException(RejectionReason.INVALID_PROVIDER_TOKEN);
             }
         } catch (NoSuchAlgorithmException | InvalidKeyException | SignatureException e) {
             // This should never happen (here, at least) because we check keys at construction time. If something's
@@ -117,11 +116,11 @@ class TokenAuthenticationValidatingPushNotificationHandler extends ValidatingPus
         }
 
         if (!this.expectedTeamId.equals(authenticationToken.getTeamId())) {
-            throw new RejectedNotificationException(RejectionReason.INVALID_PROVIDER_TOKEN, apnsId);
+            throw new RejectedNotificationException(RejectionReason.INVALID_PROVIDER_TOKEN);
         }
 
         if (authenticationToken.getIssuedAt().getTime() + AUTHENTICATION_TOKEN_EXPIRATION_MILLIS < System.currentTimeMillis()) {
-            throw new RejectedNotificationException(RejectionReason.EXPIRED_PROVIDER_TOKEN, apnsId);
+            throw new RejectedNotificationException(RejectionReason.EXPIRED_PROVIDER_TOKEN);
         }
 
         final String topic;
@@ -130,7 +129,7 @@ class TokenAuthenticationValidatingPushNotificationHandler extends ValidatingPus
 
             if (topicSequence == null) {
                 // A topic is always required when using token authentication
-                throw new RejectedNotificationException(RejectionReason.MISSING_TOPIC, apnsId);
+                throw new RejectedNotificationException(RejectionReason.MISSING_TOPIC);
             }
 
             topic = topicSequence.toString();
@@ -139,7 +138,7 @@ class TokenAuthenticationValidatingPushNotificationHandler extends ValidatingPus
         final Set<String> topicsAllowedForVerificationKey = this.topicsByVerificationKey.get(verificationKey);
 
         if (topicsAllowedForVerificationKey == null || !topicsAllowedForVerificationKey.contains(topic)) {
-            throw new RejectedNotificationException(RejectionReason.INVALID_PROVIDER_TOKEN, apnsId);
+            throw new RejectedNotificationException(RejectionReason.INVALID_PROVIDER_TOKEN);
         }
     }
 }

--- a/pushy/src/main/java/com/turo/pushy/apns/server/UnregisteredDeviceTokenException.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/UnregisteredDeviceTokenException.java
@@ -24,7 +24,6 @@ package com.turo.pushy.apns.server;
 
 import java.util.Date;
 import java.util.Objects;
-import java.util.UUID;
 
 /**
  * An exception thrown by {@link PushNotificationHandler} instances to indicate that a push notification should be
@@ -40,12 +39,9 @@ public class UnregisteredDeviceTokenException extends RejectedNotificationExcept
      * Constructs a new unregistered device token exception indicating that the device token expired at the given time.
      *
      * @param deviceTokenExpirationTimestamp the time at which the destination device token expired
-     * @param apnsId the notification identifier provided by the client that sent the notification; may be {@code null}
-     * if the client did not provide an identifier or the identifier was invalid, in which case a server-generated
-     * identifier will be used instead
      */
-    public UnregisteredDeviceTokenException(final Date deviceTokenExpirationTimestamp, final UUID apnsId) {
-        super(RejectionReason.UNREGISTERED, apnsId);
+    public UnregisteredDeviceTokenException(final Date deviceTokenExpirationTimestamp) {
+        super(RejectionReason.UNREGISTERED);
 
         Objects.requireNonNull(deviceTokenExpirationTimestamp, "Device token expiration timestamp must not be null.");
 

--- a/pushy/src/main/java/com/turo/pushy/apns/server/ValidatingPushNotificationHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/ValidatingPushNotificationHandler.java
@@ -22,6 +22,7 @@
 
 package com.turo.pushy.apns.server;
 
+import com.eatthepath.uuid.FastUUID;
 import com.turo.pushy.apns.DeliveryPriority;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpMethod;
@@ -32,7 +33,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -64,7 +64,7 @@ abstract class ValidatingPushNotificationHandler implements PushNotificationHand
             final CharSequence apnsIdSequence = headers.get(APNS_ID_HEADER);
 
             if (apnsIdSequence != null) {
-                UUID.fromString(apnsIdSequence.toString());
+                FastUUID.parseUUID(apnsIdSequence);
             }
         } catch (final IllegalArgumentException e) {
             throw new RejectedNotificationException(RejectionReason.BAD_MESSAGE_ID);

--- a/pushy/src/main/java/com/turo/pushy/apns/util/SimpleApnsPushNotification.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/util/SimpleApnsPushNotification.java
@@ -22,6 +22,7 @@
 
 package com.turo.pushy.apns.util;
 
+import com.eatthepath.uuid.FastUUID;
 import com.turo.pushy.apns.ApnsPushNotification;
 import com.turo.pushy.apns.DeliveryPriority;
 
@@ -303,7 +304,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
                 ", priority=" + priority +
                 ", topic='" + topic + '\'' +
                 ", collapseId='" + collapseId + '\'' +
-                ", apnsId=" + apnsId +
+                ", apnsId=" + (apnsId != null ? FastUUID.toString(apnsId) : null) +
                 '}';
     }
 }

--- a/pushy/src/main/java/com/turo/pushy/apns/util/SimpleApnsPushNotification.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/util/SimpleApnsPushNotification.java
@@ -22,11 +22,12 @@
 
 package com.turo.pushy.apns.util;
 
-import java.util.Date;
-import java.util.Objects;
-
 import com.turo.pushy.apns.ApnsPushNotification;
 import com.turo.pushy.apns.DeliveryPriority;
+
+import java.util.Date;
+import java.util.Objects;
+import java.util.UUID;
 
 /**
  * A simple and immutable implementation of the {@link ApnsPushNotification} interface.
@@ -43,6 +44,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
     private final DeliveryPriority priority;
     private final String topic;
     private final String collapseId;
+    private final UUID apnsId;
 
     /**
      * Constructs a new push notification with the given token, topic, and payload. No expiration time is set for the
@@ -57,7 +59,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
      * @see DeliveryPriority#IMMEDIATE
      */
     public SimpleApnsPushNotification(final String token, final String topic, final String payload) {
-        this(token, topic, payload, null, DeliveryPriority.IMMEDIATE, null);
+        this(token, topic, payload, null, DeliveryPriority.IMMEDIATE, null, null);
     }
     /**
      * Constructs a new push notification with the given token, topic, payload, and expiration time. An "immediate"
@@ -73,7 +75,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
      * @see DeliveryPriority#IMMEDIATE
      */
     public SimpleApnsPushNotification(final String token, final String topic, final String payload, final Date invalidationTime) {
-        this(token, topic, payload, invalidationTime, DeliveryPriority.IMMEDIATE, null);
+        this(token, topic, payload, invalidationTime, DeliveryPriority.IMMEDIATE, null, null);
     }
 
     /**
@@ -88,7 +90,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
      * @param priority the priority with which this notification should be delivered to the receiving device
      */
     public SimpleApnsPushNotification(final String token, final String topic, final String payload, final Date invalidationTime, final DeliveryPriority priority) {
-        this(token, topic, payload, invalidationTime, priority, null);
+        this(token, topic, payload, invalidationTime, priority, null, null);
     }
 
     /**
@@ -102,9 +104,26 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
      * {@code null}, no delivery attempts beyond the first will be made
      * @param priority the priority with which this notification should be delivered to the receiving device
      * @param collapseId the "collapse identifier" for this notification, which allows it to supersede or be superseded
-     * by other notifications with the same identifier
      */
     public SimpleApnsPushNotification(final String token, final String topic, final String payload, final Date invalidationTime, final DeliveryPriority priority, final String collapseId) {
+        this(token, topic, payload, invalidationTime, priority, collapseId, null);
+    }
+
+    /**
+     * Constructs a new push notification with the given token, topic, payload, delivery expiration time, delivery
+     * priority, "collapse identifier," and unique push notification identifier.
+     *
+     * @param token the device token to which this push notification should be delivered; must not be {@code null}
+     * @param topic the topic to which this notification should be sent; must not be {@code null}
+     * @param payload the payload to include in this push notification; must not be {@code null}
+     * @param invalidationTime the time at which Apple's servers should stop trying to deliver this message; if
+     * {@code null}, no delivery attempts beyond the first will be made
+     * @param priority the priority with which this notification should be delivered to the receiving device
+     * @param collapseId the "collapse identifier" for this notification, which allows it to supersede or be superseded
+     * @param apnsId the unique identifier for this notification; may be {@code null}, in which case the APNs server
+     * will assign a unique identifier automatically
+     */
+    public SimpleApnsPushNotification(final String token, final String topic, final String payload, final Date invalidationTime, final DeliveryPriority priority, final String collapseId, final UUID apnsId) {
         Objects.requireNonNull(token, "Destination device token must not be null.");
         Objects.requireNonNull(topic, "Destination topic must not be null.");
         Objects.requireNonNull(payload, "Payload must not be null.");
@@ -115,6 +134,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         this.priority = priority;
         this.topic = topic;
         this.collapseId = collapseId;
+        this.apnsId = apnsId;
     }
 
     /**
@@ -178,6 +198,19 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         return this.collapseId;
     }
 
+    /**
+     * Returns the canonical identifier for this push notification. The APNs server will include the given identifier in
+     * all responses related to this push notification. If no identifier is provided, the server will assign a unique
+     * identifier automatically.
+     *
+     * @return a unique identifier for this notification; may be {@code null}, in which case the APNs server will assign
+     * an identifier automatically
+     */
+    @Override
+    public UUID getApnsId() {
+        return this.apnsId;
+    }
+
     /* (non-Javadoc)
      * @see java.lang.Object#hashCode()
      */
@@ -191,6 +224,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         result = prime * result + ((this.token == null) ? 0 : this.token.hashCode());
         result = prime * result + ((this.topic == null) ? 0 : this.topic.hashCode());
         result = prime * result + ((this.collapseId == null) ? 0 : this.collapseId.hashCode());
+        result = prime * result + ((this.apnsId == null) ? 0 : this.apnsId.hashCode());
         return result;
     }
 
@@ -247,6 +281,13 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
         } else if (!this.collapseId.equals(other.collapseId)) {
             return false;
         }
+        if (Objects.equals(this.apnsId, null)) {
+            if (!Objects.equals(other.apnsId , null)) {
+                return false;
+            }
+        } else if (!this.apnsId.equals(other.apnsId)) {
+            return false;
+        }
         return true;
     }
 
@@ -255,20 +296,14 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
      */
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder();
-        builder.append("SimpleApnsPushNotification [token=");
-        builder.append(this.token);
-        builder.append(", payload=");
-        builder.append(this.payload);
-        builder.append(", invalidationTime=");
-        builder.append(this.invalidationTime);
-        builder.append(", priority=");
-        builder.append(this.priority);
-        builder.append(", topic=");
-        builder.append(this.topic);
-        builder.append(", apns-collapse-id=");
-        builder.append(this.collapseId);
-        builder.append("]");
-        return builder.toString();
+        return "SimpleApnsPushNotification{" +
+                "token='" + token + '\'' +
+                ", payload='" + payload + '\'' +
+                ", invalidationTime=" + invalidationTime +
+                ", priority=" + priority +
+                ", topic='" + topic + '\'' +
+                ", collapseId='" + collapseId + '\'' +
+                ", apnsId=" + apnsId +
+                '}';
     }
 }

--- a/pushy/src/test/java/com/turo/pushy/apns/ApnsClientTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/ApnsClientTest.java
@@ -289,6 +289,8 @@ public class ApnsClientTest extends AbstractClientServerTest {
 
             assertTrue("Clients must send notifications that conform to the APNs protocol specification.",
                     response.isAccepted());
+
+            assertNotNull(response.getApnsId());
         } finally {
             client.close().await();
             server.shutdown().await();
@@ -472,7 +474,7 @@ public class ApnsClientTest extends AbstractClientServerTest {
                 return new PushNotificationHandler() {
                     @Override
                     public void handlePushNotification(final Http2Headers headers, final ByteBuf payload) throws RejectedNotificationException {
-                        throw new UnregisteredDeviceTokenException(expiration, null);
+                        throw new UnregisteredDeviceTokenException(expiration);
                     }
                 };
             }
@@ -586,7 +588,7 @@ public class ApnsClientTest extends AbstractClientServerTest {
                 return new PushNotificationHandler() {
                     @Override
                     public void handlePushNotification(final Http2Headers headers, final ByteBuf payload) throws RejectedNotificationException {
-                        throw new RejectedNotificationException(RejectionReason.BAD_DEVICE_TOKEN, null);
+                        throw new RejectedNotificationException(RejectionReason.BAD_DEVICE_TOKEN);
                     }
                 };
             }

--- a/pushy/src/test/java/com/turo/pushy/apns/ExpireFirstTokenPushNotificationHandler.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/ExpireFirstTokenPushNotificationHandler.java
@@ -47,7 +47,7 @@ class ExpireFirstTokenPushNotificationHandler implements PushNotificationHandler
             }
 
             if (this.rejectedAuthorizationHeader.equals(authorizationHeader)) {
-                throw new RejectedNotificationException(RejectionReason.EXPIRED_PROVIDER_TOKEN, null);
+                throw new RejectedNotificationException(RejectionReason.EXPIRED_PROVIDER_TOKEN);
             }
         }
     }

--- a/pushy/src/test/java/com/turo/pushy/apns/server/MockApnsServerTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/server/MockApnsServerTest.java
@@ -22,10 +22,7 @@
 
 package com.turo.pushy.apns.server;
 
-import com.turo.pushy.apns.AbstractClientServerTest;
-import com.turo.pushy.apns.ApnsClient;
-import com.turo.pushy.apns.ApnsPushNotification;
-import com.turo.pushy.apns.PushNotificationResponse;
+import com.turo.pushy.apns.*;
 import com.turo.pushy.apns.util.SimpleApnsPushNotification;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -35,6 +32,7 @@ import org.junit.Test;
 
 import javax.net.ssl.SSLSession;
 import java.util.Date;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.*;
@@ -306,13 +304,29 @@ public class MockApnsServerTest extends AbstractClientServerTest {
         try {
             server.start(PORT).await();
 
-            final SimpleApnsPushNotification pushNotification = new SimpleApnsPushNotification(DEVICE_TOKEN, TOPIC, PAYLOAD);
+            {
+                final SimpleApnsPushNotification pushNotification = new SimpleApnsPushNotification(DEVICE_TOKEN, TOPIC, PAYLOAD);
 
-            final PushNotificationResponse<SimpleApnsPushNotification> response =
-                    client.sendNotification(pushNotification).get();
+                final PushNotificationResponse<SimpleApnsPushNotification> response =
+                        client.sendNotification(pushNotification).get();
 
-            assertTrue(response.isAccepted());
-            assertNotNull(response.getApnsId());
+                assertTrue(response.isAccepted());
+                assertNotNull(response.getApnsId());
+            }
+
+            {
+                final UUID apnsId = UUID.randomUUID();
+
+                final SimpleApnsPushNotification pushNotificationWithApnsId =
+                        new SimpleApnsPushNotification(DEVICE_TOKEN, TOPIC, PAYLOAD, null, DeliveryPriority.IMMEDIATE, null, apnsId);
+
+                final PushNotificationResponse<SimpleApnsPushNotification> response =
+                        client.sendNotification(pushNotificationWithApnsId).get();
+
+                assertTrue(response.isAccepted());
+                assertNotNull(response.getApnsId());
+                assertEquals(pushNotificationWithApnsId.getApnsId(), response.getApnsId());
+            }
         } finally {
             client.close().await();
             server.shutdown().await();
@@ -340,13 +354,29 @@ public class MockApnsServerTest extends AbstractClientServerTest {
         try {
             server.start(PORT).await();
 
-            final SimpleApnsPushNotification pushNotification = new SimpleApnsPushNotification(DEVICE_TOKEN, TOPIC, PAYLOAD);
+            {
+                final SimpleApnsPushNotification pushNotification = new SimpleApnsPushNotification(DEVICE_TOKEN, TOPIC, PAYLOAD);
 
-            final PushNotificationResponse<SimpleApnsPushNotification> response =
-                    client.sendNotification(pushNotification).get();
+                final PushNotificationResponse<SimpleApnsPushNotification> response =
+                        client.sendNotification(pushNotification).get();
 
-            assertFalse(response.isAccepted());
-            assertNotNull(response.getApnsId());
+                assertFalse(response.isAccepted());
+                assertNotNull(response.getApnsId());
+            }
+
+            {
+                final UUID apnsId = UUID.randomUUID();
+
+                final SimpleApnsPushNotification pushNotificationWithApnsId =
+                        new SimpleApnsPushNotification(DEVICE_TOKEN, TOPIC, PAYLOAD, null, DeliveryPriority.IMMEDIATE, null, apnsId);
+
+                final PushNotificationResponse<SimpleApnsPushNotification> response =
+                        client.sendNotification(pushNotificationWithApnsId).get();
+
+                assertFalse(response.isAccepted());
+                assertNotNull(response.getApnsId());
+                assertEquals(pushNotificationWithApnsId.getApnsId(), response.getApnsId());
+            }
         } finally {
             client.close().await();
             server.shutdown().await();

--- a/pushy/src/test/java/com/turo/pushy/apns/server/ValidatingPushNotificationHandlerTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/server/ValidatingPushNotificationHandlerTest.java
@@ -37,7 +37,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 public abstract class ValidatingPushNotificationHandlerTest {
@@ -87,46 +86,6 @@ public abstract class ValidatingPushNotificationHandlerTest {
     public void testHandleNotificationWithValidNotification() throws Exception {
         this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap())
                 .handlePushNotification(this.headers, this.payload);
-    }
-
-    @Test
-    public void testHandleNotificationWithSpecifiedUUID() throws Exception {
-        final UUID apnsId = UUID.randomUUID();
-
-        this.headers.set(APNS_ID_HEADER, apnsId.toString());
-
-        this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap())
-                .handlePushNotification(this.headers, this.payload);
-
-        this.headers.remove(APNS_TOPIC_HEADER);
-
-        try {
-            this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap())
-                    .handlePushNotification(this.headers, this.payload);
-
-            fail("Push notifications without a topic should be rejected.");
-        } catch (final RejectedNotificationException e) {
-            assertEquals(apnsId, e.getApnsId());
-        }
-    }
-
-    @Test
-    public void testHandleNotificationWithNullUUID() throws Exception {
-        this.headers.remove(APNS_ID_HEADER);
-
-        this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap())
-                .handlePushNotification(this.headers, this.payload);
-
-        this.headers.remove(APNS_TOPIC_HEADER);
-
-        try {
-            this.getHandler(DEVICE_TOKENS_BY_TOPIC, Collections.<String, Date>emptyMap())
-                    .handlePushNotification(this.headers, this.payload);
-
-            fail("Push notifications without a topic should be rejected.");
-        } catch (final RejectedNotificationException e) {
-            assertNotNull(e.getApnsId());
-        }
     }
 
     @Test

--- a/pushy/src/test/java/com/turo/pushy/apns/util/SimpleApnsPushNotificationTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/util/SimpleApnsPushNotificationTest.java
@@ -22,14 +22,15 @@
 
 package com.turo.pushy.apns.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
-import java.util.Date;
-
 import com.turo.pushy.apns.DeliveryPriority;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Date;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class SimpleApnsPushNotificationTest {
 
@@ -81,6 +82,7 @@ public class SimpleApnsPushNotificationTest {
         assertEquals(expiration, pushNotification.getExpiration());
         assertEquals(DeliveryPriority.IMMEDIATE, pushNotification.getPriority());
         assertNull(pushNotification.getCollapseId());
+        assertNull(pushNotification.getApnsId());
     }
 
     @Test
@@ -100,6 +102,7 @@ public class SimpleApnsPushNotificationTest {
         assertEquals(expiration, pushNotification.getExpiration());
         assertEquals(priority, pushNotification.getPriority());
         assertNull(pushNotification.getCollapseId());
+        assertNull(pushNotification.getApnsId());
     }
 
     @Test
@@ -120,5 +123,28 @@ public class SimpleApnsPushNotificationTest {
         assertEquals(expiration, pushNotification.getExpiration());
         assertEquals(priority, pushNotification.getPriority());
         assertEquals(collapseId, pushNotification.getCollapseId());
+        assertNull(pushNotification.getApnsId());
+    }
+
+    @Test
+    public void testSimpleApnsPushNotificationTokenTopicPayloadExpirationPriorityCollapseIdApnsId() {
+        final String token = "test-token";
+        final String topic = "test-topic";
+        final String payload = "{\"test\": true}";
+        final Date expiration = new Date();
+        final DeliveryPriority priority = DeliveryPriority.CONSERVE_POWER;
+        final String collapseId = "test-collapse-id";
+        final UUID apnsId = UUID.randomUUID();
+
+        final SimpleApnsPushNotification pushNotification =
+                new SimpleApnsPushNotification(token, topic, payload, expiration, priority, collapseId, apnsId);
+
+        assertEquals(token, pushNotification.getToken());
+        assertEquals(topic, pushNotification.getTopic());
+        assertEquals(payload, pushNotification.getPayload());
+        assertEquals(expiration, pushNotification.getExpiration());
+        assertEquals(priority, pushNotification.getPriority());
+        assertEquals(collapseId, pushNotification.getCollapseId());
+        assertEquals(apnsId, pushNotification.getApnsId());
     }
 }


### PR DESCRIPTION
As requested in #559 and initially implemented by @aleksandr-lapushkin in #563, this adds support for the `apns-id` header in notifications sent to the server and in responses received from the server.

Having implemented this fully and benchmarked it, I recommend against moving forward because, in my assessment, the costs outweigh the benefits. As I understand the argument put forth in #559, the main benefit of exposing the APNs ID is that, in cases where the APNs server accepts a notification but the destination device does not report receiving the notification, callers could cite the APNs ID when contacting Apple to report the problem. I believe this is a flimsy argument because APNs itself is a best-effort protocol that _does not guarantee delivery_ even if the APNs server accepts a notification. As such, I believe the probability of Apple investigating and providing technical support for individual delivery attempts is identically zero.

As for the costs, I believe there are two major areas of concern:

1. Parsing UUIDs introduces a new Thing That Can Go Wrong™; it's possible that the UUID sent by the client could be malformed (or the server's expectation about format might change in the future), although I consider both of those cases very unlikely. The server could also send crazy data back (also unlikely) for its `apns-id` header, and we need to be prepared to handle UUID parsing failures in the client. In theory, the client could just report the `apns-id` from the server as a `String` to avoid parsing time and potential errors, and that may be worthy of consideration.
2. The much larger cost is, simply, performance (as @aleksandr-lapushkin predicted in #563). Adding proper handling significantly reduces throughput in benchmarks. Benchmark results are shown below ("scores" are the time taken to send 10,000 notifications, and so lower scores are better):

Ignoring `apns-id` (i.e. the current behavior in `master`):

| Concurrent connections | Score |   Error | Units |
|------------------------|-------|---------|-------|
|                      1 | 0.317 | ± 0.014 |  s/op |
|                      4 | 0.215 | ± 0.010 |  s/op |
|                      8 | 0.208 | ± 0.008 |  s/op |

With `apns-id` handling:

| Concurrent connections | Score |   Error | Units |
|------------------------|-------|---------|-------|
|                      1 | 0.422 | ± 0.021 |  s/op |
|                      4 | 0.249 | ± 0.017 |  s/op |
|                      8 | 0.226 | ± 0.007 |  s/op |

UUID parsing in Java is definitely [slower than it needs to be](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8192784), and so it's possible that we could use a more optimized implementation in Pushy. As mentioned before, we could also skip parsing for UUIDs included in responses from the server. Still, because I'm not persuaded by the existing arguments for including this feature at all, I'm not really inclined to go too crazy trying to make this happen.

I want to be very clear that I'm open to arguments in favor of this feature even though I haven't found the arguments so far persuasive. I'd like to leave this open for discussion, but would like to bring the discussion to a close within a couple weeks. Given a complete picture of the implementation and its implications, what do you all think?

This closes #559.