### PR TITLE
Clear unattached promises when channels close

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
@@ -217,9 +217,6 @@ public class ApnsClient {
                             public void operationComplete(final ChannelFuture future) throws Exception {
                                 if (future.isSuccess()) {
                                     ApnsClient.this.metricsListener.handleNotificationSent(ApnsClient.this, notificationId);
-                                } else {
-                                    ApnsClient.this.metricsListener.handleWriteFailure(ApnsClient.this, notificationId);
-                                    responsePromise.tryFailure(future.cause());
                                 }
                             }
                         });

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
@@ -175,15 +175,6 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
 
         final ChannelPromise writePromise = context.channel().newPromise();
         this.writePushNotification(context, responsePromise, writePromise);
-
-        writePromise.addListener(new GenericFutureListener<Future<Void>>() {
-            @Override
-            public void operationComplete(final Future<Void> writeFuture) {
-                if (!writeFuture.isSuccess()) {
-                    responsePromise.tryFailure(writeFuture.cause());
-                }
-            }
-        });
     }
 
     private void writePushNotification(final ChannelHandlerContext context, final PushNotificationPromise responsePromise, final ChannelPromise writePromise) {

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientMetricsListener.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientMetricsListener.java
@@ -45,7 +45,7 @@ public interface ApnsClientMetricsListener {
      * Indicates that an attempt to send a push notification failed before the notification was processed by the APNs
      * server. Write failures may be the first event in a sequence for a given notification ID (indicating that the
      * notification was never written to the wire), but may also occur after a notification was sent if the connection
-     * closed before the notification was acknowledged by the serer.
+     * closed before the notification was acknowledged by the server.
      *
      * @param apnsClient the client that sent the notification
      * @param notificationId an opaque identifier for the push notification that can be used to correlate this event


### PR DESCRIPTION
In #669, @janzar noticed that there's some danger that there's some danger that we'll store a `Promise` in the "not yet attached to an HTTP/2 channel" map in an `ApnsClientHandler`, but then never remove it. This could happen if we started buffering push notifications after hitting the concurrent stream limit, and then the connection closed before streams could be opened for those buffered notifications.

I _think_ this fixes #669 (and I'm wondering if it helps other low-probability leaks like #659/#425, but can't think of a specific mechanism by which it would be contributing to _direct_ memory leaks). I'd still like to add a test for this case, but will need to think a bit more about how to guarantee that we're getting into a streams-buffered-before-close state.

Because a lot of what's happening here is moving a large block of existing code into an `if` block, this pull request is much easier to read with [whitespace-only changes hidden](https://github.com/relayrides/pushy/pull/670/files?w=1).