### PR TITLE
Add a Micrometer metrics listener

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: java
 jdk:
     - oraclejdk8
-    - openjdk7
 env:
     - PUSHY_SSL_PROVIDER=jdk
     - PUSHY_SSL_PROVIDER=native
 matrix:
-    exclude:
+    include:
         - jdk: openjdk7
-          env: PUSHY_SSL_PROVIDER=jdk
+          env: PUSHY_SSL_PROVIDER=native
+          install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl '!micrometer-metrics-listener'
+          script: mvn test -B -pl '!micrometer-metrics-listener'

--- a/dropwizard-metrics-listener/README.md
+++ b/dropwizard-metrics-listener/README.md
@@ -1,12 +1,12 @@
 # Dropwizard Metrics listener for Pushy
 
-This module is an implementation of Pushy's [`ApnsClientMetricsListener`](http://relayrides.github.io/pushy/apidocs/0.12/com/relayrides/pushy/apns/ApnsClientMetricsListener.html) interface that uses the [Dropwizard Metrics library](http://metrics.dropwizard.io/) to gather and report metrics. If you use [Maven](http://maven.apache.org/), you can add the listener to your project by adding the following dependency declaration to your POM:
+This module is an implementation of Pushy's [`ApnsClientMetricsListener`](http://relayrides.github.io/pushy/apidocs/0.13/com/relayrides/pushy/apns/ApnsClientMetricsListener.html) interface that uses the [Dropwizard Metrics library](http://metrics.dropwizard.io/) to gather and report metrics. If you use [Maven](http://maven.apache.org/), you can add the listener to your project by adding the following dependency declaration to your POM:
 
 ```xml
 <dependency>
     <groupId>com.turo</groupId>
     <artifactId>pushy-dropwizard-metrics-listener</artifactId>
-    <version>0.12.0</version>
+    <version>0.13.0</version>
 </dependency>
 ```
 
@@ -18,11 +18,12 @@ Creating new Dropwizard Metrics listeners is straightforward. To get started, co
 
 ```java
 final DropwizardApnsClientMetricsListener listener =
-    new DropwizardApnsClientMetricsListener();
+        new DropwizardApnsClientMetricsListener();
 
-final ApnsClient<SimpleApnsPushNotification> apnsClient =
-    new ApnsClientBuilder<SimpleApnsPushNotification>()
-        .setClientCredentials(new File("/path/to/certificate.p12"), "p12-file-password")
+final ApnsClient apnsClient = new ApnsClientBuilder()
+        .setApnsServer(ApnsClientBuilder.DEVELOPMENT_APNS_HOST)
+        .setSigningKey(ApnsSigningKey.loadFromPkcs8File(new File("/path/to/key.p8"),
+                "TEAMID1234", "KEYID67890"))
         .setMetricsListener(listener)
         .build();
 ```

--- a/dropwizard-metrics-listener/pom.xml
+++ b/dropwizard-metrics-listener/pom.xml
@@ -25,7 +25,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>pushy-dropwizard-metrics-listener</artifactId>
-  <version>0.13.0-SNAPSHOT</version>
+    <version>0.13.0-SNAPSHOT</version>
     <name>Dropwizard Metrics listener for Pushy</name>
     <description>A metrics listener for Pushy that uses the Dropwizard Metrics library for gathering and reporting metrics.</description>
 

--- a/dropwizard-metrics-listener/src/main/java/com/turo/pushy/apns/metrics/dropwizard/DropwizardApnsClientMetricsListener.java
+++ b/dropwizard-metrics-listener/src/main/java/com/turo/pushy/apns/metrics/dropwizard/DropwizardApnsClientMetricsListener.java
@@ -26,8 +26,9 @@ import com.codahale.metrics.*;
 import com.turo.pushy.apns.ApnsClient;
 import com.turo.pushy.apns.ApnsClientMetricsListener;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -77,7 +78,7 @@ public class DropwizardApnsClientMetricsListener implements ApnsClientMetricsLis
     private final MetricRegistry metrics;
 
     private final Timer notificationTimer;
-    private final Map<Long, Timer.Context> notificationTimerContexts;
+    private final ConcurrentMap<Long, Timer.Context> notificationTimerContexts;
 
     private final Meter writeFailures;
     private final Meter sentNotifications;
