### PR TITLE
Update to Netty 4.1.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ If you use [Maven](http://maven.apache.org/), you can add Pushy to your project 
 
 If you don't use Maven (or something else that understands Maven dependencies, like Gradle), you can [download Pushy as a `.jar` file](https://github.com/relayrides/pushy/releases/download/pushy-0.13.6/pushy-0.13.6.jar) and add it to your project directly. You'll also need to make sure you have Pushy's runtime dependencies on your classpath. They are:
 
-- [netty 4.1.28](http://netty.io/)
+- [netty 4.1.32](http://netty.io/)
 - [gson 2.6](https://github.com/google/gson)
 - [slf4j 1.7](http://www.slf4j.org/) (and possibly an SLF4J binding, as described in the [logging](#logging) section below)
 - [fast-uuid 0.1](https://github.com/jchambers/fast-uuid)
 
-Pushy itself requires Java 7 or newer to build and run. Under Java 7, Pushy has an additional dependency (included automatically by dependency management systems) on [netty-tcnative 2.0.12.Final](http://netty.io/wiki/forked-tomcat-native.html), a native SSL provider that (among other benefits) includes ciphers required by APNs that are not included with Java 7 by default.
+Pushy itself requires Java 7 or newer to build and run. Under Java 7, Pushy has an additional dependency (included automatically by dependency management systems) on [netty-native 2.0.20.Final](http://netty.io/wiki/forked-tomcat-native.html), a native SSL provider that (among other benefits) includes ciphers required by APNs that are not included with Java 7 by default.
 
 Under Java 8 and newer, Pushy does not require a native SSL provider, but users may choose to use it regardless for enhanced performance. To use a native provider, make sure netty-tcnative is on your classpath. Maven users may add a dependency to their project as follows:
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>2.0.12.Final</version>
+                <version>2.0.20.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.eatthepath</groupId>
@@ -150,7 +150,7 @@
     </dependencyManagement>
 
     <properties>
-        <netty.version>4.1.28.Final</netty.version>
+        <netty.version>4.1.32.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pushy/src/test/java/com/turo/pushy/apns/server/MockApnsServerTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/server/MockApnsServerTest.java
@@ -132,7 +132,6 @@ public class MockApnsServerTest extends AbstractClientServerTest {
         final NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup(1);
 
         try {
-
             final MockApnsServer providedGroupServer = new MockApnsServerBuilder()
                     .setServerCredentials(getClass().getResourceAsStream(SERVER_CERTIFICATES_FILENAME), getClass().getResourceAsStream(SERVER_KEY_FILENAME), null)
                     .setHandlerFactory(new AcceptAllPushNotificationHandlerFactory())
@@ -141,10 +140,6 @@ public class MockApnsServerTest extends AbstractClientServerTest {
 
             assertTrue(providedGroupServer.start(PORT).await().isSuccess());
             assertTrue(providedGroupServer.shutdown().await().isSuccess());
-
-            // This test fails mysteriously under OpenJDK 11 (the port is already in use) if we don't yield here. I
-            // have no idea why.
-            Thread.yield();
 
             assertTrue(providedGroupServer.start(PORT).await().isSuccess());
             assertTrue(providedGroupServer.shutdown().await().isSuccess());


### PR DESCRIPTION
This brings us up to the latest versions of Netty and netty-tcnative. Interestingly, this update produces a noticeable improvement in throughput as measured by our benchmarks.