### PR TITLE
Make ALPN a user-selectable option for mock servers

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/server/BenchmarkApnsServerBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/BenchmarkApnsServerBuilder.java
@@ -94,6 +94,12 @@ public class BenchmarkApnsServerBuilder extends BaseHttp2ServerBuilder<Benchmark
     }
 
     @Override
+    public BenchmarkApnsServerBuilder setUseAlpn(final boolean useAlpn) {
+        super.setUseAlpn(useAlpn);
+        return this;
+    }
+
+    @Override
     public BenchmarkApnsServer build() throws SSLException {
         return super.build();
     }

--- a/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerBuilder.java
@@ -97,6 +97,12 @@ public class MockApnsServerBuilder extends BaseHttp2ServerBuilder<MockApnsServer
         return this;
     }
 
+    @Override
+    public MockApnsServerBuilder setUseAlpn(final boolean useAlpn) {
+        super.setUseAlpn(useAlpn);
+        return this;
+    }
+
     /**
      * Sets the handler factory to be used to construct push notification handlers for the server under construction.
      * Servers require a handler factory.


### PR DESCRIPTION
As a follow-up to #656, this change makes ALPN optional (off by default) for mock servers. This is intended for folks using Pushy's mock server to test other APNs clients.