### PR TITLE
Consolidate flushes to reduce overhead

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsChannelFactory.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsChannelFactory.java
@@ -28,6 +28,7 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.*;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http2.Http2FrameLogger;
+import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
@@ -151,6 +152,8 @@ class ApnsChannelFactory implements PooledObjectFactory<Channel>, Closeable {
                                 apnsClientHandler.gracefulShutdownTimeoutMillis(gracefulShutdownTimeoutMillis);
                             }
 
+                            // TODO Use a named constant when https://github.com/netty/netty/pull/8683 is available
+                            pipeline.addLast(new FlushConsolidationHandler(256, true));
                             pipeline.addLast(new IdleStateHandler(idlePingIntervalMillis, 0, 0, TimeUnit.MILLISECONDS));
                             pipeline.addLast(apnsClientHandler);
                             pipeline.remove(ConnectionNegotiationErrorHandler.INSTANCE);


### PR DESCRIPTION
This change batches calls to `flush` together where possible. `flush` is a relatively expensive call. By batching calls to `flush` together, we can sell out write latency (which isn't really a primary concern) to pick up some gains in overall throughput (which _is_ a primary concern). Some benchmarks with a local client and server show a significant improvement with this change in place:

### Before

| Concurrent connections | Time to send 10,000 notifications |
|------------------------|-----------------------------------|
|                      1 |             0.336 ± 0.003 seconds |
|                      4 |             0.231 ± 0.019 seconds |
|                      8 |             0.221 ± 0.013 seconds |

### After

| Concurrent connections | Time to send 10,000 notifications |
|------------------------|-----------------------------------|
|                      1 |             0.312 ± 0.002 seconds |
|                      4 |             0.160 ± 0.009 seconds |
|                      8 |             0.152 ± 0.013 seconds |

This closes #655.