### PR TITLE
Use fancier server builder generics

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/server/BaseHttp2ServerBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/BaseHttp2ServerBuilder.java
@@ -35,7 +35,7 @@ import java.io.InputStream;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 
-abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
+abstract class BaseHttp2ServerBuilder<T extends BaseHttp2ServerBuilder<T, S>, S extends BaseHttp2Server> {
 
     protected X509Certificate[] certificateChain;
     protected PrivateKey privateKey;
@@ -77,7 +77,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @since 0.8
      */
-    public BaseHttp2ServerBuilder setServerCredentials(final File certificatePemFile, final File privateKeyPkcs8File, final String privateKeyPassword) {
+    public T setServerCredentials(final File certificatePemFile, final File privateKeyPkcs8File, final String privateKeyPassword) {
         this.certificateChain = null;
         this.privateKey = null;
 
@@ -89,7 +89,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
 
         this.privateKeyPassword = privateKeyPassword;
 
-        return this;
+        return (T) this;
     }
 
     /**
@@ -107,7 +107,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @since 0.8
      */
-    public BaseHttp2ServerBuilder setServerCredentials(final InputStream certificatePemInputStream, final InputStream privateKeyPkcs8InputStream, final String privateKeyPassword) {
+    public T setServerCredentials(final InputStream certificatePemInputStream, final InputStream privateKeyPkcs8InputStream, final String privateKeyPassword) {
         this.certificateChain = null;
         this.privateKey = null;
 
@@ -119,7 +119,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
 
         this.privateKeyPassword = privateKeyPassword;
 
-        return this;
+        return (T) this;
     }
 
     /**
@@ -134,7 +134,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @since 0.8
      */
-    public BaseHttp2ServerBuilder setServerCredentials(final X509Certificate[] certificates, final PrivateKey privateKey, final String privateKeyPassword) {
+    public T setServerCredentials(final X509Certificate[] certificates, final PrivateKey privateKey, final String privateKeyPassword) {
         this.certificateChain = certificates;
         this.privateKey = privateKey;
 
@@ -146,7 +146,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
 
         this.privateKeyPassword = privateKeyPassword;
 
-        return this;
+        return (T) this;
     }
 
     /**
@@ -161,12 +161,12 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @return a reference to this builder
      */
-    public BaseHttp2ServerBuilder setTrustedClientCertificateChain(final File certificatePemFile) {
+    public T setTrustedClientCertificateChain(final File certificatePemFile) {
         this.trustedClientCertificatePemFile = certificatePemFile;
         this.trustedClientCertificateInputStream = null;
         this.trustedClientCertificates = null;
 
-        return this;
+        return (T) this;
     }
 
     /**
@@ -181,12 +181,12 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @return a reference to this builder
      */
-    public BaseHttp2ServerBuilder setTrustedClientCertificateChain(final InputStream certificateInputStream) {
+    public T setTrustedClientCertificateChain(final InputStream certificateInputStream) {
         this.trustedClientCertificatePemFile = null;
         this.trustedClientCertificateInputStream = certificateInputStream;
         this.trustedClientCertificates = null;
 
-        return this;
+        return (T) this;
     }
 
     /**
@@ -201,12 +201,12 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @return a reference to this builder
      */
-    public BaseHttp2ServerBuilder setTrustedServerCertificateChain(final X509Certificate... certificates) {
+    public T setTrustedServerCertificateChain(final X509Certificate... certificates) {
         this.trustedClientCertificatePemFile = null;
         this.trustedClientCertificateInputStream = null;
         this.trustedClientCertificates = certificates;
 
-        return this;
+        return (T) this;
     }
 
     /**
@@ -220,9 +220,9 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @since 0.8
      */
-    public BaseHttp2ServerBuilder setEventLoopGroup(final EventLoopGroup eventLoopGroup) {
+    public T setEventLoopGroup(final EventLoopGroup eventLoopGroup) {
         this.eventLoopGroup = eventLoopGroup;
-        return this;
+        return (T) this;
     }
 
     /**
@@ -236,13 +236,13 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @since 0.12
      */
-    public BaseHttp2ServerBuilder setMaxConcurrentStreams(final int maxConcurrentStreams) {
+    public T setMaxConcurrentStreams(final int maxConcurrentStreams) {
         if (maxConcurrentStreams <= 0) {
             throw new IllegalArgumentException("Maximum number of concurrent streams must be positive.");
         }
 
         this.maxConcurrentStreams = maxConcurrentStreams;
-        return this;
+        return (T) this;
     }
 
     /**
@@ -254,7 +254,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
      *
      * @since 0.8
      */
-    public T build() throws SSLException {
+    public S build() throws SSLException {
         final SslContext sslContext;
         {
             final SslProvider sslProvider;
@@ -303,7 +303,7 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
             sslContext = sslContextBuilder.build();
         }
 
-        final T server = this.constructServer(sslContext);
+        final S server = this.constructServer(sslContext);
 
         if (sslContext instanceof ReferenceCounted) {
             ((ReferenceCounted) sslContext).release();
@@ -312,5 +312,5 @@ abstract class BaseHttp2ServerBuilder <T extends BaseHttp2Server> {
         return server;
     }
 
-    protected abstract T constructServer(final SslContext sslContext);
+    protected abstract S constructServer(final SslContext sslContext);
 }

--- a/pushy/src/main/java/com/turo/pushy/apns/server/BenchmarkApnsServerBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/BenchmarkApnsServerBuilder.java
@@ -22,14 +22,7 @@
 
 package com.turo.pushy.apns.server;
 
-import io.netty.channel.EventLoopGroup;
 import io.netty.handler.ssl.SslContext;
-
-import javax.net.ssl.SSLException;
-import java.io.File;
-import java.io.InputStream;
-import java.security.PrivateKey;
-import java.security.cert.X509Certificate;
 
 /**
  * <p>A {@code BenchmarkApnsServerBuilder} constructs new {@link BenchmarkApnsServer} instances. Callers must supply
@@ -43,60 +36,7 @@ import java.security.cert.X509Certificate;
  *
  * @since 0.13.0
  */
-public class BenchmarkApnsServerBuilder extends BaseHttp2ServerBuilder<BenchmarkApnsServer> {
-
-    @Override
-    public BenchmarkApnsServerBuilder setServerCredentials(final File certificatePemFile, final File privateKeyPkcs8File, final String privateKeyPassword) {
-        super.setServerCredentials(certificatePemFile, privateKeyPkcs8File, privateKeyPassword);
-        return this;
-    }
-
-    @Override
-    public BenchmarkApnsServerBuilder setServerCredentials(final InputStream certificatePemInputStream, final InputStream privateKeyPkcs8InputStream, final String privateKeyPassword) {
-        super.setServerCredentials(certificatePemInputStream, privateKeyPkcs8InputStream, privateKeyPassword);
-        return this;
-    }
-
-    @Override
-    public BenchmarkApnsServerBuilder setServerCredentials(final X509Certificate[] certificates, final PrivateKey privateKey, final String privateKeyPassword) {
-        super.setServerCredentials(certificates, privateKey, privateKeyPassword);
-        return this;
-    }
-
-    @Override
-    public BenchmarkApnsServerBuilder setTrustedClientCertificateChain(final File certificatePemFile) {
-        super.setTrustedClientCertificateChain(certificatePemFile);
-        return this;
-    }
-
-    @Override
-    public BenchmarkApnsServerBuilder setTrustedClientCertificateChain(final InputStream certificateInputStream) {
-        super.setTrustedClientCertificateChain(certificateInputStream);
-        return this;
-    }
-
-    @Override
-    public BenchmarkApnsServerBuilder setTrustedServerCertificateChain(final X509Certificate... certificates) {
-        super.setTrustedServerCertificateChain(certificates);
-        return this;
-    }
-
-    @Override
-    public BenchmarkApnsServerBuilder setEventLoopGroup(final EventLoopGroup eventLoopGroup) {
-        super.setEventLoopGroup(eventLoopGroup);
-        return this;
-    }
-
-    @Override
-    public BenchmarkApnsServerBuilder setMaxConcurrentStreams(final int maxConcurrentStreams) {
-        super.setMaxConcurrentStreams(maxConcurrentStreams);
-        return this;
-    }
-
-    @Override
-    public BenchmarkApnsServer build() throws SSLException {
-        return super.build();
-    }
+public class BenchmarkApnsServerBuilder extends BaseHttp2ServerBuilder<BenchmarkApnsServerBuilder, BenchmarkApnsServer> {
 
     @Override
     protected BenchmarkApnsServer constructServer(final SslContext sslContext) {

--- a/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/MockApnsServerBuilder.java
@@ -22,14 +22,7 @@
 
 package com.turo.pushy.apns.server;
 
-import io.netty.channel.EventLoopGroup;
 import io.netty.handler.ssl.SslContext;
-
-import javax.net.ssl.SSLException;
-import java.io.File;
-import java.io.InputStream;
-import java.security.PrivateKey;
-import java.security.cert.X509Certificate;
 
 /**
  * <p>A {@code MockApnsServerBuilder} constructs new {@link MockApnsServer} instances. Callers must supply server
@@ -44,58 +37,10 @@ import java.security.cert.X509Certificate;
  *
  * @since 0.8
  */
-public class MockApnsServerBuilder extends BaseHttp2ServerBuilder<MockApnsServer> {
+public class MockApnsServerBuilder extends BaseHttp2ServerBuilder<MockApnsServerBuilder, MockApnsServer> {
 
     private PushNotificationHandlerFactory handlerFactory;
     private MockApnsServerListener listener;
-
-    @Override
-    public MockApnsServerBuilder setServerCredentials(final File certificatePemFile, final File privateKeyPkcs8File, final String privateKeyPassword) {
-        super.setServerCredentials(certificatePemFile, privateKeyPkcs8File, privateKeyPassword);
-        return this;
-    }
-
-    @Override
-    public MockApnsServerBuilder setServerCredentials(final InputStream certificatePemInputStream, final InputStream privateKeyPkcs8InputStream, final String privateKeyPassword) {
-        super.setServerCredentials(certificatePemInputStream, privateKeyPkcs8InputStream, privateKeyPassword);
-        return this;
-    }
-
-    @Override
-    public MockApnsServerBuilder setServerCredentials(final X509Certificate[] certificates, final PrivateKey privateKey, final String privateKeyPassword) {
-        super.setServerCredentials(certificates, privateKey, privateKeyPassword);
-        return this;
-    }
-
-    @Override
-    public MockApnsServerBuilder setTrustedClientCertificateChain(final File certificatePemFile) {
-        super.setTrustedClientCertificateChain(certificatePemFile);
-        return this;
-    }
-
-    @Override
-    public MockApnsServerBuilder setTrustedClientCertificateChain(final InputStream certificateInputStream) {
-        super.setTrustedClientCertificateChain(certificateInputStream);
-        return this;
-    }
-
-    @Override
-    public MockApnsServerBuilder setTrustedServerCertificateChain(final X509Certificate... certificates) {
-        super.setTrustedServerCertificateChain(certificates);
-        return this;
-    }
-
-    @Override
-    public MockApnsServerBuilder setEventLoopGroup(final EventLoopGroup eventLoopGroup) {
-        super.setEventLoopGroup(eventLoopGroup);
-        return this;
-    }
-
-    @Override
-    public MockApnsServerBuilder setMaxConcurrentStreams(final int maxConcurrentStreams) {
-        super.setMaxConcurrentStreams(maxConcurrentStreams);
-        return this;
-    }
 
     /**
      * Sets the handler factory to be used to construct push notification handlers for the server under construction.
@@ -125,11 +70,6 @@ public class MockApnsServerBuilder extends BaseHttp2ServerBuilder<MockApnsServer
     public MockApnsServerBuilder setListener(final MockApnsServerListener listener) {
         this.listener = listener;
         return this;
-    }
-
-    @Override
-    public MockApnsServer build() throws SSLException {
-        return super.build();
     }
 
     @Override


### PR DESCRIPTION
This change modifies how we're using generics in mock server builders so we don't have to override everything in subclasses of `BaseHttp2ServerBuilder` for type safety. Now, this definitely comes with some tradeoffs (see https://stackoverflow.com/questions/38099005/how-to-return-this-in-the-generic-class for additional discussion). The main problem is that we're using an unsafe cast in `BaseHttp2ServerBuilder` (`return (T) this`), and careless subclassers could break things. That said, I think it's unlikely that folks are subclassing server builders and, if they are and do something weird that causes casting problems, _well maybe they should fix that._

I'm very open to feedback on these ideas, but I think the gains in simplicity and reduced repetition justify the costs (primarily risk of making a mistake in an improbable use case).