### PR TITLE
Added `summary-arg` and `summary-arg-count` to the payload builder.

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/util/ApnsPayloadBuilder.java
@@ -540,13 +540,15 @@ public class ApnsPayloadBuilder {
      *
      * <blockquote>The string the notification adds to the category’s summary format string.</blockquote>
      *
-     * <p>For example when defining an UNNotificationCategory, passing a format string like
-     * "%u more messages from %@" to the categorySummaryFormat argument, will produce
+     * <p>For example in iOS 12, when defining an {@code UNNotificationCategory}, passing a format string like
+     * "%u more messages from %@" to the {@code categorySummaryFormat} argument, will produce
      * "x more messages from {summaryArgument}.</p>
      *
-     * <p>By default, it says “x more notifications”, no summary argument is included.</p>
+     * <p>In iOS 12, the default summary format string in English is "%u more notifications" and does not have a
+     * placeholder for a summary argument. By default, no summary argument is included in push notification payloads.</p>
      *
-     * @param summaryArgument the summary argument for this notification
+     * @param summaryArgument the summary argument for this notification; if
+     * {@code null}, the {@code summary-arg} key is omitted from the payload entirely
      *
      * @return a reference to this payload builder
      *
@@ -566,13 +568,19 @@ public class ApnsPayloadBuilder {
      *
      * <blockquote>The number of items the notification adds to the category’s summary format string.</blockquote>
      *
-     * <p>For example when defining an UNNotificationCategory, passing a format string like
-     * like "%u more podcasts" to the categorySummaryFormat argument, will produce "{argumentSummaryCount} more podcasts"
+     * <p>By default, all notifications count as a single "item" in a group of notifications. The summary argument count
+     * controls how many "items" in a "stack" of notifications are represented by a specific notification.
+     * If, for example, a notification informed a user that seven new podcasts are available, it might be helpful to set
+     * the summary argument count to 7. When "stacked," the notification would contribute an item count of 7
+     * to the total number of notifications reported in the summary string (for example, "7 more podcasts").
      * </p>
      *
-     * <p>By default, summary argument count is 1 and it can not be 0.</p>
+     * <p>By default, notifications count as a single "item" in a group of notifications, and so the default
+     * summary argument count is 1 (even if no summary argument count is specified in the notification payload).
+     * If specified, summary argument count must be positive.</p>
      *
      * @param summaryArgumentCount the summary argument count for this notification
+     * {@code null}, the {@code summary-arg-count} key is omitted from the payload entirely
      *
      * @return a reference to this payload builder
      *
@@ -583,6 +591,9 @@ public class ApnsPayloadBuilder {
      * @since 0.13.6
      */
     public ApnsPayloadBuilder setSummaryArgumentCount(final Integer summaryArgumentCount) {
+        if (summaryArgumentCount != null && summaryArgumentCount < 1) {
+            throw new IllegalArgumentException("Summary argument count must be positive.");
+        }
         this.summaryArgumentCount = summaryArgumentCount;
         return this;
     }

--- a/pushy/src/main/java/com/turo/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/util/ApnsPayloadBuilder.java
@@ -85,8 +85,8 @@ public class ApnsPayloadBuilder {
     private static final String CONTENT_AVAILABLE_KEY = "content-available";
     private static final String MUTABLE_CONTENT_KEY = "mutable-content";
     private static final String THREAD_ID_KEY = "thread-id";
-    private static final String SUMMARY_ARGUMENT = "summary-arg";
-    private static final String SUMMARY_ARGUMENT_COUNT = "summary-arg-count";
+    private static final String SUMMARY_ARGUMENT_KEY = "summary-arg";
+    private static final String SUMMARY_ARGUMENT_COUNT_KEY = "summary-arg-count";
     private static final String URL_ARGS_KEY = "url-args";
 
     private static final String ALERT_TITLE_KEY = "title";
@@ -538,16 +538,21 @@ public class ApnsPayloadBuilder {
     /**
      * <p>Sets the summary argument for this notification. The summary argument is:</p>
      *
-     * <blockquote>The argument to be inserted in the summary for this notification when the system groups the
-     * category’s notifications. For example when defining an UNNotificationCategory, passing a format string like
+     * <blockquote>The string the notification adds to the category’s summary format string.</blockquote>
+     *
+     * <p>For example when defining an UNNotificationCategory, passing a format string like
      * "%u more messages from %@" to the categorySummaryFormat argument, will produce
-     * "x more messages from {summaryArgument}</blockquote>
+     * "x more messages from {summaryArgument}.</p>
      *
      * <p>By default, it says “x more notifications”, no summary argument is included.</p>
      *
      * @param summaryArgument the summary argument for this notification
      *
      * @return a reference to this payload builder
+     *
+     * @see <a href=
+     *      "https://developer.apple.com/documentation/usernotifications/unnotificationcontent">
+     *      UNNotificationContent</a>
      *
      * @since 0.13.6
      */
@@ -559,15 +564,21 @@ public class ApnsPayloadBuilder {
     /**
      * <p>Sets the summary argument count for this notification. The summary argument count is:</p>
      *
-     * <blockquote>A number that indicates how many items in the summary are represented in the summary.
-     * For example if a podcast app sends one notification for 3 new episodes in a show,
-     * the argument should be the name of the show and the count should be 3.</blockquote>
+     * <blockquote>The number of items the notification adds to the category’s summary format string.</blockquote>
+     *
+     * <p>For example when defining an UNNotificationCategory, passing a format string like
+     * like "%u more podcasts" to the categorySummaryFormat argument, will produce "{argumentSummaryCount} more podcasts"
+     * </p>
      *
      * <p>By default, summary argument count is 1 and it can not be 0.</p>
      *
      * @param summaryArgumentCount the summary argument count for this notification
      *
      * @return a reference to this payload builder
+     *
+     * @see <a href=
+     *      "https://developer.apple.com/documentation/usernotifications/unnotificationcontent">
+     *      UNNotificationContent</a>
      *
      * @since 0.13.6
      */
@@ -717,14 +728,6 @@ public class ApnsPayloadBuilder {
                 aps.put(THREAD_ID_KEY, this.threadId);
             }
 
-            if (this.summaryArgument != null) {
-                aps.put(SUMMARY_ARGUMENT, this.summaryArgument);
-            }
-
-            if (this.summaryArgumentCount != null) {
-                aps.put(SUMMARY_ARGUMENT_COUNT, this.summaryArgumentCount);
-            }
-
             if (this.urlArguments != null) {
                 aps.put(URL_ARGS_KEY, this.urlArguments);
             }
@@ -741,6 +744,14 @@ public class ApnsPayloadBuilder {
 
                 if (this.alertSubtitle != null) {
                     alert.put(ALERT_SUBTITLE_KEY, this.alertSubtitle);
+                }
+
+                if (this.summaryArgument != null) {
+                    alert.put(SUMMARY_ARGUMENT_KEY, this.summaryArgument);
+                }
+
+                if (this.summaryArgumentCount != null) {
+                    alert.put(SUMMARY_ARGUMENT_COUNT_KEY, this.summaryArgumentCount);
                 }
 
                 if (this.showActionButton) {

--- a/pushy/src/main/java/com/turo/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/util/ApnsPayloadBuilder.java
@@ -68,6 +68,9 @@ public class ApnsPayloadBuilder {
 
     private String threadId = null;
 
+    private String summaryArgument = null;
+    private Integer summaryArgumentCount = null;
+
     private String[] urlArguments = null;
 
     private boolean preferStringRepresentationForAlerts = false;
@@ -82,6 +85,8 @@ public class ApnsPayloadBuilder {
     private static final String CONTENT_AVAILABLE_KEY = "content-available";
     private static final String MUTABLE_CONTENT_KEY = "mutable-content";
     private static final String THREAD_ID_KEY = "thread-id";
+    private static final String SUMMARY_ARGUMENT = "summary-arg";
+    private static final String SUMMARY_ARGUMENT_COUNT = "summary-arg-count";
     private static final String URL_ARGS_KEY = "url-args";
 
     private static final String ALERT_TITLE_KEY = "title";
@@ -531,6 +536,47 @@ public class ApnsPayloadBuilder {
     }
 
     /**
+     * <p>Sets the summary argument for this notification. The summary argument is:</p>
+     *
+     * <blockquote>The argument to be inserted in the summary for this notification when the system groups the
+     * category’s notifications. For example when defining an UNNotificationCategory, passing a format string like
+     * "%u more messages from %@" to the categorySummaryFormat argument, will produce
+     * "x more messages from {summaryArgument}</blockquote>
+     *
+     * <p>By default, it says “x more notifications”, no summary argument is included.</p>
+     *
+     * @param summaryArgument the summary argument for this notification
+     *
+     * @return a reference to this payload builder
+     *
+     * @since 0.13.6
+     */
+    public ApnsPayloadBuilder setSummaryArgument(final String summaryArgument) {
+        this.summaryArgument = summaryArgument;
+        return this;
+    }
+
+    /**
+     * <p>Sets the summary argument count for this notification. The summary argument count is:</p>
+     *
+     * <blockquote>A number that indicates how many items in the summary are represented in the summary.
+     * For example if a podcast app sends one notification for 3 new episodes in a show,
+     * the argument should be the name of the show and the count should be 3.</blockquote>
+     *
+     * <p>By default, summary argument count is 1 and it can not be 0.</p>
+     *
+     * @param summaryArgumentCount the summary argument count for this notification
+     *
+     * @return a reference to this payload builder
+     *
+     * @since 0.13.6
+     */
+    public ApnsPayloadBuilder setSummaryArgumentCount(final Integer summaryArgumentCount) {
+        this.summaryArgumentCount = summaryArgumentCount;
+        return this;
+    }
+
+    /**
      * <p>Sets the list of arguments to populate placeholders in the {@code urlFormatString} associated with a Safari
      * push notification. Has no effect for non-Safari notifications. According to the Notification Programming Guide
      * for Websites:</p>
@@ -669,6 +715,14 @@ public class ApnsPayloadBuilder {
 
             if (this.threadId != null) {
                 aps.put(THREAD_ID_KEY, this.threadId);
+            }
+
+            if (this.summaryArgument != null) {
+                aps.put(SUMMARY_ARGUMENT, this.summaryArgument);
+            }
+
+            if (this.summaryArgumentCount != null) {
+                aps.put(SUMMARY_ARGUMENT_COUNT, this.summaryArgumentCount);
             }
 
             if (this.urlArguments != null) {

--- a/pushy/src/test/java/com/turo/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -457,7 +457,11 @@ public class ApnsPayloadBuilderTest {
         this.builder.setSummaryArgument(summaryArgument);
 
         final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
-        assertEquals(summaryArgument, aps.get("summary-arg"));
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
+
+        assertEquals(summaryArgument, alert.get("summary-arg"));
     }
 
     @Test
@@ -467,7 +471,11 @@ public class ApnsPayloadBuilderTest {
         this.builder.setSummaryArgumentCount(argumentSummaryCount);
 
         final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
-        assertEquals(argumentSummaryCount, ((Number) aps.get("summary-arg-count")).intValue());
+
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> alert = (Map<String, Object>) aps.get("alert");
+
+        assertEquals(argumentSummaryCount, ((Number) alert.get("summary-arg-count")).intValue());
     }
 
     @Test

--- a/pushy/src/test/java/com/turo/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -451,6 +451,26 @@ public class ApnsPayloadBuilderTest {
     }
 
     @Test
+    public void testSetSummaryArgument() {
+        final String summaryArgument = "This is a summary argument";
+
+        this.builder.setSummaryArgument(summaryArgument);
+
+        final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+        assertEquals(summaryArgument, aps.get("summary-arg"));
+    }
+
+    @Test
+    public void testSetSummaryArgumentCount() {
+        final int argumentSummaryCount = 3;
+
+        this.builder.setSummaryArgumentCount(argumentSummaryCount);
+
+        final Map<String, Object> aps = this.extractApsObjectFromPayloadString(this.builder.buildWithDefaultMaximumLength());
+        assertEquals(argumentSummaryCount, ((Number) aps.get("summary-arg-count")).intValue());
+    }
+
+    @Test
     public void testAddCustomProperty() {
         final String customKey = "string";
         final String customValue = "Hello";


### PR DESCRIPTION
This adds support for the summary-arg and  summary-arg-count fields to the payload builder.