### PR TITLE
Create an entirely separate benchmark server

### DIFF
--- a/benchmark/src/main/java/com/turo/pushy/apns/ApnsClientBenchmark.java
+++ b/benchmark/src/main/java/com/turo/pushy/apns/ApnsClientBenchmark.java
@@ -23,9 +23,8 @@
 package com.turo.pushy.apns;
 
 import com.turo.pushy.apns.auth.ApnsSigningKey;
-import com.turo.pushy.apns.server.AcceptAllPushNotificationHandlerFactory;
-import com.turo.pushy.apns.server.MockApnsServer;
-import com.turo.pushy.apns.server.MockApnsServerBuilder;
+import com.turo.pushy.apns.server.BenchmarkApnsServer;
+import com.turo.pushy.apns.server.BenchmarkApnsServerBuilder;
 import com.turo.pushy.apns.util.ApnsPayloadBuilder;
 import com.turo.pushy.apns.util.SimpleApnsPushNotification;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -49,7 +48,7 @@ public class ApnsClientBenchmark {
     private NioEventLoopGroup serverEventLoopGroup;
 
     private ApnsClient client;
-    private MockApnsServer server;
+    private BenchmarkApnsServer server;
 
     private List<SimpleApnsPushNotification> pushNotifications;
 
@@ -95,11 +94,10 @@ public class ApnsClientBenchmark {
                 .setEventLoopGroup(this.clientEventLoopGroup)
                 .build();
 
-        this.server = new MockApnsServerBuilder()
+        this.server = new BenchmarkApnsServerBuilder()
                 .setServerCredentials(getClass().getResourceAsStream(SERVER_CERTIFICATES_FILENAME), this.getClass().getResourceAsStream(SERVER_KEY_FILENAME), null)
                 .setTrustedClientCertificateChain(getClass().getResourceAsStream(CA_CERTIFICATE_FILENAME))
                 .setEventLoopGroup(this.serverEventLoopGroup)
-                .setHandlerFactory(new AcceptAllPushNotificationHandlerFactory())
                 .build();
 
         this.pushNotifications = new ArrayList<>(this.notificationCount);

--- a/pushy/src/main/java/com/turo/pushy/apns/server/BaseHttp2Server.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/BaseHttp2Server.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2013-2018 Turo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.turo.pushy.apns.server;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.*;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.util.ReferenceCounted;
+import io.netty.util.concurrent.*;
+
+import javax.net.ssl.SSLSession;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+abstract class BaseHttp2Server {
+    private final SslContext sslContext;
+    private final AtomicBoolean hasReleasedSslContext = new AtomicBoolean(false);
+
+    private final ServerBootstrap bootstrap;
+    private final boolean shouldShutDownEventLoopGroup;
+
+    private ChannelGroup allChannels;
+
+    BaseHttp2Server(final SslContext sslContext, final EventLoopGroup eventLoopGroup) {
+
+        this.sslContext = sslContext;
+
+        if (this.sslContext instanceof ReferenceCounted) {
+            ((ReferenceCounted) this.sslContext).retain();
+        }
+
+        this.bootstrap = new ServerBootstrap();
+
+        if (eventLoopGroup != null) {
+            this.bootstrap.group(eventLoopGroup);
+            this.shouldShutDownEventLoopGroup = false;
+        } else {
+            this.bootstrap.group(new NioEventLoopGroup(1));
+            this.shouldShutDownEventLoopGroup = true;
+        }
+
+        this.bootstrap.channel(ServerSocketChannelClassUtil.getServerSocketChannelClass(this.bootstrap.config().group()));
+        this.bootstrap.childHandler(new ChannelInitializer<SocketChannel>() {
+
+            @Override
+            protected void initChannel(final SocketChannel channel) {
+                final SslHandler sslHandler = sslContext.newHandler(channel.alloc());
+                channel.pipeline().addLast(sslHandler);
+                channel.pipeline().addLast(new ApplicationProtocolNegotiationHandler(ApplicationProtocolNames.HTTP_1_1) {
+
+                    @Override
+                    protected void configurePipeline(final ChannelHandlerContext context, final String protocol) throws Exception {
+                        if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
+                            BaseHttp2Server.this.addHandlersToPipeline(sslHandler.engine().getSession(), context.pipeline());
+                            BaseHttp2Server.this.allChannels.add(context.channel());
+                        } else {
+                            throw new IllegalStateException("Unexpected protocol: " + protocol);
+                        }
+                    }
+                });
+            }
+        });
+    }
+
+    protected abstract void addHandlersToPipeline(final SSLSession sslSession, final ChannelPipeline pipeline) throws Exception;
+
+    /**
+     * Starts this mock server and listens for traffic on the given port.
+     *
+     * @param port the port to which this server should bind
+     *
+     * @return a {@code Future} that will succeed when the server has bound to the given port and is ready to accept
+     * traffic
+     */
+    public Future<Void> start(final int port) {
+        final ChannelFuture channelFuture = this.bootstrap.bind(port);
+
+        this.allChannels = new DefaultChannelGroup(channelFuture.channel().eventLoop(), true);
+        this.allChannels.add(channelFuture.channel());
+
+        return channelFuture;
+    }
+
+    /**
+     * <p>Shuts down this server and releases the port to which this server was bound. If a {@code null} event loop
+     * group was provided at construction time, the server will also shut down its internally-managed event loop
+     * group.</p>
+     *
+     * <p>If a non-null {@code EventLoopGroup} was provided at construction time, mock servers may be reconnected and
+     * reused after they have been shut down. If no event loop group was provided at construction time, mock servers may
+     * not be restarted after they have been shut down via this method.</p>
+     *
+     * @return a {@code Future} that will succeed once the server has finished unbinding from its port and, if the
+     * server was managing its own event loop group, its event loop group has shut down
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public Future<Void> shutdown() {
+        final Future<Void> channelCloseFuture = (this.allChannels != null) ?
+                this.allChannels.close() : new SucceededFuture<Void>(GlobalEventExecutor.INSTANCE, null);
+
+        final Future<Void> disconnectFuture;
+
+        if (this.shouldShutDownEventLoopGroup) {
+            // Wait for the channel to close before we try to shut down the event loop group
+            channelCloseFuture.addListener(new GenericFutureListener<Future<Void>>() {
+
+                @Override
+                public void operationComplete(final Future<Void> future) throws Exception {
+                    BaseHttp2Server.this.bootstrap.config().group().shutdownGracefully();
+                }
+            });
+
+            // Since the termination future for the event loop group is a Future<?> instead of a Future<Void>,
+            // we'll need to create our own promise and then notify it when the termination future completes.
+            disconnectFuture = new DefaultPromise<>(GlobalEventExecutor.INSTANCE);
+
+            this.bootstrap.config().group().terminationFuture().addListener(new GenericFutureListener() {
+
+                @Override
+                public void operationComplete(final Future future) throws Exception {
+                    ((Promise<Void>) disconnectFuture).trySuccess(null);
+                }
+            });
+        } else {
+            // We're done once we've closed all the channels, so we can return the closure future directly.
+            disconnectFuture = channelCloseFuture;
+        }
+
+        disconnectFuture.addListener(new GenericFutureListener<Future<Void>>() {
+            @Override
+            public void operationComplete(final Future<Void> future) throws Exception {
+                if (BaseHttp2Server.this.sslContext instanceof ReferenceCounted) {
+                    if (BaseHttp2Server.this.hasReleasedSslContext.compareAndSet(false, true)) {
+                        ((ReferenceCounted) BaseHttp2Server.this.sslContext).release();
+                    }
+                }
+            }
+        });
+
+        return disconnectFuture;
+    }
+}

--- a/pushy/src/main/java/com/turo/pushy/apns/server/BaseHttp2ServerBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/BaseHttp2ServerBuilder.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2013-2018 Turo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.turo.pushy.apns.server;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.handler.codec.http2.Http2SecurityUtil;
+import io.netty.handler.ssl.*;
+import io.netty.util.ReferenceCounted;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLException;
+import java.io.File;
+import java.io.InputStream;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
+
+    protected X509Certificate[] certificateChain;
+    protected PrivateKey privateKey;
+
+    protected File certificateChainPemFile;
+    protected File privateKeyPkcs8File;
+
+    protected InputStream certificateChainInputStream;
+    protected InputStream privateKeyPkcs8InputStream;
+
+    protected String privateKeyPassword;
+
+    protected File trustedClientCertificatePemFile;
+    protected InputStream trustedClientCertificateInputStream;
+    protected X509Certificate[] trustedClientCertificates;
+
+    protected EventLoopGroup eventLoopGroup;
+
+    protected int maxConcurrentStreams = DEFAULT_MAX_CONCURRENT_STREAMS;
+
+    /**
+     * The default maximum number of concurrent streams for an APNs server, which matches the default limit set by the
+     * real APNs server at the time of this writing.
+     */
+    public static final int DEFAULT_MAX_CONCURRENT_STREAMS = 1500;
+
+    private static final Logger log = LoggerFactory.getLogger(BaseHttp2ServerBuilder.class);
+
+    /**
+     * <p>Sets the credentials for the server under construction using the certificates in the given PEM file and the
+     * private key in the given PKCS#8 file.</p>
+     *
+     * @param certificatePemFile a PEM file containing the certificate chain for the server under construction
+     * @param privateKeyPkcs8File a PKCS#8 file containing the private key for the server under construction
+     * @param privateKeyPassword the password for the given private key, or {@code null} if the key is not
+     * password-protected
+     *
+     * @return a reference to this builder
+     *
+     * @since 0.8
+     */
+    public BaseHttp2ServerBuilder setServerCredentials(final File certificatePemFile, final File privateKeyPkcs8File, final String privateKeyPassword) {
+        this.certificateChain = null;
+        this.privateKey = null;
+
+        this.certificateChainPemFile = certificatePemFile;
+        this.privateKeyPkcs8File = privateKeyPkcs8File;
+
+        this.certificateChainInputStream = null;
+        this.privateKeyPkcs8InputStream = null;
+
+        this.privateKeyPassword = privateKeyPassword;
+
+        return this;
+    }
+
+    /**
+     * <p>Sets the credentials for the server under construction using the certificates in the given PEM input stream
+     * and the private key in the given PKCS#8 input stream.</p>
+     *
+     * @param certificatePemInputStream a PEM input stream containing the certificate chain for the server under
+     * construction
+     * @param privateKeyPkcs8InputStream a PKCS#8 input stream containing the private key for the server under
+     * construction
+     * @param privateKeyPassword the password for the given private key, or {@code null} if the key is not
+     * password-protected
+     *
+     * @return a reference to this builder
+     *
+     * @since 0.8
+     */
+    public BaseHttp2ServerBuilder setServerCredentials(final InputStream certificatePemInputStream, final InputStream privateKeyPkcs8InputStream, final String privateKeyPassword) {
+        this.certificateChain = null;
+        this.privateKey = null;
+
+        this.certificateChainPemFile = null;
+        this.privateKeyPkcs8File = null;
+
+        this.certificateChainInputStream = certificatePemInputStream;
+        this.privateKeyPkcs8InputStream = privateKeyPkcs8InputStream;
+
+        this.privateKeyPassword = privateKeyPassword;
+
+        return this;
+    }
+
+    /**
+     * <p>Sets the credentials for the server under construction.</p>
+     *
+     * @param certificates a certificate chain including the server's own certificate
+     * @param privateKey the private key for the server's certificate
+     * @param privateKeyPassword the password for the given private key, or {@code null} if the key is not
+     * password-protected
+     *
+     * @return a reference to this builder
+     *
+     * @since 0.8
+     */
+    public BaseHttp2ServerBuilder setServerCredentials(final X509Certificate[] certificates, final PrivateKey privateKey, final String privateKeyPassword) {
+        this.certificateChain = certificates;
+        this.privateKey = privateKey;
+
+        this.certificateChainPemFile = null;
+        this.privateKeyPkcs8File = null;
+
+        this.certificateChainInputStream = null;
+        this.privateKeyPkcs8InputStream = null;
+
+        this.privateKeyPassword = privateKeyPassword;
+
+        return this;
+    }
+
+    /**
+     * <p>Sets the trusted certificate chain for the server under construction using the contents of the given PEM
+     * file. If not set (or {@code null}), the server will use the JVM's default trust manager.</p>
+     *
+     * <p>In development environments, callers will almost always need to provide a trusted certificate chain for
+     * clients (since clients in development environments will generally not present credentials recognized by the JVM's
+     * default trust manager).</p>
+     *
+     * @param certificatePemFile a PEM file containing one or more trusted certificates
+     *
+     * @return a reference to this builder
+     */
+    public BaseHttp2ServerBuilder setTrustedClientCertificateChain(final File certificatePemFile) {
+        this.trustedClientCertificatePemFile = certificatePemFile;
+        this.trustedClientCertificateInputStream = null;
+        this.trustedClientCertificates = null;
+
+        return this;
+    }
+
+    /**
+     * <p>Sets the trusted certificate chain for the server under construction using the contents of the given PEM
+     * input stream. If not set (or {@code null}), the server will use the JVM's default trust manager.</p>
+     *
+     * <p>In development environments, callers will almost always need to provide a trusted certificate chain for
+     * clients (since clients in development environments will generally not present credentials recognized by the JVM's
+     * default trust manager).</p>
+     *
+     * @param certificateInputStream an input stream to PEM-formatted data containing one or more trusted certificates
+     *
+     * @return a reference to this builder
+     */
+    public BaseHttp2ServerBuilder setTrustedClientCertificateChain(final InputStream certificateInputStream) {
+        this.trustedClientCertificatePemFile = null;
+        this.trustedClientCertificateInputStream = certificateInputStream;
+        this.trustedClientCertificates = null;
+
+        return this;
+    }
+
+    /**
+     * <p>Sets the trusted certificate chain for the server under construction. If not set (or {@code null}), the
+     * server will use the JVM's default trust manager.</p>
+     *
+     * <p>In development environments, callers will almost always need to provide a trusted certificate chain for
+     * clients (since clients in development environments will generally not present credentials recognized by the JVM's
+     * default trust manager).</p>
+     *
+     * @param certificates one or more trusted certificates
+     *
+     * @return a reference to this builder
+     */
+    public BaseHttp2ServerBuilder setTrustedServerCertificateChain(final X509Certificate... certificates) {
+        this.trustedClientCertificatePemFile = null;
+        this.trustedClientCertificateInputStream = null;
+        this.trustedClientCertificates = certificates;
+
+        return this;
+    }
+
+    /**
+     * <p>Sets the event loop group to be used by the server under construction. If not set (or if {@code null}), the
+     * server will create and manage its own event loop group.</p>
+     *
+     * @param eventLoopGroup the event loop group to use for this server, or {@code null} to let the server manage its
+     * own event loop group
+     *
+     * @return a reference to this builder
+     *
+     * @since 0.8
+     */
+    public BaseHttp2ServerBuilder setEventLoopGroup(final EventLoopGroup eventLoopGroup) {
+        this.eventLoopGroup = eventLoopGroup;
+        return this;
+    }
+
+    /**
+     * Sets the maximum number of concurrent HTTP/2 streams allowed by the server under construction. By default,
+     * mock servers will have a concurrent stream limit of {@value DEFAULT_MAX_CONCURRENT_STREAMS}.
+     *
+     * @param maxConcurrentStreams the maximum number of concurrent HTTP/2 streams allowed by the server under
+     * construction; must be positive
+     *
+     * @return a reference to this builder
+     *
+     * @since 0.12
+     */
+    public BaseHttp2ServerBuilder setMaxConcurrentStreams(final int maxConcurrentStreams) {
+        if (maxConcurrentStreams <= 0) {
+            throw new IllegalArgumentException("Maximum number of concurrent streams must be positive.");
+        }
+
+        this.maxConcurrentStreams = maxConcurrentStreams;
+        return this;
+    }
+
+    /**
+     * Constructs a new server with the previously-set configuration.
+     *
+     * @return a new server instance with the previously-set configuration
+     *
+     * @throws SSLException if an SSL context could not be created for the new server for any reason
+     *
+     * @since 0.8
+     */
+    public T build() throws SSLException {
+        final SslContext sslContext;
+        {
+            final SslProvider sslProvider;
+
+            if (OpenSsl.isAvailable()) {
+                if (OpenSsl.isAlpnSupported()) {
+                    log.info("Native SSL provider is available and supports ALPN; will use native provider.");
+                    sslProvider = SslProvider.OPENSSL;
+                } else {
+                    log.info("Native SSL provider is available, but does not support ALPN; will use JDK SSL provider.");
+                    sslProvider = SslProvider.JDK;
+                }
+            } else {
+                log.info("Native SSL provider not available; will use JDK SSL provider.");
+                sslProvider = SslProvider.JDK;
+            }
+
+            final SslContextBuilder sslContextBuilder;
+
+            if (this.certificateChain != null && this.privateKey != null) {
+                sslContextBuilder = SslContextBuilder.forServer(this.privateKey, this.privateKeyPassword, this.certificateChain);
+            } else if (this.certificateChainPemFile != null && this.privateKeyPkcs8File != null) {
+                sslContextBuilder = SslContextBuilder.forServer(this.certificateChainPemFile, this.privateKeyPkcs8File, this.privateKeyPassword);
+            } else if (this.certificateChainInputStream != null && this.privateKeyPkcs8InputStream != null) {
+                sslContextBuilder = SslContextBuilder.forServer(this.certificateChainInputStream, this.privateKeyPkcs8InputStream, this.privateKeyPassword);
+            } else {
+                throw new IllegalStateException("Must specify server credentials before building a mock server.");
+            }
+
+            sslContextBuilder.sslProvider(sslProvider)
+                    .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+                    .clientAuth(ClientAuth.OPTIONAL)
+                    .applicationProtocolConfig(new ApplicationProtocolConfig(
+                            ApplicationProtocolConfig.Protocol.ALPN,
+                            ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
+                            ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+                            ApplicationProtocolNames.HTTP_2));
+
+            if (this.trustedClientCertificatePemFile != null) {
+                sslContextBuilder.trustManager(this.trustedClientCertificatePemFile);
+            } else if (this.trustedClientCertificateInputStream != null) {
+                sslContextBuilder.trustManager(this.trustedClientCertificateInputStream);
+            } else if (this.trustedClientCertificates != null) {
+                sslContextBuilder.trustManager(this.trustedClientCertificates);
+            }
+
+            sslContext = sslContextBuilder.build();
+        }
+
+        final T server = this.constructServer(sslContext);
+
+        if (sslContext instanceof ReferenceCounted) {
+            ((ReferenceCounted) sslContext).release();
+        }
+
+        return server;
+    }
+
+    protected abstract T constructServer(final SslContext sslContext);
+}

--- a/pushy/src/main/java/com/turo/pushy/apns/server/BenchmarkApnsServer.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/BenchmarkApnsServer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2013-2018 Turo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.turo.pushy.apns.server;
+
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.handler.codec.http2.Http2Settings;
+import io.netty.handler.ssl.SslContext;
+
+import javax.net.ssl.SSLSession;
+
+/**
+ * A simple HTTP/2 server designed to crudely emulate the behavior of a real APNs server as simply and quickly as
+ * possible. Benchmark servers <em>always</em> accept notifications, regardless of whether they are legal or
+ * well-formed, and <em>always</em> include the same {@code apns-id} header for any given connection. These behaviors
+ * minimize the processing time consumed by the server, reducing the chances that benchmarks are measuring the
+ * performance of the mock server instead of the performance of the client.
+ *
+ * @since 0.13.0
+ */
+public class BenchmarkApnsServer extends BaseHttp2Server {
+
+    private final int maxConcurrentStreams;
+
+    BenchmarkApnsServer(final SslContext sslContext, final EventLoopGroup eventLoopGroup, final int maxConcurrentStreams) {
+        super(sslContext, eventLoopGroup);
+
+        this.maxConcurrentStreams = maxConcurrentStreams;
+    }
+
+    @Override
+    protected void addHandlersToPipeline(final SSLSession sslSession, final ChannelPipeline pipeline) {
+        pipeline.addLast(new BenchmarkApnsServerHandler.BenchmarkApnsServerHandlerBuilder()
+                .initialSettings(Http2Settings.defaultSettings().maxConcurrentStreams(this.maxConcurrentStreams))
+                .build());
+    }
+}

--- a/pushy/src/main/java/com/turo/pushy/apns/server/BenchmarkApnsServerBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/BenchmarkApnsServerBuilder.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2013-2018 Turo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.turo.pushy.apns.server;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.handler.ssl.SslContext;
+
+import javax.net.ssl.SSLException;
+import java.io.File;
+import java.io.InputStream;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+/**
+ * <p>A {@code BenchmarkApnsServerBuilder} constructs new {@link BenchmarkApnsServer} instances. Callers must supply
+ * server credentials via one of the {@code setServerCredentials} methods prior to constructing a new server with the
+ * {@link BenchmarkApnsServerBuilder#build()} method; all other settings are optional.</p>
+ *
+ * <p>Server builders may be reused to generate multiple servers, and their settings may be changed from one server to
+ * the next.</p>
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ *
+ * @since 0.13.0
+ */
+public class BenchmarkApnsServerBuilder extends BaseHttp2ServerBuilder<BenchmarkApnsServer> {
+
+    @Override
+    public BenchmarkApnsServerBuilder setServerCredentials(final File certificatePemFile, final File privateKeyPkcs8File, final String privateKeyPassword) {
+        super.setServerCredentials(certificatePemFile, privateKeyPkcs8File, privateKeyPassword);
+        return this;
+    }
+
+    @Override
+    public BenchmarkApnsServerBuilder setServerCredentials(final InputStream certificatePemInputStream, final InputStream privateKeyPkcs8InputStream, final String privateKeyPassword) {
+        super.setServerCredentials(certificatePemInputStream, privateKeyPkcs8InputStream, privateKeyPassword);
+        return this;
+    }
+
+    @Override
+    public BenchmarkApnsServerBuilder setServerCredentials(final X509Certificate[] certificates, final PrivateKey privateKey, final String privateKeyPassword) {
+        super.setServerCredentials(certificates, privateKey, privateKeyPassword);
+        return this;
+    }
+
+    @Override
+    public BenchmarkApnsServerBuilder setTrustedClientCertificateChain(final File certificatePemFile) {
+        super.setTrustedClientCertificateChain(certificatePemFile);
+        return this;
+    }
+
+    @Override
+    public BenchmarkApnsServerBuilder setTrustedClientCertificateChain(final InputStream certificateInputStream) {
+        super.setTrustedClientCertificateChain(certificateInputStream);
+        return this;
+    }
+
+    @Override
+    public BenchmarkApnsServerBuilder setTrustedServerCertificateChain(final X509Certificate... certificates) {
+        super.setTrustedServerCertificateChain(certificates);
+        return this;
+    }
+
+    @Override
+    public BenchmarkApnsServerBuilder setEventLoopGroup(final EventLoopGroup eventLoopGroup) {
+        super.setEventLoopGroup(eventLoopGroup);
+        return this;
+    }
+
+    @Override
+    public BenchmarkApnsServerBuilder setMaxConcurrentStreams(final int maxConcurrentStreams) {
+        super.setMaxConcurrentStreams(maxConcurrentStreams);
+        return this;
+    }
+
+    @Override
+    public BenchmarkApnsServer build() throws SSLException {
+        return super.build();
+    }
+
+    @Override
+    protected BenchmarkApnsServer constructServer(final SslContext sslContext) {
+        return new BenchmarkApnsServer(sslContext, this.eventLoopGroup, this.maxConcurrentStreams);
+    }
+}

--- a/pushy/src/main/java/com/turo/pushy/apns/server/BenchmarkApnsServerHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/BenchmarkApnsServerHandler.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2013-2018 Turo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.turo.pushy.apns.server;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http2.*;
+import io.netty.util.AsciiString;
+
+import java.util.UUID;
+
+class BenchmarkApnsServerHandler extends Http2ConnectionHandler implements Http2FrameListener {
+
+    private static final Http2Headers SUCCESS_HEADERS = new DefaultHttp2Headers()
+            .status(HttpResponseStatus.OK.codeAsText())
+            .add(new AsciiString("apns-id"), new AsciiString(UUID.randomUUID().toString()));
+
+    public static class BenchmarkApnsServerHandlerBuilder extends AbstractHttp2ConnectionHandlerBuilder<BenchmarkApnsServerHandler, BenchmarkApnsServerHandlerBuilder> {
+
+        @Override
+        public BenchmarkApnsServerHandlerBuilder initialSettings(final Http2Settings initialSettings) {
+            return super.initialSettings(initialSettings);
+        }
+
+        @Override
+        public BenchmarkApnsServerHandler build(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings) {
+            final BenchmarkApnsServerHandler handler = new BenchmarkApnsServerHandler(decoder, encoder, initialSettings);
+            this.frameListener(handler);
+            return handler;
+        }
+
+        @Override
+        public BenchmarkApnsServerHandler build() {
+            return super.build();
+        }
+    }
+
+    BenchmarkApnsServerHandler(final Http2ConnectionDecoder decoder, final Http2ConnectionEncoder encoder, final Http2Settings initialSettings) {
+        super(decoder, encoder, initialSettings);
+    }
+
+    @Override
+    public int onDataRead(final ChannelHandlerContext context, final int streamId, final ByteBuf data, final int padding, final boolean endOfStream) {
+        if (endOfStream) {
+            handleEndOfStream(context, streamId);
+        }
+
+        return data.readableBytes() + padding;
+    }
+
+    @Override
+    public void onHeadersRead(final ChannelHandlerContext context, final int streamId, final Http2Headers headers, final int padding, final boolean endOfStream) {
+        if (endOfStream) {
+            handleEndOfStream(context, streamId);
+        }
+    }
+
+    private void handleEndOfStream(final ChannelHandlerContext context, final int streamId) {
+        this.encoder().writeHeaders(context, streamId, SUCCESS_HEADERS, 0, true, context.channel().newPromise());
+    }
+
+    @Override
+    public void onHeadersRead(final ChannelHandlerContext context, final int streamId, final Http2Headers headers, final int streamDependency,
+                              final short weight, final boolean exclusive, final int padding, final boolean endOfStream) {
+
+        this.onHeadersRead(context, streamId, headers, padding, endOfStream);
+    }
+
+    @Override
+    public void onPriorityRead(final ChannelHandlerContext context, final int streamId, final int streamDependency, final short weight, final boolean exclusive) {
+    }
+
+    @Override
+    public void onRstStreamRead(final ChannelHandlerContext context, final int streamId, final long errorCode) {
+    }
+
+    @Override
+    public void onSettingsAckRead(final ChannelHandlerContext context) {
+    }
+
+    @Override
+    public void onSettingsRead(final ChannelHandlerContext context, final Http2Settings settings) {
+    }
+
+    @Override
+    public void onPingRead(final ChannelHandlerContext context, final long data) {
+    }
+
+    @Override
+    public void onPingAckRead(final ChannelHandlerContext context, final long data) {
+    }
+
+    @Override
+    public void onPushPromiseRead(final ChannelHandlerContext context, final int streamId, final int promisedStreamId, final Http2Headers headers, final int padding) {
+    }
+
+    @Override
+    public void onGoAwayRead(final ChannelHandlerContext context, final int lastStreamId, final long errorCode, final ByteBuf debugData) {
+    }
+
+    @Override
+    public void onWindowUpdateRead(final ChannelHandlerContext context, final int streamId, final int windowSizeIncrement) {
+    }
+
+    @Override
+    public void onUnknownFrame(final ChannelHandlerContext context, final byte frameType, final int streamId, final Http2Flags flags, final ByteBuf payload) {
+    }
+}

--- a/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServer.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServer.java
@@ -22,24 +22,12 @@
 
 package com.turo.pushy.apns.server;
 
-import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.group.ChannelGroup;
-import io.netty.channel.group.DefaultChannelGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http2.Http2Settings;
-import io.netty.handler.ssl.ApplicationProtocolNames;
-import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslHandler;
-import io.netty.util.ReferenceCounted;
-import io.netty.util.concurrent.*;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import javax.net.ssl.SSLSession;
 
 /**
  * <p>A mock APNs server is an HTTP/2 server that can be configured to respond to APNs push notifications with a variety
@@ -59,142 +47,35 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @since 0.8
  */
-public class MockApnsServer {
+public class MockApnsServer extends BaseHttp2Server {
 
-    private final SslContext sslContext;
-    private final AtomicBoolean hasReleasedSslContext = new AtomicBoolean(false);
+    private final PushNotificationHandlerFactory handlerFactory;
+    private final MockApnsServerListener listener;
 
-    private final ServerBootstrap bootstrap;
-    private final boolean shouldShutDownEventLoopGroup;
+    private final int maxConcurrentStreams;
 
-    private ChannelGroup allChannels;
+    MockApnsServer(final SslContext sslContext, final EventLoopGroup eventLoopGroup,
+                   final PushNotificationHandlerFactory handlerFactory, final MockApnsServerListener listener,
+                   final int maxConcurrentStreams) {
 
-    MockApnsServer(final SslContext sslContext, final PushNotificationHandlerFactory handlerFactory,
-                   final MockApnsServerListener listener, final int maxConcurrentStreams,
-                   final EventLoopGroup eventLoopGroup) {
+        super(sslContext, eventLoopGroup);
 
-        this.sslContext = sslContext;
+        this.handlerFactory = handlerFactory;
+        this.listener = listener;
 
-        if (this.sslContext instanceof ReferenceCounted) {
-            ((ReferenceCounted) this.sslContext).retain();
-        }
-
-        this.bootstrap = new ServerBootstrap();
-
-        if (eventLoopGroup != null) {
-            this.bootstrap.group(eventLoopGroup);
-            this.shouldShutDownEventLoopGroup = false;
-        } else {
-            this.bootstrap.group(new NioEventLoopGroup(1));
-            this.shouldShutDownEventLoopGroup = true;
-        }
-
-        this.bootstrap.channel(ServerSocketChannelClassUtil.getServerSocketChannelClass(this.bootstrap.config().group()));
-        this.bootstrap.childHandler(new ChannelInitializer<SocketChannel>() {
-
-            @Override
-            protected void initChannel(final SocketChannel channel) throws Exception {
-                final SslHandler sslHandler = sslContext.newHandler(channel.alloc());
-                channel.pipeline().addLast(sslHandler);
-                channel.pipeline().addLast(new ApplicationProtocolNegotiationHandler(ApplicationProtocolNames.HTTP_1_1) {
-
-                    @Override
-                    protected void configurePipeline(final ChannelHandlerContext context, final String protocol) throws Exception {
-                        if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
-                            final PushNotificationHandler pushNotificationHandler =
-                                    handlerFactory.buildHandler(sslHandler.engine().getSession());
-
-                            final MockApnsServerHandler serverHandler = new MockApnsServerHandler.MockApnsServerHandlerBuilder()
-                                    .pushNotificationHandler(pushNotificationHandler)
-                                    .initialSettings(Http2Settings.defaultSettings().maxConcurrentStreams(maxConcurrentStreams))
-                                    .listener(listener)
-                                    .build();
-
-                            context.pipeline().addLast(serverHandler);
-
-                            MockApnsServer.this.allChannels.add(context.channel());
-                        } else {
-                            throw new IllegalStateException("Unexpected protocol: " + protocol);
-                        }
-                    }
-                });
-            }
-        });
+        this.maxConcurrentStreams = maxConcurrentStreams;
     }
 
-    /**
-     * Starts this mock server and listens for traffic on the given port.
-     *
-     * @param port the port to which this server should bind
-     *
-     * @return a {@code Future} that will succeed when the server has bound to the given port and is ready to accept
-     * traffic
-     */
-    public Future<Void> start(final int port) {
-        final ChannelFuture channelFuture = this.bootstrap.bind(port);
+    @Override
+    protected void addHandlersToPipeline(final SSLSession sslSession, final ChannelPipeline pipeline) throws Exception {
+        final PushNotificationHandler pushNotificationHandler = this.handlerFactory.buildHandler(sslSession);
 
-        this.allChannels = new DefaultChannelGroup(channelFuture.channel().eventLoop(), true);
-        this.allChannels.add(channelFuture.channel());
+        final MockApnsServerHandler serverHandler = new MockApnsServerHandler.MockApnsServerHandlerBuilder()
+                .pushNotificationHandler(pushNotificationHandler)
+                .initialSettings(Http2Settings.defaultSettings().maxConcurrentStreams(this.maxConcurrentStreams))
+                .listener(this.listener)
+                .build();
 
-        return channelFuture;
-    }
-
-    /**
-     * <p>Shuts down this server and releases the port to which this server was bound. If a {@code null} event loop
-     * group was provided at construction time, the server will also shut down its internally-managed event loop
-     * group.</p>
-     *
-     * <p>If a non-null {@code EventLoopGroup} was provided at construction time, mock servers may be reconnected and
-     * reused after they have been shut down. If no event loop group was provided at construction time, mock servers may
-     * not be restarted after they have been shut down via this method.</p>
-     *
-     * @return a {@code Future} that will succeed once the server has finished unbinding from its port and, if the
-     * server was managing its own event loop group, its event loop group has shut down
-     */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public Future<Void> shutdown() {
-        final Future<Void> channelCloseFuture = (this.allChannels != null) ?
-                this.allChannels.close() : new SucceededFuture<Void>(GlobalEventExecutor.INSTANCE, null);
-
-        final Future<Void> disconnectFuture;
-
-        if (this.shouldShutDownEventLoopGroup) {
-            // Wait for the channel to close before we try to shut down the event loop group
-            channelCloseFuture.addListener(new GenericFutureListener<Future<Void>>() {
-
-                @Override
-                public void operationComplete(final Future<Void> future) throws Exception {
-                    MockApnsServer.this.bootstrap.config().group().shutdownGracefully();
-                }
-            });
-
-            // Since the termination future for the event loop group is a Future<?> instead of a Future<Void>,
-            // we'll need to create our own promise and then notify it when the termination future completes.
-            disconnectFuture = new DefaultPromise<>(GlobalEventExecutor.INSTANCE);
-
-            this.bootstrap.config().group().terminationFuture().addListener(new GenericFutureListener() {
-
-                @Override
-                public void operationComplete(final Future future) throws Exception {
-                    ((Promise<Void>) disconnectFuture).trySuccess(null);
-                }
-            });
-        } else {
-            // We're done once we've closed all the channels, so we can return the closure future directly.
-            disconnectFuture = channelCloseFuture;
-        }
-
-        disconnectFuture.addListener(new GenericFutureListener<Future<Void>>() {
-            @Override
-            public void operationComplete(final Future<Void> future) throws Exception {
-                if (MockApnsServer.this.sslContext instanceof ReferenceCounted) {
-                    if (MockApnsServer.this.hasReleasedSslContext.compareAndSet(false, true)) {
-                        ((ReferenceCounted) MockApnsServer.this.sslContext).release();
-                    }
-                }
-            }
-        });
-
-        return disconnectFuture;
+        pipeline.addLast(serverHandler);
     }
 }

--- a/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerBuilder.java
@@ -23,14 +23,7 @@
 package com.turo.pushy.apns.server;
 
 import io.netty.channel.EventLoopGroup;
-import io.netty.handler.codec.http2.Http2SecurityUtil;
-import io.netty.handler.ssl.*;
-import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
-import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
-import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
-import io.netty.util.ReferenceCounted;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.netty.handler.ssl.SslContext;
 
 import javax.net.ssl.SSLException;
 import java.io.File;
@@ -51,196 +44,56 @@ import java.security.cert.X509Certificate;
  *
  * @since 0.8
  */
-public class MockApnsServerBuilder {
-    private X509Certificate[] certificateChain;
-    private PrivateKey privateKey;
-
-    private File certificateChainPemFile;
-    private File privateKeyPkcs8File;
-
-    private InputStream certificateChainInputStream;
-    private InputStream privateKeyPkcs8InputStream;
-
-    private String privateKeyPassword;
-
-    private File trustedClientCertificatePemFile;
-    private InputStream trustedClientCertificateInputStream;
-    private X509Certificate[] trustedClientCertificates;
+public class MockApnsServerBuilder extends BaseHttp2ServerBuilder<MockApnsServer> {
 
     private PushNotificationHandlerFactory handlerFactory;
-
     private MockApnsServerListener listener;
 
-    private EventLoopGroup eventLoopGroup;
-
-    private int maxConcurrentStreams = DEFAULT_MAX_CONCURRENT_STREAMS;
-
-    /**
-     * The default maximum number of concurrent streams for an APNs server, which matches the default limit set by the
-     * real APNs server at the time of this writing.
-     */
-    public static final int DEFAULT_MAX_CONCURRENT_STREAMS = 1500;
-
-    private static final Logger log = LoggerFactory.getLogger(MockApnsServerBuilder.class);
-
-    /**
-     * <p>Sets the credentials for the server under construction using the certificates in the given PEM file and the
-     * private key in the given PKCS#8 file.</p>
-     *
-     * @param certificatePemFile a PEM file containing the certificate chain for the server under construction
-     * @param privateKeyPkcs8File a PKCS#8 file containing the private key for the server under construction
-     * @param privateKeyPassword the password for the given private key, or {@code null} if the key is not
-     * password-protected
-     *
-     * @return a reference to this builder
-     *
-     * @since 0.8
-     */
+    @Override
     public MockApnsServerBuilder setServerCredentials(final File certificatePemFile, final File privateKeyPkcs8File, final String privateKeyPassword) {
-        this.certificateChain = null;
-        this.privateKey = null;
-
-        this.certificateChainPemFile = certificatePemFile;
-        this.privateKeyPkcs8File = privateKeyPkcs8File;
-
-        this.certificateChainInputStream = null;
-        this.privateKeyPkcs8InputStream = null;
-
-        this.privateKeyPassword = privateKeyPassword;
-
+        super.setServerCredentials(certificatePemFile, privateKeyPkcs8File, privateKeyPassword);
         return this;
     }
 
-    /**
-     * <p>Sets the credentials for the server under construction using the certificates in the given PEM input stream
-     * and the private key in the given PKCS#8 input stream.</p>
-     *
-     * @param certificatePemInputStream a PEM input stream containing the certificate chain for the server under
-     * construction
-     * @param privateKeyPkcs8InputStream a PKCS#8 input stream containing the private key for the server under
-     * construction
-     * @param privateKeyPassword the password for the given private key, or {@code null} if the key is not
-     * password-protected
-     *
-     * @return a reference to this builder
-     *
-     * @since 0.8
-     */
+    @Override
     public MockApnsServerBuilder setServerCredentials(final InputStream certificatePemInputStream, final InputStream privateKeyPkcs8InputStream, final String privateKeyPassword) {
-        this.certificateChain = null;
-        this.privateKey = null;
-
-        this.certificateChainPemFile = null;
-        this.privateKeyPkcs8File = null;
-
-        this.certificateChainInputStream = certificatePemInputStream;
-        this.privateKeyPkcs8InputStream = privateKeyPkcs8InputStream;
-
-        this.privateKeyPassword = privateKeyPassword;
-
+        super.setServerCredentials(certificatePemInputStream, privateKeyPkcs8InputStream, privateKeyPassword);
         return this;
     }
 
-    /**
-     * <p>Sets the credentials for the server under construction.</p>
-     *
-     * @param certificates a certificate chain including the server's own certificate
-     * @param privateKey the private key for the server's certificate
-     * @param privateKeyPassword the password for the given private key, or {@code null} if the key is not
-     * password-protected
-     *
-     * @return a reference to this builder
-     *
-     * @since 0.8
-     */
+    @Override
     public MockApnsServerBuilder setServerCredentials(final X509Certificate[] certificates, final PrivateKey privateKey, final String privateKeyPassword) {
-        this.certificateChain = certificates;
-        this.privateKey = privateKey;
-
-        this.certificateChainPemFile = null;
-        this.privateKeyPkcs8File = null;
-
-        this.certificateChainInputStream = null;
-        this.privateKeyPkcs8InputStream = null;
-
-        this.privateKeyPassword = privateKeyPassword;
-
+        super.setServerCredentials(certificates, privateKey, privateKeyPassword);
         return this;
     }
 
-    /**
-     * <p>Sets the trusted certificate chain for the server under construction using the contents of the given PEM
-     * file. If not set (or {@code null}), the server will use the JVM's default trust manager.</p>
-     *
-     * <p>In development environments, callers will almost always need to provide a trusted certificate chain for
-     * clients (since clients in development environments will generally not present credentials recognized by the JVM's
-     * default trust manager).</p>
-     *
-     * @param certificatePemFile a PEM file containing one or more trusted certificates
-     *
-     * @return a reference to this builder
-     */
+    @Override
     public MockApnsServerBuilder setTrustedClientCertificateChain(final File certificatePemFile) {
-        this.trustedClientCertificatePemFile = certificatePemFile;
-        this.trustedClientCertificateInputStream = null;
-        this.trustedClientCertificates = null;
-
+        super.setTrustedClientCertificateChain(certificatePemFile);
         return this;
     }
 
-    /**
-     * <p>Sets the trusted certificate chain for the server under construction using the contents of the given PEM
-     * input stream. If not set (or {@code null}), the server will use the JVM's default trust manager.</p>
-     *
-     * <p>In development environments, callers will almost always need to provide a trusted certificate chain for
-     * clients (since clients in development environments will generally not present credentials recognized by the JVM's
-     * default trust manager).</p>
-     *
-     * @param certificateInputStream an input stream to PEM-formatted data containing one or more trusted certificates
-     *
-     * @return a reference to this builder
-     */
+    @Override
     public MockApnsServerBuilder setTrustedClientCertificateChain(final InputStream certificateInputStream) {
-        this.trustedClientCertificatePemFile = null;
-        this.trustedClientCertificateInputStream = certificateInputStream;
-        this.trustedClientCertificates = null;
-
+        super.setTrustedClientCertificateChain(certificateInputStream);
         return this;
     }
 
-    /**
-     * <p>Sets the trusted certificate chain for the server under construction. If not set (or {@code null}), the
-     * server will use the JVM's default trust manager.</p>
-     *
-     * <p>In development environments, callers will almost always need to provide a trusted certificate chain for
-     * clients (since clients in development environments will generally not present credentials recognized by the JVM's
-     * default trust manager).</p>
-     *
-     * @param certificates one or more trusted certificates
-     *
-     * @return a reference to this builder
-     */
+    @Override
     public MockApnsServerBuilder setTrustedServerCertificateChain(final X509Certificate... certificates) {
-        this.trustedClientCertificatePemFile = null;
-        this.trustedClientCertificateInputStream = null;
-        this.trustedClientCertificates = certificates;
-
+        super.setTrustedServerCertificateChain(certificates);
         return this;
     }
 
-    /**
-     * <p>Sets the event loop group to be used by the server under construction. If not set (or if {@code null}), the
-     * server will create and manage its own event loop group.</p>
-     *
-     * @param eventLoopGroup the event loop group to use for this server, or {@code null} to let the server manage its
-     * own event loop group
-     *
-     * @return a reference to this builder
-     *
-     * @since 0.8
-     */
+    @Override
     public MockApnsServerBuilder setEventLoopGroup(final EventLoopGroup eventLoopGroup) {
-        this.eventLoopGroup = eventLoopGroup;
+        super.setEventLoopGroup(eventLoopGroup);
+        return this;
+    }
+
+    @Override
+    public MockApnsServerBuilder setMaxConcurrentStreams(final int maxConcurrentStreams) {
+        super.setMaxConcurrentStreams(maxConcurrentStreams);
         return this;
     }
 
@@ -274,96 +127,17 @@ public class MockApnsServerBuilder {
         return this;
     }
 
-
-    /**
-     * Sets the maximum number of concurrent HTTP/2 streams allowed by the server under construction. By default,
-     * mock servers will have a concurrent stream limit of {@value DEFAULT_MAX_CONCURRENT_STREAMS}.
-     *
-     * @param maxConcurrentStreams the maximum number of concurrent HTTP/2 streams allowed by the server under
-     * construction; must be positive
-     *
-     * @return a reference to this builder
-     *
-     * @since 0.12
-     */
-    public MockApnsServerBuilder setMaxConcurrentStreams(final int maxConcurrentStreams) {
-        if (maxConcurrentStreams <= 0) {
-            throw new IllegalArgumentException("Maximum number of concurrent streams must be positive.");
-        }
-
-        this.maxConcurrentStreams = maxConcurrentStreams;
-        return this;
+    @Override
+    public MockApnsServer build() throws SSLException {
+        return super.build();
     }
 
-    /**
-     * Constructs a new {@link MockApnsServer} with the previously-set configuration.
-     *
-     * @return a new MockApnsServer instance with the previously-set configuration
-     *
-     * @throws SSLException if an SSL context could not be created for the new server for any reason
-     *
-     * @since 0.8
-     */
-    public MockApnsServer build() throws SSLException {
+    @Override
+    protected MockApnsServer constructServer(final SslContext sslContext) {
         if (this.handlerFactory == null) {
             throw new IllegalStateException("Must provide a push notification handler factory before building a mock server.");
         }
 
-        final SslContext sslContext;
-        {
-            final SslProvider sslProvider;
-
-            if (OpenSsl.isAvailable()) {
-                if (OpenSsl.isAlpnSupported()) {
-                    log.info("Native SSL provider is available and supports ALPN; will use native provider.");
-                    sslProvider = SslProvider.OPENSSL;
-                } else {
-                    log.info("Native SSL provider is available, but does not support ALPN; will use JDK SSL provider.");
-                    sslProvider = SslProvider.JDK;
-                }
-            } else {
-                log.info("Native SSL provider not available; will use JDK SSL provider.");
-                sslProvider = SslProvider.JDK;
-            }
-
-            final SslContextBuilder sslContextBuilder;
-
-            if (this.certificateChain != null && this.privateKey != null) {
-                sslContextBuilder = SslContextBuilder.forServer(this.privateKey, this.privateKeyPassword, this.certificateChain);
-            } else if (this.certificateChainPemFile != null && this.privateKeyPkcs8File != null) {
-                sslContextBuilder = SslContextBuilder.forServer(this.certificateChainPemFile, this.privateKeyPkcs8File, this.privateKeyPassword);
-            } else if (this.certificateChainInputStream != null && this.privateKeyPkcs8InputStream != null) {
-                sslContextBuilder = SslContextBuilder.forServer(this.certificateChainInputStream, this.privateKeyPkcs8InputStream, this.privateKeyPassword);
-            } else {
-                throw new IllegalStateException("Must specify server credentials before building a mock server.");
-            }
-
-            sslContextBuilder.sslProvider(sslProvider)
-                    .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
-                    .clientAuth(ClientAuth.OPTIONAL)
-                    .applicationProtocolConfig(new ApplicationProtocolConfig(
-                            Protocol.ALPN,
-                            SelectorFailureBehavior.NO_ADVERTISE,
-                            SelectedListenerFailureBehavior.ACCEPT,
-                            ApplicationProtocolNames.HTTP_2));
-
-            if (this.trustedClientCertificatePemFile != null) {
-                sslContextBuilder.trustManager(this.trustedClientCertificatePemFile);
-            } else if (this.trustedClientCertificateInputStream != null) {
-                sslContextBuilder.trustManager(this.trustedClientCertificateInputStream);
-            } else if (this.trustedClientCertificates != null) {
-                sslContextBuilder.trustManager(this.trustedClientCertificates);
-            }
-
-            sslContext = sslContextBuilder.build();
-        }
-
-        final MockApnsServer server = new MockApnsServer(sslContext, this.handlerFactory, this.listener, this.maxConcurrentStreams, this.eventLoopGroup);
-
-        if (sslContext instanceof ReferenceCounted) {
-            ((ReferenceCounted) sslContext).release();
-        }
-
-        return server;
+        return new MockApnsServer(sslContext, this.eventLoopGroup, this.handlerFactory, this.listener, this.maxConcurrentStreams);
     }
 }


### PR DESCRIPTION
While working on #577, I realized that we've created a situation where benchmarks can be affected significantly by adding or removing server-side logic. In other words, there's some danger that what we're measuring is the performance of the mock server more than the performance of the client, and that's almost certainly not what we want.

This change creates an entirely separate benchmark server that has almost no server-side logic at all. The idea is that, even as server-side logic changes in the future, those server-side changes shouldn't affect our client benchmarks. One consequence is that the benchmark server just says "yes" to everything, but I think that's fine for benchmarking; the main `MockApnsServer` is unchanged.

TODO:

- [x] Update the docs