### PR TITLE
Update to Netty 4.1.25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ matrix:
 
         - os: linux
           jdk: oraclejdk8
-          env: PUSHY_SSL_PROVIDER=netty-tcnative
 
         - os: linux
           jdk: openjdk7
@@ -21,4 +20,3 @@ matrix:
 
         - os: osx
           osx_image: xcode8.3
-          env: PUSHY_SSL_PROVIDER=netty-tcnative

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you use [Maven](http://maven.apache.org/), you can add Pushy to your project 
 
 If you don't use Maven (or something else that understands Maven dependencies, like Gradle), you can [download Pushy as a `.jar` file](https://github.com/relayrides/pushy/releases/download/pushy-0.13.1/pushy-0.13.1.jar) and add it to your project directly. You'll also need to make sure you have Pushy's runtime dependencies on your classpath. They are:
 
-- [netty 4.1.24](http://netty.io/)
+- [netty 4.1.25](http://netty.io/)
 - [gson 2.6](https://github.com/google/gson)
 - [slf4j 1.7](http://www.slf4j.org/) (and possibly an SLF4J binding, as described in the [logging](#logging) section below)
 - [fast-uuid 0.1](https://github.com/jchambers/fast-uuid)

--- a/pom.xml
+++ b/pom.xml
@@ -101,17 +101,7 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-kqueue</artifactId>
                 <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-kqueue</artifactId>
-                <version>${netty.version}</version>
                 <classifier>osx-x86_64</classifier>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-epoll</artifactId>
-                <version>${netty.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     </licenses>
 
     <properties>
-        <netty.version>4.1.24.Final</netty.version>
+        <netty.version>4.1.25.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -77,12 +77,19 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-kqueue</artifactId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
+            <classifier>linux-x86_64</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-kqueue</artifactId>
+            <classifier>osx-x86_64</classifier>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -136,56 +143,31 @@
         </profile>
 
         <profile>
-            <id>test-with-netty-tcnative</id>
+            <id>test-with-jdk-ssl-provider</id>
             <activation>
                 <property>
                     <name>env.PUSHY_SSL_PROVIDER</name>
-                    <value>netty-tcnative</value>
+                    <value>jdk</value>
                 </property>
             </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-tcnative-boringssl-static</artifactId>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
-            <id>test-with-native-kqueue</id>
-            <activation>
-                <property>
-                    <name>env.TRAVIS_OS_NAME</name>
-                    <value>osx</value>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-transport-native-kqueue</artifactId>
-                    <classifier>osx-x86_64</classifier>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
-            <id>test-with-native-epoll</id>
-            <activation>
-                <property>
-                    <name>env.TRAVIS_OS_NAME</name>
-                    <value>linux</value>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-transport-native-epoll</artifactId>
-                    <classifier>linux-x86_64</classifier>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.16</version>
+                        <configuration>
+                            <argLine>-Dio.netty.transport.noNative=true -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Dio.netty.leakDetection.level=paranoid -ea</argLine>
+                            <properties>
+                                <property>
+                                    <name>listener</name>
+                                    <value>com.turo.pushy.apns.PrintTestNameRunListener</value>
+                                </property>
+                            </properties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
This moves us up to the Netty 4.1.25, which was just released. @flozano you may be interested in https://github.com/netty/netty/pull/7903, which introduces a `-Dio.netty.handler.ssl.noOpenSsl=true/false` option for ignoring native SSL providers even if they're on the classpath.

TODO:

- [ ] ~Simplify SSL provider selection by relying on Netty defaults~ (won't do—the default native provider isn't reference-counted)
- [x] Switch unit tests to use `io.netty.handler.ssl.noOpenSsl` option