### PR TITLE
Make RejectionReason getters public

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/server/RejectionReason.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/RejectionReason.java
@@ -74,11 +74,11 @@ public enum RejectionReason {
         this.httpResponseStatus = httpResponseStatus;
     }
 
-    String getReasonText() {
+    public String getReasonText() {
         return this.reasonText;
     }
 
-    HttpResponseStatus getHttpResponseStatus() {
+    public HttpResponseStatus getHttpResponseStatus() {
         return this.httpResponseStatus;
     }
 }


### PR DESCRIPTION
Writing an application in scala.  We want to pattern match over the string values of `RejectionReason`'s `reasonText` property so we can perform different actions based on the response.  The `SimplePushNotificationResponse` that gets returned by Apple only has a `getRejectionReason` method which returns string.  There's no way to access the `reasonText` property so at the moment we essentially need to recreate this enum in our own code to match on this value.

from the scala REPL:
```
<scala> RejectionReason.BAD_DEVICE_TOKEN.getReasonText
<console>:17: error: method getReasonText in class RejectionReason cannot be accessed in com.turo.pushy.apns.server.RejectionReason
       RejectionReason.BAD_DEVICE_TOKEN.getReasonText
```