### PR TITLE
Fix inconsistent feedback on connection exception, Issue #583

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -27,11 +27,11 @@
     <parent>
         <artifactId>pushy-parent</artifactId>
         <groupId>com.turo</groupId>
-        <version>0.12.0-1</version>
+        <version>0.12.0-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>pushy-benchmark</artifactId>
-  <version>0.12.0-1</version>
+  <version>0.12.0-2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Pushy benchmarks</name>

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -27,11 +27,11 @@
     <parent>
         <artifactId>pushy-parent</artifactId>
         <groupId>com.turo</groupId>
-        <version>0.12.1-SNAPSHOT</version>
+        <version>0.12.0-1</version>
     </parent>
 
     <artifactId>pushy-benchmark</artifactId>
-  <version>0.12.1-SNAPSHOT</version>
+  <version>0.12.0-1</version>
     <packaging>jar</packaging>
 
     <name>Pushy benchmarks</name>

--- a/dropwizard-metrics-listener/pom.xml
+++ b/dropwizard-metrics-listener/pom.xml
@@ -25,14 +25,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>pushy-dropwizard-metrics-listener</artifactId>
-  <version>0.12.1-SNAPSHOT</version>
+  <version>0.12.0-1</version>
     <name>Dropwizard Metrics listener for Pushy</name>
     <description>A metrics listener for Pushy that uses the Dropwizard Metrics library for gathering and reporting metrics.</description>
 
     <parent>
         <groupId>com.turo</groupId>
         <artifactId>pushy-parent</artifactId>
-        <version>0.12.1-SNAPSHOT</version>
+        <version>0.12.0-1</version>
     </parent>
 
     <dependencies>

--- a/dropwizard-metrics-listener/pom.xml
+++ b/dropwizard-metrics-listener/pom.xml
@@ -25,14 +25,14 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>pushy-dropwizard-metrics-listener</artifactId>
-  <version>0.12.0-1</version>
+  <version>0.12.0-2-SNAPSHOT</version>
     <name>Dropwizard Metrics listener for Pushy</name>
     <description>A metrics listener for Pushy that uses the Dropwizard Metrics library for gathering and reporting metrics.</description>
 
     <parent>
         <groupId>com.turo</groupId>
         <artifactId>pushy-parent</artifactId>
-        <version>0.12.0-1</version>
+        <version>0.12.0-2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -195,20 +195,20 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.1</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
+                    <!--<plugin>-->
+                        <!--<groupId>org.apache.maven.plugins</groupId>-->
+                        <!--<artifactId>maven-gpg-plugin</artifactId>-->
+                        <!--<version>1.1</version>-->
+                        <!--<executions>-->
+                            <!--<execution>-->
+                                <!--<id>sign-artifacts</id>-->
+                                <!--<phase>verify</phase>-->
+                                <!--<goals>-->
+                                    <!--<goal>sign</goal>-->
+                                <!--</goals>-->
+                            <!--</execution>-->
+                        <!--</executions>-->
+                    <!--</plugin>-->
                 </plugins>
             </build>
         </profile>
@@ -232,10 +232,24 @@
         </developer>
     </developers>
     <inceptionYear>2013</inceptionYear>
-    <url>http://relayrides.github.com/pushy/</url>
+    <url>http://anwerup.github.com/pushy/</url>
     <scm>
-        <connection>scm:git:https://github.com/relayrides/pushy.git</connection>
-        <developerConnection>scm:git:git@github.com:relayrides/pushy.git</developerConnection>
-        <url>https://github.com/relayrides/pushy</url>
+        <connection>scm:git:https://github.com/anwerup/pushy.git</connection>
+        <developerConnection>scm:git:git@github.com:anwerup/pushy.git</developerConnection>
+        <url>https://github.com/anwerup/pushy</url>
     </scm>
+
+    <!-- Encap internal distribution and deployment repos -->
+    <distributionManagement>
+        <repository>
+            <id>encap-release-repo</id>
+            <url>https://test.encap.no/repository/content/repositories/releases</url>
+            <uniqueVersion>true</uniqueVersion>
+        </repository>
+        <snapshotRepository>
+            <id>encap-snapshot-repo</id>
+            <url>https://test.encap.no/repository/content/repositories/snapshots</url>
+            <uniqueVersion>true</uniqueVersion>
+        </snapshotRepository>
+    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>com.turo</groupId>
     <artifactId>pushy-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.12.1-SNAPSHOT</version>
+    <version>0.12.0-1</version>
     <name>Pushy parent</name>
     <description>A Java library for sending push notifications</description>
 
