### PR TITLE
Add user-supplied tags to Micrometer gauges

### DIFF
--- a/micrometer-metrics-listener/pom.xml
+++ b/micrometer-metrics-listener/pom.xml
@@ -65,6 +65,16 @@
                     </links>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/micrometer-metrics-listener/src/main/java/com/turo/pushy/apns/metrics/micrometer/MicrometerApnsClientMetricsListener.java
+++ b/micrometer-metrics-listener/src/main/java/com/turo/pushy/apns/metrics/micrometer/MicrometerApnsClientMetricsListener.java
@@ -26,6 +26,7 @@ import com.turo.pushy.apns.ApnsClient;
 import com.turo.pushy.apns.ApnsClientMetricsListener;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 
 import java.util.List;
@@ -160,7 +161,8 @@ public class MicrometerApnsClientMetricsListener implements ApnsClientMetricsLis
         this.rejectedNotifications = meterRegistry.counter(REJECTED_NOTIFICATIONS_COUNTER_NAME, tags);
 
         this.connectionFailures = meterRegistry.counter(CONNECTION_FAILURES_COUNTER_NAME, tags);
-        meterRegistry.gauge(OPEN_CONNECTIONS_GAUGE_NAME, openConnections);
+
+        meterRegistry.gauge(OPEN_CONNECTIONS_GAUGE_NAME, Tags.of(tags), openConnections);
     }
 
     /**

--- a/micrometer-metrics-listener/src/test/java/com/turo/pushy/apns/metrics/micrometer/MicrometerApnsClientMetricsListenerTest.java
+++ b/micrometer-metrics-listener/src/test/java/com/turo/pushy/apns/metrics/micrometer/MicrometerApnsClientMetricsListenerTest.java
@@ -22,14 +22,16 @@
 
 package com.turo.pushy.apns.metrics.micrometer;
 
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class MicrometerApnsClientMetricsListenerTest {
 
@@ -40,6 +42,25 @@ public class MicrometerApnsClientMetricsListenerTest {
     public void setUp() {
         this.meterRegistry = new SimpleMeterRegistry();
         this.listener = new MicrometerApnsClientMetricsListener(this.meterRegistry);
+    }
+
+    @Test
+    public void testMicrometerApnsClientMetricsListenerNoTags() {
+        for (final Meter meter : this.meterRegistry.getMeters()) {
+            assertTrue(meter.getId().getTags().isEmpty());
+        }
+    }
+
+    @Test
+    public void testMicrometerApnsClientMetricsListenerTags() {
+        final MeterRegistry taggedMeterRegistry = new SimpleMeterRegistry();
+        new MicrometerApnsClientMetricsListener(taggedMeterRegistry, "key", "value");
+
+        final List<Tag> expectedTags = Collections.singletonList(Tag.of("key", "value"));
+
+        for (final Meter meter : taggedMeterRegistry.getMeters()) {
+            assertEquals(expectedTags, meter.getId().getTags());
+        }
     }
 
     @Test


### PR DESCRIPTION
This fixes #668, a bug where we weren't applying user-provided tags to the "open connections" gauge in the Micrometer metrics listener.