### PR TITLE
Including ALPN supported protocols in Mock Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@ doc
 _site
 #ignore intellij files
 *.iml
+*.ipr
+*.iws
 .idea/

--- a/pushy/src/main/java/com/turo/pushy/apns/server/BaseHttp2ServerBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/BaseHttp2ServerBuilder.java
@@ -291,6 +291,15 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
                 sslContextBuilder.trustManager(this.trustedClientCertificates);
             }
 
+            // Mock server needs to be able to inform to ALPN-enabled HTTP clients
+            // which protocols are supported during the protocol negotiation phase.
+            // In this case, mock server should only support HTTP/2 in order to mock real APNS servers.
+            sslContextBuilder.applicationProtocolConfig(new ApplicationProtocolConfig(
+                    ApplicationProtocolConfig.Protocol.ALPN,
+                    ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
+                    ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+                    ApplicationProtocolNames.HTTP_2));
+
             sslContext = sslContextBuilder.build();
         }
 


### PR DESCRIPTION
Fixing an issue in mock server where the ALPN extension fields for protocol negotiation were not being added to the 'Server Hello' TLS package.

When using mock server with different HTTP/2-compliant clients only accepting HTTP/2 protocol, connection couldn't be established as mock server wasn't setting ALPN extension fields with the supported protocols.

'_Server Hello_' package from the **real** APNS server.
![image](https://user-images.githubusercontent.com/5717234/50254556-61390900-03e6-11e9-9c3b-443a8ff817ce.png)

'_Server Hello_' package from mock server **before** the fix.
![image](https://user-images.githubusercontent.com/5717234/50254899-b88ba900-03e7-11e9-8254-19691295695d.png)

'_Server Hello_' package from mock server **after** the fix.
![image](https://user-images.githubusercontent.com/5717234/50254719-1d92cf00-03e7-11e9-8a86-14c65da99f2d.png)