@@ -146,6 +146,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -195,20 +202,23 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <!--<plugin>-->
-                        <!--<groupId>org.apache.maven.plugins</groupId>-->
-                        <!--<artifactId>maven-gpg-plugin</artifactId>-->
-                        <!--<version>1.1</version>-->
-                        <!--<executions>-->
-                            <!--<execution>-->
-                                <!--<id>sign-artifacts</id>-->
-                                <!--<phase>verify</phase>-->
-                                <!--<goals>-->
-                                    <!--<goal>sign</goal>-->
-                                <!--</goals>-->
-                            <!--</execution>-->
-                        <!--</executions>-->
-                    <!--</plugin>-->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.1</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>com.turo</groupId>
     <artifactId>pushy-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.12.0-1</version>
+    <version>0.12.0-2-SNAPSHOT</version>
     <name>Pushy parent</name>
     <description>A Java library for sending push notifications</description>
 

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -25,13 +25,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>pushy</artifactId>
-    <version>0.12.1-SNAPSHOT</version>
+    <version>0.12.0-1</version>
     <name>Pushy</name>
 
     <parent>
         <groupId>com.turo</groupId>
         <artifactId>pushy-parent</artifactId>
-        <version>0.12.1-SNAPSHOT</version>
+        <version>0.12.0-1</version>
     </parent>
 
     <dependencies>

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -25,13 +25,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>pushy</artifactId>
-    <version>0.12.0-1</version>
+    <version>0.12.0-2-SNAPSHOT</version>
     <name>Pushy</name>
 
     <parent>
         <groupId>com.turo</groupId>
         <artifactId>pushy-parent</artifactId>
-        <version>0.12.0-1</version>
+        <version>0.12.0-2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsChannelPool.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsChannelPool.java
@@ -206,6 +206,30 @@ class ApnsChannelPool {
         }
     }
 
+    /**
+     * Continue processing other messages on the queue
+     */
+    void proceede() {
+        if (this.executor.inEventLoop()) {
+            this.procedeWithinEventExecutor();
+        } else {
+            this.executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    ApnsChannelPool.this.procedeWithinEventExecutor();
+                }
+            });
+        }
+    }
+
+    private void procedeWithinEventExecutor() {
+        assert this.executor.inEventLoop();
+
+        if (!this.pendingAcquisitionPromises.isEmpty()) {
+            this.acquireWithinEventExecutor(this.pendingAcquisitionPromises.poll());
+        }
+    }
+
     private void releaseWithinEventExecutor(final Channel channel) {
         assert this.executor.inEventLoop();
 

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
@@ -228,6 +228,7 @@ public class ApnsClient {
                         ApnsClient.this.channelPool.release(channel);
                     } else {
                         responsePromise.tryFailure(acquireFuture.cause());
+                        ApnsClient.this.channelPool.proceede();
                     }
                 }
             });

--- a/pushy/src/test/java/com/turo/pushy/apns/AbstractClientServerTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/AbstractClientServerTest.java
@@ -56,6 +56,7 @@ public class AbstractClientServerTest {
 
     protected static final String HOST = "localhost";
     protected static final int PORT = 8443;
+    protected static final int INVALID_PORT = 19231;
 
     protected static final String TEAM_ID = "team-id";
     protected static final String KEY_ID = "key-id";
@@ -108,6 +109,18 @@ public class AbstractClientServerTest {
         try (final InputStream p12InputStream = getClass().getResourceAsStream(MULTI_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
             return new ApnsClientBuilder()
                     .setApnsServer(HOST, PORT)
+                    .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
+                    .setTrustedServerCertificateChain(getClass().getResourceAsStream(CA_CERTIFICATE_FILENAME))
+                    .setEventLoopGroup(EVENT_LOOP_GROUP)
+                    .setMetricsListener(metricsListener)
+                    .build();
+        }
+    }
+
+    protected ApnsClient buildInvalidAddressTlsAuthenticationClient(final ApnsClientMetricsListener metricsListener) throws IOException {
+        try (final InputStream p12InputStream = getClass().getResourceAsStream(MULTI_TOPIC_CLIENT_KEYSTORE_FILENAME)) {
+            return new ApnsClientBuilder()
+                    .setApnsServer(HOST, INVALID_PORT)
                     .setClientCredentials(p12InputStream, KEYSTORE_PASSWORD)
                     .setTrustedServerCertificateChain(getClass().getResourceAsStream(CA_CERTIFICATE_FILENAME))
                     .setEventLoopGroup(EVENT_LOOP_GROUP)


### PR DESCRIPTION
See issue #583 'Messages hangs after connection failure'. This fix solves that issue and all other related issues where messages are queued indefinitely due to failure to acquire a connection.

Also added a test showing the problem. Running ApnsClientTest.testConsistentConnectionFailures without the fix will cause it to hang on line 672 until the test times out and fails.