### PR TITLE
Drop commons-codec as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ If you don't use Maven (or something else that understands Maven dependencies, l
 
 - [netty 4.1.23](http://netty.io/)
 - [netty-tcnative-2.0.8.Final](http://netty.io/wiki/forked-tomcat-native.html)
-- [Apache Commons Codec 1.10](https://commons.apache.org/proper/commons-codec/)
 - [gson 2.6](https://github.com/google/gson)
 - [slf4j 1.7](http://www.slf4j.org/) (and possibly an SLF4J binding, as described in the [logging](#logging) section below)
 - [fast-uuid 0.1](https://github.com/jchambers/fast-uuid)

--- a/pom.xml
+++ b/pom.xml
@@ -77,11 +77,6 @@
                 <version>2.8.0</version>
             </dependency>
             <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>1.10</version>
-            </dependency>
-            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -60,10 +60,6 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/pushy/src/main/java/com/turo/pushy/apns/auth/ApnsKey.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/auth/ApnsKey.java
@@ -22,6 +22,11 @@
 
 package com.turo.pushy.apns.auth;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.base64.Base64;
+
+import java.nio.charset.StandardCharsets;
 import java.security.interfaces.ECKey;
 import java.security.spec.ECParameterSpec;
 import java.util.Objects;
@@ -37,7 +42,7 @@ import java.util.Objects;
  *
  * @since 0.10
  */
-public abstract class ApnsKey implements ECKey {
+abstract class ApnsKey implements ECKey {
 
     private final String teamId;
     private final String keyId;
@@ -95,5 +100,20 @@ public abstract class ApnsKey implements ECKey {
     @Override
     public ECParameterSpec getParams() {
         return this.key.getParams();
+    }
+
+    protected static byte[] decodeBase64EncodedString(final String base64EncodedString) {
+        final ByteBuf base64EncodedByteBuf =
+                Unpooled.wrappedBuffer(base64EncodedString.getBytes(StandardCharsets.US_ASCII));
+
+        final ByteBuf decodedByteBuf = Base64.decode(base64EncodedByteBuf);
+        final byte[] decodedBytes = new byte[decodedByteBuf.readableBytes()];
+
+        decodedByteBuf.readBytes(decodedBytes);
+
+        base64EncodedByteBuf.release();
+        decodedByteBuf.release();
+
+        return decodedBytes;
     }
 }

--- a/pushy/src/main/java/com/turo/pushy/apns/auth/ApnsSigningKey.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/auth/ApnsSigningKey.java
@@ -22,8 +22,6 @@
 
 package com.turo.pushy.apns.auth;
 
-import org.apache.commons.codec.binary.Base64;
-
 import java.io.*;
 import java.math.BigInteger;
 import java.security.InvalidKeyException;
@@ -155,7 +153,7 @@ public class ApnsSigningKey extends ApnsKey implements ECPrivateKey {
                 base64EncodedPrivateKey = privateKeyBuilder.toString();
             }
 
-            final byte[] keyBytes = Base64.decodeBase64(base64EncodedPrivateKey);
+            final byte[] keyBytes = decodeBase64EncodedString(base64EncodedPrivateKey);
 
             final PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
             final KeyFactory keyFactory = KeyFactory.getInstance("EC");

--- a/pushy/src/main/java/com/turo/pushy/apns/auth/ApnsVerificationKey.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/auth/ApnsVerificationKey.java
@@ -23,7 +23,6 @@
 package com.turo.pushy.apns.auth;
 
 import com.turo.pushy.apns.ApnsClient;
-import org.apache.commons.codec.binary.Base64;
 
 import java.io.*;
 import java.security.InvalidKeyException;
@@ -160,7 +159,7 @@ public class ApnsVerificationKey extends ApnsKey implements ECPublicKey {
                 base64EncodedPublicKey = publicKeyBuilder.toString();
             }
 
-            final byte[] keyBytes = Base64.decodeBase64(base64EncodedPublicKey);
+            final byte[] keyBytes = decodeBase64EncodedString(base64EncodedPublicKey);
 
             final X509EncodedKeySpec keySpec = new X509EncodedKeySpec(keyBytes);
             final KeyFactory keyFactory = KeyFactory.getInstance("EC");

--- a/pushy/src/test/java/com/turo/pushy/apns/auth/ApnsKeyTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/auth/ApnsKeyTest.java
@@ -22,14 +22,20 @@
 
 package com.turo.pushy.apns.auth;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+@RunWith(JUnitParamsRunner.class)
 public abstract class ApnsKeyTest {
 
     protected abstract ApnsKey getApnsKey() throws NoSuchAlgorithmException, InvalidKeyException, IOException;
@@ -52,5 +58,18 @@ public abstract class ApnsKeyTest {
     @Test
     public void testGetParams() throws Exception {
         assertNotNull(this.getApnsKey().getParams());
+    }
+
+    @Test
+    // Test vectors from https://tools.ietf.org/html/rfc4648#section-10
+    @Parameters({
+            "Zg==,     f",
+            "Zm8=,     fo",
+            "Zm9v,     foo",
+            "Zm9vYg==, foob",
+            "Zm9vYmE=, fooba",
+            "Zm9vYmFy, foobar"  })
+    public void testDecodeBase64EncodedString(final String base64EncodedString, final String decodedAsciiString) {
+        assertEquals(decodedAsciiString, new String(ApnsKey.decodeBase64EncodedString(base64EncodedString), StandardCharsets.US_ASCII));
     }
 }

--- a/pushy/src/test/java/com/turo/pushy/apns/auth/AuthenticationTokenTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/auth/AuthenticationTokenTest.java
@@ -109,4 +109,14 @@ public class AuthenticationTokenTest {
 
         assertTrue(Pattern.matches("^[a-zA-Z0-9_\\-]+\\.[a-zA-Z0-9_\\-]+\\.[a-zA-Z0-9_\\-]+$", token.toString()));
     }
+
+    @Test
+    public void testEncodeDecodeBase64() {
+        final byte[] originalBytes =
+                "We expect to get these bytes back after encoding, then decoding as Base64.".getBytes();
+
+        final String encodedString = AuthenticationToken.encodeUnpaddedBase64UrlString(originalBytes);
+
+        assertArrayEquals(originalBytes, AuthenticationToken.decodeBase64UrlEncodedString(encodedString));
+    }
 }


### PR DESCRIPTION
[Apache Commons Codec](https://commons.apache.org/proper/commons-codec/) is a fine library that we were using for Base64 encoding/decoding for APNs signing/verification keys and authentication tokens. Even though it's a little more verbose, we can do the same thing with Netty's Base64 tools. Since we already depend on Netty, we can use that instead and have one less dependency to keep track of.