### PR TITLE
Use shading to build the packages

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -100,7 +100,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -109,6 +109,20 @@
                         </goals>
                         <configuration>
                             <finalName>${uberjar.name}</finalName>
+                            <relocations>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>com.turo.pushy.external.io.netty</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.code.gson</pattern>
+                                    <shadedPattern>com.turo.pushy.external.com.google.code.gson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>com.turo.pushy.external.org.apache.commons</shadedPattern>
+                                </relocation>
+                            </relocations>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>org.openjdk.jmh.Main</mainClass>

--- a/dropwizard-metrics-listener/pom.xml
+++ b/dropwizard-metrics-listener/pom.xml
@@ -40,6 +40,7 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>pushy</artifactId>
             <version>${project.version}</version>
+            <classifier>shaded</classifier>
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -112,6 +112,37 @@
                 <plugins>
                     <!-- Download the alpn-boot.jar in advance to add it to the boot classpath. -->
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <relocations>
+                                        <relocation>
+                                            <pattern>io.netty</pattern>
+                                            <shadedPattern>com.turo.pushy.external.io.netty</shadedPattern>
+                                        </relocation>
+                                        <relocation>
+                                            <pattern>com.google.code.gson</pattern>
+                                            <shadedPattern>com.turo.pushy.external.com.google.code.gson</shadedPattern>
+                                        </relocation>
+                                        <relocation>
+                                            <pattern>org.apache.commons</pattern>
+                                            <shadedPattern>com.turo.pushy.external.org.apache.commons</shadedPattern>
+                                        </relocation>
+                                    </relocations>
+                                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                                    <shadedClassifierName>shaded</shadedClassifierName>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <artifactId>maven-dependency-plugin</artifactId>
                         <executions>
                             <execution>


### PR DESCRIPTION
This PR adds generation of JARs shading the dependencies. It shades `io.netty`, `com.google.code.gson` and `org.apache.commons` into `com.turo.pushy.external`. 

This PR addresses #498. This is especially useful when used with newer versions of Spring Webflux, which use Netty with their Project Reactor, as it's more likely to produce version conflicts.

This also introduces the drawback of breaking source compatibility when using Netty extensions. For example, in my project, I had to rename the import of Netty's Future. 

What are your thoughts?