### PR TITLE
Stubbornly cling to frames in Javadoc after Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,5 +283,25 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>generate-javadoc-with-frames</id>
+            <activation>
+                <jdk>11</jdk>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <configuration>
+                                <additionalOptions>--frames</additionalOptions>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Even though `--no-frames` is the [default for Javadoc as of Java 11](https://bugs.openjdk.java.net/browse/JDK-8202961), I have to admit that I find the list of classes and packages to be pretty valuable. This change stubbornly clings to the past and continues to generate Javadoc with frames.

TODO:

- [x] Add version-activated Maven profiles to only add the `--frames` flag with Java 11 or newer