### PR TITLE
Drop netty-tcnative as a dependency under Java 8 and newer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ jdk:
     - oraclejdk8
 env:
     - PUSHY_SSL_PROVIDER=jdk
-    - PUSHY_SSL_PROVIDER=native
+    - PUSHY_SSL_PROVIDER=netty-tcnative
 matrix:
     include:
         - jdk: openjdk7
-          env: PUSHY_SSL_PROVIDER=native
+          env: PUSHY_SSL_PROVIDER=
           install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl '!micrometer-metrics-listener'
           script: mvn test -B -pl '!micrometer-metrics-listener'

--- a/README.md
+++ b/README.md
@@ -24,12 +24,22 @@ If you use [Maven](http://maven.apache.org/), you can add Pushy to your project 
 If you don't use Maven (or something else that understands Maven dependencies, like Gradle), you can [download Pushy as a `.jar` file](https://github.com/relayrides/pushy/releases/download/pushy-0.13.1/pushy-0.13.1.jar) and add it to your project directly. You'll also need to make sure you have Pushy's runtime dependencies on your classpath. They are:
 
 - [netty 4.1.24](http://netty.io/)
-- [netty-tcnative-2.0.8.Final](http://netty.io/wiki/forked-tomcat-native.html)
 - [gson 2.6](https://github.com/google/gson)
 - [slf4j 1.7](http://www.slf4j.org/) (and possibly an SLF4J binding, as described in the [logging](#logging) section below)
 - [fast-uuid 0.1](https://github.com/jchambers/fast-uuid)
 
-Pushy itself requires Java 7 or newer to build and run.
+Pushy itself requires Java 7 or newer to build and run. Under Java 7, Pushy has an additional dependency (included automatically by dependency management systems) on [netty-tcnative 2.0.8.Final](http://netty.io/wiki/forked-tomcat-native.html), a native SSL provider that (among other benefits) includes ciphers required by APNs that are not included with Java 7 by default.
+
+Under Java 8 and newer, Pushy does not require a native SSL provider, but users may choose to use it regardless for enhanced performance. To use a native provider, make sure netty-tcnative is on your classpath. Maven users may add a dependency to their project as follows:
+
+```xml
+<dependency>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-tcnative-boringssl-static</artifactId>
+    <version>2.0.8.Final</version>
+    <scope>runtime</scope>
+</dependency>
+```
 
 ## Authenticating with the APNs server
 
@@ -164,7 +174,7 @@ Making the most of your system resources for high-throughput applications always
 
 ## System requirements
 
-Pushy works with Java 7 and newer. By default, it depends on `netty-tcnative` and should work "out of the box" for most users. Users who can't (or choose not to) use `netty-tcnative` may need to take extra steps to [configure a JDK SSL provider](https://github.com/relayrides/pushy/wiki/Using-a-JDK-SSL-provider).
+Pushy requires Java 7 or newer. Under Java 7, Pushy depends on netty-tcnative as an SSL provider (it is included automatically by dependency management systems, but Java 7 users managing dependcies manually will need to make sure it's on their classpath). A native SSL provider is not required under Java 8 and newer, but users may still choose to include one for enhanced performance.
 
 ## Metrics
 

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -62,11 +62,6 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.4</version>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <scope>runtime</scope>
-        </dependency>
     </dependencies>
 
     <properties>
@@ -175,4 +170,22 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>benchmark-with-netty-tcnative</id>
+            <activation>
+                <property>
+                    <name>env.PUSHY_SSL_PROVIDER</name>
+                    <value>netty-tcnative</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -184,6 +184,7 @@
                 <dependency>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-tcnative-boringssl-static</artifactId>
+                    <scope>runtime</scope>
                 </dependency>
             </dependencies>
         </profile>

--- a/dropwizard-metrics-listener/pom.xml
+++ b/dropwizard-metrics-listener/pom.xml
@@ -49,6 +49,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/micrometer-metrics-listener/pom.xml
+++ b/micrometer-metrics-listener/pom.xml
@@ -48,6 +48,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
                 <version>2.0.8.Final</version>
+                <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>com.eatthepath</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
                 <version>2.0.8.Final</version>
-                <scope>runtime</scope>
             </dependency>
             <dependency>
                 <groupId>com.eatthepath</groupId>
@@ -87,19 +86,16 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>pl.pragmatists</groupId>
                 <artifactId>JUnitParams</artifactId>
                 <version>1.0.6</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${slf4j.version}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -63,14 +63,17 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>pl.pragmatists</groupId>
             <artifactId>JUnitParams</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -117,6 +120,7 @@
                 <dependency>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-tcnative-boringssl-static</artifactId>
+                    <scope>runtime</scope>
                 </dependency>
             </dependencies>
         </profile>
@@ -132,6 +136,7 @@
                 <dependency>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-tcnative-boringssl-static</artifactId>
+                    <scope>test</scope>
                 </dependency>
             </dependencies>
         </profile>

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -48,10 +48,6 @@
             <artifactId>netty-resolver-dns</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.eatthepath</groupId>
             <artifactId>fast-uuid</artifactId>
         </dependency>
@@ -93,6 +89,7 @@
                     </links>
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -112,14 +109,31 @@
 
     <profiles>
         <profile>
-            <id>test-with-alpn-boot</id>
+            <id>jdk-7</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <jdk>1.7</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>test-with-netty-tcnative</id>
+            <activation>
                 <property>
                     <name>env.PUSHY_SSL_PROVIDER</name>
-                    <value>jdk</value>
+                    <value>netty-tcnative</value>
                 </property>
             </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-tcnative-boringssl-static</artifactId>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientBuilder.java
@@ -517,17 +517,12 @@ public class ApnsClientBuilder {
         {
             final SslProvider sslProvider;
 
-            if ("jdk".equalsIgnoreCase(System.getenv("PUSHY_SSL_PROVIDER"))) {
-                log.info("JDK provider specified in PUSHY_SSL_PROVIDER environment variable; will use JDK SSL provider.");
-                sslProvider = SslProvider.JDK;
+            if (OpenSsl.isAvailable()) {
+                log.info("Native SSL provider is available; will use native provider.");
+                sslProvider = SslProvider.OPENSSL_REFCNT;
             } else {
-                if (OpenSsl.isAvailable()) {
-                    log.info("Native SSL provider is available; will use native provider.");
-                    sslProvider = SslProvider.OPENSSL_REFCNT;
-                } else {
-                    log.info("Native SSL provider not available; will use JDK SSL provider.");
-                    sslProvider = SslProvider.JDK;
-                }
+                log.info("Native SSL provider not available; will use JDK SSL provider.");
+                sslProvider = SslProvider.JDK;
             }
 
             final SslContextBuilder sslContextBuilder = SslContextBuilder.forClient()


### PR DESCRIPTION
Since we moved to direct protocol negotiation in #598, we no longer strictly need `netty-tcnative` under Java 8 and newer. This change makes that A Thing™. After this, folks who want to use `netty-tcnative` will need to add it as a dependency on their own.

I suspect this will provoke some opinions; what do you all think?