@@ -144,7 +145,7 @@ public class DropwizardApnsClientMetricsListener implements ApnsClientMetricsLis
         this.metrics = new MetricRegistry();
 
         this.notificationTimer = this.metrics.timer(NOTIFICATION_TIMER_NAME);
-        this.notificationTimerContexts = new HashMap<>();
+        this.notificationTimerContexts = new ConcurrentHashMap<>();
 
         this.writeFailures = this.metrics.meter(WRITE_FAILURES_METER_NAME);
         this.sentNotifications = this.metrics.meter(SENT_NOTIFICATIONS_METER_NAME);

--- a/dropwizard-metrics-listener/src/test/java/com/turo/pushy/apns/metrics/dropwizard/DropwizardApnsClientMetricsListenerTest.java
+++ b/dropwizard-metrics-listener/src/test/java/com/turo/pushy/apns/metrics/dropwizard/DropwizardApnsClientMetricsListenerTest.java
@@ -39,7 +39,7 @@ public class DropwizardApnsClientMetricsListenerTest {
     private DropwizardApnsClientMetricsListener listener;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         this.listener = new DropwizardApnsClientMetricsListener();
     }
 
@@ -96,9 +96,9 @@ public class DropwizardApnsClientMetricsListenerTest {
     @Test
     public void testHandleConnectionCreationFailed() {
         final Meter connectionFailures = (Meter) this.listener.getMetrics().get(DropwizardApnsClientMetricsListener.CONNECTION_FAILURES_METER_NAME);
+        assertEquals(0, connectionFailures.getCount());
 
         this.listener.handleConnectionCreationFailed(null);
-
         assertEquals(1, connectionFailures.getCount());
     }
 

--- a/dropwizard-metrics-listener/src/test/java/com/turo/pushy/apns/metrics/dropwizard/ExampleApp.java
+++ b/dropwizard-metrics-listener/src/test/java/com/turo/pushy/apns/metrics/dropwizard/ExampleApp.java
@@ -25,6 +25,9 @@ package com.turo.pushy.apns.metrics.dropwizard;
 import com.codahale.metrics.MetricRegistry;
 import com.turo.pushy.apns.ApnsClient;
 import com.turo.pushy.apns.ApnsClientBuilder;
+import com.turo.pushy.apns.auth.ApnsSigningKey;
+
+import java.io.File;
 
 public class ExampleApp {
 
@@ -38,6 +41,9 @@ public class ExampleApp {
                 new DropwizardApnsClientMetricsListener();
 
         final ApnsClient apnsClient = new ApnsClientBuilder()
+                .setApnsServer(ApnsClientBuilder.DEVELOPMENT_APNS_HOST)
+                .setSigningKey(ApnsSigningKey.loadFromPkcs8File(new File("/path/to/key.p8"),
+                        "TEAMID1234", "KEYID67890"))
                 .setMetricsListener(listener)
                 .build();
 

--- a/micrometer-metrics-listener/README.md
+++ b/micrometer-metrics-listener/README.md
@@ -1,0 +1,36 @@
+# Micrometer Metrics listener for Pushy
+
+This module is an implementation of Pushy's [`ApnsClientMetricsListener`](http://relayrides.github.io/pushy/apidocs/0.13/com/relayrides/pushy/apns/ApnsClientMetricsListener.html) interface that uses the [Micrometer application monitoring library](http://micrometer.io/) to gather and report metrics. If you use [Maven](http://maven.apache.org/), you can add the listener to your project by adding the following dependency declaration to your POM:
+
+```xml
+<dependency>
+    <groupId>com.turo</groupId>
+    <artifactId>pushy-micrometer-metrics-listener</artifactId>
+    <version>0.13.0</version>
+</dependency>
+```
+
+If you don't use Maven, you can add the `.jar` file and its dependencies to your classpath by the method of your choice. The Micrometer listener for Pushy depends on Pushy itself (obviously enough) and version 1.0 of the [Micrometer application monitoring library](http://micrometer.io/). Please note that while Pushy itself works with Java 7 and newer, **the Micrometer metrics listener requires Java 8 or newer.**
+
+## Using the Micrometer Metrics listener
+
+Creating new Micrometer listeners is straightforward. To get started, construct a new listener by passing an existing `MeterRegistry` (and an optional list of [tags](http://micrometer.io/docs/concepts#_naming_meters)) to the `MicrometerApnsClientMetricsListener` constructor. From there, construct a new `ApnsClient` with the metric listener:
+
+```java
+final MicrometerApnsClientMetricsListener listener =
+        new MicrometerApnsClientMetricsListener(existingMeterRegistry,
+                "notifications", "apns", "pushy");
+
+final ApnsClient apnsClient = new ApnsClientBuilder()
+        .setApnsServer(ApnsClientBuilder.DEVELOPMENT_APNS_HOST)
+        .setSigningKey(ApnsSigningKey.loadFromPkcs8File(new File("/path/to/key.p8"),
+                "TEAMID1234", "KEYID67890"))
+        .setMetricsListener(listener)
+        .build();
+```
+
+Note that a `MicrometerApnsClientMetricsListener` is intended for use with only one `ApnsClient` at a time; if you're constructing multiple clients with the same builder, you'll need to specify a new listener for each client.
+
+## License
+
+The Micrometer metrics listener for Pushy is available under the [MIT License](http://opensource.org/licenses/MIT).

--- a/micrometer-metrics-listener/pom.xml
+++ b/micrometer-metrics-listener/pom.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2013-2017 Turo
+  Copyright (c) 2013-2018 Turo
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
@@ -24,14 +24,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>pushy-dropwizard-metrics-listener</artifactId>
-  <version>0.13.0-SNAPSHOT</version>
-    <name>Dropwizard Metrics listener for Pushy</name>
-    <description>A metrics listener for Pushy that uses the Dropwizard Metrics library for gathering and reporting metrics.</description>
+    <artifactId>pushy-micrometer-metrics-listener</artifactId>
+    <name>Micrometer metrics listener for Pushy</name>
+    <description>A metrics listener for Pushy that uses the Micrometer application monitoring library for gathering and reporting metrics.</description>
 
     <parent>
-        <groupId>com.turo</groupId>
         <artifactId>pushy-parent</artifactId>
+        <groupId>com.turo</groupId>
         <version>0.13.0-SNAPSHOT</version>
     </parent>
 
@@ -42,9 +41,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-core</artifactId>
-            <version>3.1.0</version>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>1.0.3</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -63,7 +62,6 @@
                     <show>public</show>
                     <links>
                         <link>http://relayrides.github.io/pushy/apidocs/0.12/</link>
-                        <link>http://metrics.dropwizard.io/3.1.0/apidocs/</link>
                     </links>
                 </configuration>
             </plugin>

--- a/micrometer-metrics-listener/src/main/java/com/turo/pushy/apns/metrics/micrometer/MicrometerApnsClientMetricsListener.java
+++ b/micrometer-metrics-listener/src/main/java/com/turo/pushy/apns/metrics/micrometer/MicrometerApnsClientMetricsListener.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2013-2018 Turo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.turo.pushy.apns.metrics.micrometer;
+
+import com.turo.pushy.apns.ApnsClient;
+import com.turo.pushy.apns.ApnsClientMetricsListener;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * <p>An {@link ApnsClientMetricsListener} implementation that gathers and reports metrics
+ * using the <a href="http://micrometer.io/">Micrometer application monitoring library</a>. A
+ * {@code MicrometerApnsClientMetricsListener} is intended to be used with a single
+ * {@link ApnsClient} instance; to gather metrics from multiple clients, callers should create
+ * multiple listeners.</p>
+ *
+ * <p>Callers provide a {@link io.micrometer.core.instrument.MeterRegistry} to the
+ * {@code MicrometerApnsClientMetricsListener} at construction time, and the listener populates the registry with the
+ * following metrics:</p>
+ *
+ * <dl>
+ *  <dt>{@value #NOTIFICATION_TIMER_NAME}</dt>
+ *  <dd>A {@link io.micrometer.core.instrument.Timer} that measures the time between sending notifications and receiving
+ *  a reply (whether accepted or rejected) from the APNs server.</dd>
+ *
+ *  <dt>{@value #WRITE_FAILURES_COUNTER_NAME}</dt>
+ *  <dd>A {@link io.micrometer.core.instrument.Counter} that measures the number and rate of failures to send notifications to the
+ *  APNs server.</dd>
+ *
+ *  <dt>{@value #SENT_NOTIFICATIONS_COUNTER_NAME}</dt>
+ *  <dd>A {@link io.micrometer.core.instrument.Counter} that measures the number and rate of notifications successfully sent to the
+ *  APNs server.</dd>
+ *
+ *  <dt>{@value #ACCEPTED_NOTIFICATIONS_COUNTER_NAME}</dt>
+ *  <dd>A {@link io.micrometer.core.instrument.Counter} that measures the number and rate of notifications accepted by the APNs
+ *  server.</dd>
+ *
+ *  <dt>{@value #REJECTED_NOTIFICATIONS_COUNTER_NAME}</dt>
+ *  <dd>A {@link io.micrometer.core.instrument.Counter} that measures the number and rate of notifications rejected by the APNs
+ *  server.</dd>
+ *
+ *  <dt>{@value #OPEN_CONNECTIONS_GAUGE_NAME}</dt>
+ *  <dd>A {@link io.micrometer.core.instrument.Gauge} that indicates number of open connections.</dd>
+ *
+ *  <dt>{@value #CONNECTION_FAILURES_COUNTER_NAME}</dt>
+ *  <dd>A {@link io.micrometer.core.instrument.Counter} that measures the number and rate of failed attempts to connect to the APNs
+ *  server.</dd>
+ * </dl>
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ */
+public class MicrometerApnsClientMetricsListener implements ApnsClientMetricsListener {
+
+    private final Timer notificationTimer;
+    private final ConcurrentMap<Long, Long> notificationStartTimes;
+
+    private final Counter writeFailures;
+    private final Counter sentNotifications;
+    private final Counter acceptedNotifications;
+    private final Counter rejectedNotifications;
+
+    private final AtomicInteger openConnections = new AtomicInteger(0);
+    private final Counter connectionFailures;
+
+    private static final String[] EMPTY_STRING_ARRAY = new String[0];
+
+    /**
+     * The name of a {@link io.micrometer.core.instrument.Timer} that measures round-trip time when sending
+     * notifications.
+     */
+    public static final String NOTIFICATION_TIMER_NAME = "notifications.sent.timer";
+
+    /**
+     * The name of a {@link io.micrometer.core.instrument.Counter} that measures the number of write failures when
+     * sending notifications.
+     */
+    public static final String WRITE_FAILURES_COUNTER_NAME = "notifications.failed";
+
+    /**
+     * The name of a {@link io.micrometer.core.instrument.Counter} that measures the number of notifications sent
+     * (regardless of whether they're accepted or rejected by the server).
+     */
+    public static final String SENT_NOTIFICATIONS_COUNTER_NAME = "notifications.sent";
+
+    /**
+     * The name of a {@link io.micrometer.core.instrument.Counter} that measures the number of notifications accepted by
+     * the APNs server.
+     */
+    public static final String ACCEPTED_NOTIFICATIONS_COUNTER_NAME = "notifications.accepted";
+
+    /**
+     * The name of a {@link io.micrometer.core.instrument.Counter} that measures the number of notifications rejected by
+     * the APNs server.
+     */
+    public static final String REJECTED_NOTIFICATIONS_COUNTER_NAME = "notifications.rejected";
+
+    /**
+     * The name of a {@link io.micrometer.core.instrument.Gauge} that measures the number of open connections in an APNs
+     * client's internal connection pool.
+     */
+    public static final String OPEN_CONNECTIONS_GAUGE_NAME = "connections.open";
+
+    /**
+     * The name of a {@link io.micrometer.core.instrument.Counter} that measures the number of a client's failed
+     * connection attempts.
+     */
+    public static final String CONNECTION_FAILURES_COUNTER_NAME = "connections.failed";
+
+    /**
+     * Constructs a new Micrometer metrics listener that adds metrics to the given registry with the given list of tags.
+     *
+     * @param meterRegistry the registry to which to add metrics
+     * @param tags an optional list of tags to attach to metrics; may be {@code null} or empty, in which case no tags
+     * are added
+     */
+    public MicrometerApnsClientMetricsListener(final MeterRegistry meterRegistry, final List<String> tags) {
+        this(meterRegistry, tags != null ? tags.toArray(EMPTY_STRING_ARRAY) : null);
+    }
+
+    /**
+     * Constructs a new Micrometer metrics listener that adds metrics to the given registry with the given list of tags.
+     *
+     * @param meterRegistry the registry to which to add metrics
+     * @param tags an optional list of tags to attach to metrics
+     */
+    public MicrometerApnsClientMetricsListener(final MeterRegistry meterRegistry, final String... tags) {
+        this.notificationStartTimes = new ConcurrentHashMap<>();
+        this.notificationTimer = meterRegistry.timer(NOTIFICATION_TIMER_NAME, tags);
+
+        this.writeFailures = meterRegistry.counter(WRITE_FAILURES_COUNTER_NAME, tags);
+        this.sentNotifications = meterRegistry.counter(SENT_NOTIFICATIONS_COUNTER_NAME, tags);
+        this.acceptedNotifications = meterRegistry.counter(ACCEPTED_NOTIFICATIONS_COUNTER_NAME, tags);
+        this.rejectedNotifications = meterRegistry.counter(REJECTED_NOTIFICATIONS_COUNTER_NAME, tags);
+
+        this.connectionFailures = meterRegistry.counter(CONNECTION_FAILURES_COUNTER_NAME, tags);
+        meterRegistry.gauge(OPEN_CONNECTIONS_GAUGE_NAME, openConnections);
+    }
+
+    /**
+     * Records a failed attempt to send a notification and updates metrics accordingly.
+     *
+     * @param apnsClient the client that failed to write the notification; note that this is ignored by
+     * {@code MicrometerApnsClientMetricsListener} instances, which should always be used for exactly one client
+     * @param notificationId an opaque, unique identifier for the notification that could not be written
+     */
+    @Override
+    public void handleWriteFailure(final ApnsClient apnsClient, final long notificationId) {
+        this.notificationStartTimes.remove(notificationId);
+        this.writeFailures.increment();
+    }
+
+    /**
+     * Records a successful attempt to send a notification and updates metrics accordingly.
+     *
+     * @param apnsClient the client that sent the notification; note that this is ignored by
+     * {@code MicrometerApnsClientMetricsListener} instances, which should always be used for exactly one client
+     * @param notificationId an opaque, unique identifier for the notification that was sent
+     */
+    @Override
+    public void handleNotificationSent(final ApnsClient apnsClient, final long notificationId) {
+        this.notificationStartTimes.put(notificationId, System.nanoTime());
+        this.sentNotifications.increment();
+    }
+
+    /**
+     * Records that the APNs server accepted a previously-sent notification and updates metrics accordingly.
+     *
+     * @param apnsClient the client that sent the accepted notification; note that this is ignored by
+     * {@code MicrometerApnsClientMetricsListener} instances, which should always be used for exactly one client
+     * @param notificationId an opaque, unique identifier for the notification that was accepted
+     */
+    @Override
+    public void handleNotificationAccepted(final ApnsClient apnsClient, final long notificationId) {
+        this.recordEndTimeForNotification(notificationId);
+        this.acceptedNotifications.increment();
+    }
+
+    /**
+     * Records that the APNs server rejected a previously-sent notification and updates metrics accordingly.
+     *
+     * @param apnsClient the client that sent the rejected notification; note that this is ignored by
+     * {@code MicrometerApnsClientMetricsListener} instances, which should always be used for exactly one client
+     * @param notificationId an opaque, unique identifier for the notification that was rejected
+     */
+    @Override
+    public void handleNotificationRejected(final ApnsClient apnsClient, final long notificationId) {
+        this.recordEndTimeForNotification(notificationId);
+        this.rejectedNotifications.increment();
+    }
+
+    private void recordEndTimeForNotification(final long notificationId) {
+        final long endTime = System.nanoTime();
+        final Long startTime = this.notificationStartTimes.remove(notificationId);
+
+        if (startTime != null) {
+            this.notificationTimer.record(endTime - startTime, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    /**
+     * Records that the APNs server added a new connection to its internal connection pool and updates metrics
+     * accordingly.
+     *
+     * @param apnsClient the client that added the new connection
+     */
+    @Override
+    public void handleConnectionAdded(final ApnsClient apnsClient) {
+        this.openConnections.incrementAndGet();
+    }
+
+    /**
+     * Records that the APNs server removed a connection from its internal connection pool and updates metrics
+     * accordingly.
+     *
+     * @param apnsClient the client that removed the connection
+     */
+    @Override
+    public void handleConnectionRemoved(final ApnsClient apnsClient) {
+        this.openConnections.decrementAndGet();
+    }
+
+    /**
+     * Records that a previously-started attempt to connect to the APNs server failed and updates metrics accordingly.
+     *
+     * @param apnsClient the client that failed to connect; note that this is ignored by
+     * {@code MicrometerApnsClientMetricsListener} instances, which should always be used for exactly one client
+     */
+    @Override
+    public void handleConnectionCreationFailed(final ApnsClient apnsClient) {
+        this.connectionFailures.increment();
+    }
+}

--- a/micrometer-metrics-listener/src/main/java/com/turo/pushy/apns/metrics/micrometer/package-info.java
+++ b/micrometer-metrics-listener/src/main/java/com/turo/pushy/apns/metrics/micrometer/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2013-2018 Turo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * <p>Provides a concrete implementation of the {@link com.turo.pushy.apns.ApnsClientMetricsListener} interface
+ * that gathers and reports metrics using the <a href="http://micrometer.io/">Micrometer application monitoring
+ * library</a>.</p>
+ *
+ * @author <a href="https://github.com/jchambers">Jon Chambers</a>
+ */
+package com.turo.pushy.apns.metrics.micrometer;

--- a/micrometer-metrics-listener/src/main/java/overview.html
+++ b/micrometer-metrics-listener/src/main/java/overview.html
@@ -1,0 +1,35 @@
+<!--
+  Copyright (c) 2013-2018 Turo
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+  -->
+
+<!DOCTYPE html>
+
+<html>
+    <head>
+        <title>Micrometer metrics listener for Pushy overview</title>
+    </head>
+
+    <body>
+        <p>This library provides a metrics listener for <a href="http://relayrides.github.io/pushy/" target="_top">Pushy</a> (a Java library for sending APNs push) notifications that gathers metrics using the <a href="http://micrometer.io/">Micrometer application monitoring library</a>.</p>
+
+        <p>It is available under the <a href="http://opensource.org/licenses/MIT">MIT License</a>.</p>
+    </body>
+</html>

--- a/micrometer-metrics-listener/src/test/java/com/turo/pushy/apns/metrics/micrometer/ExampleApp.java
+++ b/micrometer-metrics-listener/src/test/java/com/turo/pushy/apns/metrics/micrometer/ExampleApp.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2013-2018 Turo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.turo.pushy.apns.metrics.micrometer;
+
+import com.turo.pushy.apns.ApnsClient;
+import com.turo.pushy.apns.ApnsClientBuilder;
+import com.turo.pushy.apns.auth.ApnsSigningKey;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import java.io.File;
+
+public class ExampleApp {
+
+    public static void main(final String... args) throws Exception {
+        final MeterRegistry existingMeterRegistry = new SimpleMeterRegistry();
+
+        // Note that a MicrometerApnsClientMetricsListener is intended for use
+        // with only one ApnsClient at a time; if you're constructing multiple
+        // clients with the same builder, you'll need to specify a new listener
+        // for each client.
+        final MicrometerApnsClientMetricsListener listener =
+                new MicrometerApnsClientMetricsListener(existingMeterRegistry,
+                        "notifications", "apns", "pushy");
+
+        final ApnsClient apnsClient = new ApnsClientBuilder()
+                .setApnsServer(ApnsClientBuilder.DEVELOPMENT_APNS_HOST)
+                .setSigningKey(ApnsSigningKey.loadFromPkcs8File(new File("/path/to/key.p8"),
+                        "TEAMID1234", "KEYID67890"))
+                .setMetricsListener(listener)
+                .build();
+    }
+}

--- a/micrometer-metrics-listener/src/test/java/com/turo/pushy/apns/metrics/micrometer/MicrometerApnsClientMetricsListenerTest.java
+++ b/micrometer-metrics-listener/src/test/java/com/turo/pushy/apns/metrics/micrometer/MicrometerApnsClientMetricsListenerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2013-2018 Turo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.turo.pushy.apns.metrics.micrometer;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MicrometerApnsClientMetricsListenerTest {
+
+    private MeterRegistry meterRegistry;
+    private MicrometerApnsClientMetricsListener listener;
+
+    @Before
+    public void setUp() {
+        this.meterRegistry = new SimpleMeterRegistry();
+        this.listener = new MicrometerApnsClientMetricsListener(this.meterRegistry);
+    }
+
+    @Test
+    public void testHandleWriteFailure() {
+        final Counter writeFailures = this.meterRegistry.get(MicrometerApnsClientMetricsListener.WRITE_FAILURES_COUNTER_NAME).counter();
+        assertEquals(0, (int) writeFailures.count());
+
+        this.listener.handleWriteFailure(null, 1);
+        assertEquals(1, (int) writeFailures.count());
+    }
+
+    @Test
+    public void testHandleNotificationSent() {
+        final Counter sentNotifications = this.meterRegistry.get(MicrometerApnsClientMetricsListener.SENT_NOTIFICATIONS_COUNTER_NAME).counter();
+        assertEquals(0, (int) sentNotifications.count());
+
+        this.listener.handleNotificationSent(null, 1);
+        assertEquals(1, (int) sentNotifications.count());
+    }
+
+    @Test
+    public void testHandleNotificationAccepted() {
+        final Counter acceptedNotifications = this.meterRegistry.get(MicrometerApnsClientMetricsListener.ACCEPTED_NOTIFICATIONS_COUNTER_NAME).counter();
+        assertEquals(0, (int) acceptedNotifications.count());
+
+        this.listener.handleNotificationAccepted(null, 1);
+        assertEquals(1, (int) acceptedNotifications.count());
+    }
+
+    @Test
+    public void testHandleNotificationRejected() {
+        final Counter rejectedNotifications = this.meterRegistry.get(MicrometerApnsClientMetricsListener.REJECTED_NOTIFICATIONS_COUNTER_NAME).counter();
+        assertEquals(0, (int) rejectedNotifications.count());
+
+        this.listener.handleNotificationRejected(null, 1);
+        assertEquals(1, (int) rejectedNotifications.count());
+    }
+
+    @Test
+    public void testHandleConnectionAddedAndRemoved() {
+        final Gauge openConnectionGauge = this.meterRegistry.get(MicrometerApnsClientMetricsListener.OPEN_CONNECTIONS_GAUGE_NAME).gauge();
+
+        this.listener.handleConnectionAdded(null);
+
+        assertEquals(1, (int) openConnectionGauge.value());
+
+        this.listener.handleConnectionRemoved(null);
+
+        assertEquals(0, (int) openConnectionGauge.value());
+    }
+
+    @Test
+    public void testHandleConnectionCreationFailed() {
+        final Counter connectionFailures = this.meterRegistry.get(MicrometerApnsClientMetricsListener.CONNECTION_FAILURES_COUNTER_NAME).counter();
+        assertEquals(0, (int) connectionFailures.count());
+
+        this.listener.handleConnectionCreationFailed(null);
+        assertEquals(1, (int) connectionFailures.count());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <module>pushy</module>
         <module>benchmark</module>
         <module>dropwizard-metrics-listener</module>
+        <module>micrometer-metrics-listener</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
This adds an implementation of `ApnsClientMetricsListener` for the [Micrometer application monitoring library](http://micrometer.io/).

I do need to say that I found the Micrometer documentation to be vague and incomplete. While I don't wish to be overly-critical of others' work, I feel I need to point out that my confidence that I'm using best practices—particularly around adding metrics to a `MeterRegistry`—is low. Feedback from experienced Micrometer users is very welcome.

Assuming this is the right way to use Micrometer, this closes #595.

TODO:

- [x] Finish docs for `MicrometerApnsClientMetricsListener`