### PR TITLE
Updated links to Apple's docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/relayrides/pushy.svg?branch=master)](https://travis-ci.org/relayrides/pushy)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.turo/pushy/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.turo/pushy)
 
-Pushy is a Java library for sending [APNs](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html) (iOS, macOS, and Safari) push notifications. It is written and maintained by the engineers at [Turo](https://turo.com/).
+Pushy is a Java library for sending [APNs](https://developer.apple.com/documentation/usernotifications) (iOS, macOS, and Safari) push notifications. It is written and maintained by the engineers at [Turo](https://turo.com/).
 
 Pushy sends push notifications using Apple's HTTP/2-based APNs protocol and supports both TLS and token-based authentication. It distinguishes itself from other push notification libraries with a focus on [thorough documentation](http://relayrides.github.io/pushy/apidocs/0.13/), asynchronous operation, and design for industrial-scale operation; with Pushy, it's easy and efficient to maintain multiple parallel connections to the APNs gateway to send large numbers of notifications to many different applications ("topics").
 
@@ -43,7 +43,7 @@ Under Java 8 and newer, Pushy does not require a native SSL provider, but users 
 
 ## Authenticating with the APNs server
 
-Before you can get started with Pushy, you'll need to do some provisioning work with Apple to register your app and get the required certificates or signing keys (more on these shortly). For details on this process, please see the [Provisioning Procedures](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html) section of Apple's official documentation. Please note that there are [some caveats](https://github.com/relayrides/pushy/wiki/Certificates), particularly under macOS 10.13 (El Capitan).
+Before you can get started with Pushy, you'll need to do some provisioning work with Apple to register your app and get the required certificates or signing keys (more on these shortly). For details on this process, please see the [Registering Your App with APNs](https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns) section of Apple's UserNotifications documentation. Please note that there are [some caveats](https://github.com/relayrides/pushy/wiki/Certificates), particularly under macOS 10.13 (El Capitan).
 
 Generally speaking, APNs clients must authenticate with the APNs server by some means before they can send push notifications. Currently, APNs (and Pushy) supports two authentication methods: TLS-based authentication and token-based authentication. The two approaches are mutually-exclusive; you'll need to pick one or the other for each client.
 

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
@@ -46,9 +46,8 @@ import java.util.concurrent.atomic.AtomicLong;
  * authentication tokens for each notification they send. Clients that opt to use TLS-based authentication may send
  * notifications to any topic named in the client certificate. Clients that opt to use token-based authentication may
  * send notifications to any topic associated with the team to which the client's signing key belongs. Please see the
- * <a href="https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html">Local
- * and Remote Notification Programming Guide</a> for a detailed discussion of the APNs protocol, topics, and
- * certificate/key provisioning.</p>
+ * <a href="https://developer.apple.com/documentation/usernotifications">UserNotifications Framework documentation</a>
+ * for a detailed discussion of the APNs protocol, topics, and certificate/key provisioning.</p>
  *
  * <p>Clients are constructed using an {@link ApnsClientBuilder}. Callers may
  * optionally specify an {@link EventLoopGroup} when constructing a new client. If no event loop group is specified,

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientBuilder.java
@@ -114,8 +114,7 @@ public class ApnsClientBuilder {
      * <blockquote>You can alternatively use port 2197 when communicating with APNs. You might do this, for example, to
      * allow APNs traffic through your firewall but to block other HTTPS traffic.</blockquote>
      *
-     * @see <a href="https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW1">Communicating
-     * with APNs</a>
+     * @see <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns">Sending Notification Requests to APNs</a>
      *
      * @since 0.5
      */
@@ -134,7 +133,7 @@ public class ApnsClientBuilder {
      * @see ApnsClientBuilder#DEVELOPMENT_APNS_HOST
      * @see ApnsClientBuilder#PRODUCTION_APNS_HOST
      *
-     * @see <a href="https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW1">Communicating with APNs</a>
+     * @see <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns">Sending Notification Requests to APNs</a>
      *
      * @since 0.11
      */
@@ -158,7 +157,7 @@ public class ApnsClientBuilder {
      * @see ApnsClientBuilder#DEFAULT_APNS_PORT
      * @see ApnsClientBuilder#ALTERNATE_APNS_PORT
      *
-     * @see <a href="https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW1">Communicating with APNs</a>
+     * @see <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns">Sending Notification Requests to APNs</a>
      *
      * @since 0.11
      */

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsPushNotification.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsPushNotification.java
@@ -37,9 +37,7 @@ import java.util.UUID;
  *
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
  *
- * @see <a href=
- *      "https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html">
- *      Local and Remote Notification Programming Guide - Apple Push Notification Service</a>
+ * @see <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns">Sending Notification Requests to APNs</a>
  *
  * @see ApnsPayloadBuilder
  * @see PushNotificationResponse#getApnsId()

--- a/pushy/src/main/java/com/turo/pushy/apns/DeliveryPriority.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/DeliveryPriority.java
@@ -27,9 +27,7 @@ package com.turo.pushy.apns;
  * notification may be delivered to the receiving device by the APNs gateway and does <em>not</em> affect when the
  * notification will be sent to the gateway itself.
  *
- * @see <a href=
- *      "https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html">
- *      Local and Remote Notification Programming Guide - Communicating with APNs</a>
+ * @see <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns">Sending Notification Requests to APNs</a>
  *
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
  *

--- a/pushy/src/main/java/com/turo/pushy/apns/auth/AuthenticationToken.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/auth/AuthenticationToken.java
@@ -56,9 +56,7 @@ import java.util.concurrent.TimeUnit;
  * <p>Tokens may be constructed from an {@link ApnsSigningKey} (for clients sending notifications) or from a
  * Base64-encoded JWT string (for servers verifying a token from a client).</p>
  *
- * @see <a href="https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW1">Local
- * and Remote Notification Programming Guide - Communicating with APNs</a>
- *
+ * @see <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_token_based_connection_to_apns">Establishing a Token-Based Connection to APNs</a>
  * @see <a href="https://tools.ietf.org/html/rfc7519">RFC 7519 - JSON Web Token (JWT)</a>
  *
  * @see com.turo.pushy.apns.ApnsClientBuilder#setSigningKey(ApnsSigningKey)

--- a/pushy/src/main/java/com/turo/pushy/apns/server/RejectionReason.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/RejectionReason.java
@@ -26,8 +26,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 
 /**
  * An enumeration of reasons a push notification may be rejected by an APNs server. The most up-to-date descriptions of
- * each rejection reason are available in Table 8-6 of Apple's <a href="https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW1">Local
- * and Remote Notification Programming Guide - Communicating with APNs</a>.
+ * each rejection reason are available in Table 5 of <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns#2947619">Sending Notification Requests to APNs</a>.
  */
 public enum RejectionReason {
     BAD_COLLAPSE_ID("BadCollapseId", HttpResponseStatus.BAD_REQUEST),

--- a/pushy/src/main/java/com/turo/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/util/ApnsPayloadBuilder.java
@@ -35,9 +35,7 @@ import java.util.*;
  *
  * @author <a href="https://github.com/jchambers">Jon Chambers</a>
  *
- * @see <a href=
- *      "https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html">
- *      Local and Push Notification Programming Guide - Apple Push Notification Service - Payload Key Reference</a>
+ * @see <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification">Generating a Remote Notification</a>
  */
 public class ApnsPayloadBuilder {
 
@@ -387,8 +385,7 @@ public class ApnsPayloadBuilder {
      *
      * @return a reference to this payload builder
      *
-     * @see <a href="https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/SupportingNotificationsinYourApp.html#//apple_ref/doc/uid/TP40008194-CH4-SW26">Configuring
-     * Categories and Actionable Notifications</a>
+     * @see <a href="https://developer.apple.com/documentation/usernotifications/declaring_your_actionable_notification_types">Declaring Your Actionable Notification Types</a>
      */
     public ApnsPayloadBuilder setCategoryName(final String categoryName) {
         this.categoryName = categoryName;
@@ -488,8 +485,7 @@ public class ApnsPayloadBuilder {
      * @return a reference to this payload builder
      *
      * @see <a href=
-     *      "https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html#//apple_ref/doc/uid/TP40008194-CH10-SW8">Configuring
-     *      a Silent Notification</a>
+     *      "https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_updates_to_your_app_silently">Pushing Updates to Your App Silently</a>
      */
     public ApnsPayloadBuilder setContentAvailable(final boolean contentAvailable) {
         this.contentAvailable = contentAvailable;

--- a/pushy/src/main/java/com/turo/pushy/apns/util/TokenUtil.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/util/TokenUtil.java
@@ -32,7 +32,7 @@ public class TokenUtil {
     /**
      * Returns a "sanitized" version of the given token string suitable for sending to an APNs server. This method
      * returns a version of the original string with all non-hexadecimal digits removed. This can be especially useful
-     * when dealing with strings produced with <a href="https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSData_Class/Reference/Reference.html#//apple_ref/occ/instm/NSData/description">
+     * when dealing with strings produced with <a href="https://developer.apple.com/documentation/foundation/nsdata/1412579-description">
      * {@code [NSData describe]}</a>.
      *
      * @param tokenString the token string to sanitize

--- a/pushy/src/main/java/com/turo/pushy/apns/util/package-info.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/util/package-info.java
@@ -30,7 +30,7 @@
  *
  * <p>Device tokens identify the device to which a push notification is being sent. Ultimately, tokens need to be
  * expressed as a string of hexadecimal characters, but a common practice is to transmit tokens as the output of
- * <a href="https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSData_Class/Reference/Reference.html#//apple_ref/occ/instm/NSData/description">
+ * <a href="https://developer.apple.com/documentation/foundation/nsdata/1412579-description">
  * {@code [NSData describe]}</a>. The {@link com.turo.pushy.apns.util.TokenUtil} class provides methods for
  * sanitizing token strings so they can be sent safely to the APNs gateway.</p>
  *

--- a/pushy/src/main/java/overview.html
+++ b/pushy/src/main/java/overview.html
@@ -29,8 +29,8 @@
 
     <body>
         <p><a href="https://relayrides.github.io/pushy/" target="_top">Pushy</a> is a Java library for sending
-        <a href="https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html" target="_top">APNs</a>
-        (iOS and OS X) push notifications. Pushy is written by the engineers at <a href="https://turo.com/" target="_top">Turo</a>.</p>
+        <a href="https://developer.apple.com/documentation/usernotifications" target="_top">APNs</a>(iOS and OS X) push
+        notifications. Pushy is written by the engineers at <a href="https://turo.com/" target="_top">Turo</a>.</p>
 
         <p>Pushy sends push notifications using Apple's HTTP/2-based APNs protocol. It distinguishes itself from other
         push notification libraries with a focus on thorough documentation, asynchronous operation, and design for


### PR DESCRIPTION
This change replaces all links to Apple's outdated [Local and Remote Notification Programming Guide](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html#//apple_ref/doc/uid/TP40008194-CH8-SW1) with links to the current [UserNotifications Framework documentation](https://developer.apple.com/documentation/usernotifications). This closes #618.

TODO:

- [x] Update links on the [wiki](https://github.com/relayrides/pushy/wiki)