### PR TITLE
Update to Netty 4.1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ If you use [Maven](http://maven.apache.org/), you can add Pushy to your project 
 
 If you don't use Maven (or something else that understands Maven dependencies, like Gradle), you can [download Pushy as a `.jar` file](https://github.com/relayrides/pushy/releases/download/pushy-0.12.1/pushy-0.12.1.jar) and add it to your project directly. You'll also need to make sure you have Pushy's runtime dependencies on your classpath. They are:
 
-- [netty 4.1.22](http://netty.io/)
-- [netty-tcnative-2.0.7.Final](http://netty.io/wiki/forked-tomcat-native.html)
+- [netty 4.1.23](http://netty.io/)
+- [netty-tcnative-2.0.8.Final](http://netty.io/wiki/forked-tomcat-native.html)
 - [Apache Commons Codec 1.10](https://commons.apache.org/proper/commons-codec/)
 - [gson 2.6](https://github.com/google/gson)
 - [slf4j 1.7](http://www.slf4j.org/) (and possibly an SLF4J binding, as described in the [logging](#logging) section below)

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>2.0.7.Final</version>
+                <version>2.0.8.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.eatthepath</groupId>
@@ -111,7 +111,7 @@
     </licenses>
 
     <properties>
-        <netty.version>4.1.22.Final</netty.version>
+        <netty.version>4.1.23.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
As advertised. Sounds like there are some upstream fixes for some memory leaks.