### PR TITLE
Update to Netty 4.1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you use [Maven](http://maven.apache.org/), you can add Pushy to your project 
 
 If you don't use Maven (or something else that understands Maven dependencies, like Gradle), you can [download Pushy as a `.jar` file](https://github.com/relayrides/pushy/releases/download/pushy-0.13.0/pushy-0.13.0.jar) and add it to your project directly. You'll also need to make sure you have Pushy's runtime dependencies on your classpath. They are:
 
-- [netty 4.1.23](http://netty.io/)
+- [netty 4.1.24](http://netty.io/)
 - [netty-tcnative-2.0.8.Final](http://netty.io/wiki/forked-tomcat-native.html)
 - [gson 2.6](https://github.com/google/gson)
 - [slf4j 1.7](http://www.slf4j.org/) (and possibly an SLF4J binding, as described in the [logging](#logging) section below)

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     </licenses>
 
     <properties>
-        <netty.version>4.1.23.Final</netty.version>
+        <netty.version>4.1.24.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
Netty 4.1.24 came out today, and it sounds like it fixes a [pretty nasty bug](https://github.com/netty/netty/pull/7878). This updates Pushy to depend on Netty 4.1.24.