### PR TITLE
Represent the `critical` flag in payloads as a number

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/util/ApnsPayloadBuilder.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/util/ApnsPayloadBuilder.java
@@ -112,12 +112,12 @@ public class ApnsPayloadBuilder {
 
     private static class SoundForCriticalAlert {
         private final String name;
-        private final boolean critical;
+        private final int critical;
         private final double volume;
 
         private SoundForCriticalAlert(final String name, final boolean critical, final double volume) {
             this.name = name;
-            this.critical = critical;
+            this.critical = critical ? 1 : 0;
             this.volume = volume;
         }
     }

--- a/pushy/src/test/java/com/turo/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -25,8 +25,11 @@ package com.turo.pushy.apns.util;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.lang.reflect.Type;
 import java.nio.charset.CharsetEncoder;
@@ -37,6 +40,7 @@ import java.util.Map;
 
 import static org.junit.Assert.*;
 
+@RunWith(JUnitParamsRunner.class)
 public class ApnsPayloadBuilderTest {
 
     private ApnsPayloadBuilder builder;
@@ -368,9 +372,9 @@ public class ApnsPayloadBuilderTest {
     }
 
     @Test
-    public void testSetSoundForCriticalAlert() {
+    @Parameters({"true, 1", "false, 0"})
+    public void testSetSoundForCriticalAlert(final boolean isCriticalAlert, final int expectedCriticalValue) {
         final String soundFileName = "dying-giraffe.aiff";
-        final boolean isCriticalAlert = true;
         final double soundVolume = 0.781;
 
         this.builder.setSound(soundFileName, isCriticalAlert, soundVolume);
@@ -381,7 +385,7 @@ public class ApnsPayloadBuilderTest {
         final Map<String, Object> soundDictionary = (Map<String, Object>) aps.get("sound");
 
         assertEquals(soundFileName, soundDictionary.get("name"));
-        assertEquals(isCriticalAlert, soundDictionary.get("critical"));
+        assertEquals(expectedCriticalValue, soundDictionary.get("critical"));
         assertEquals(soundVolume, soundDictionary.get("volume"));
     }
 

--- a/pushy/src/test/java/com/turo/pushy/apns/util/ApnsPayloadBuilderTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/util/ApnsPayloadBuilderTest.java
@@ -385,7 +385,7 @@ public class ApnsPayloadBuilderTest {
         final Map<String, Object> soundDictionary = (Map<String, Object>) aps.get("sound");
 
         assertEquals(soundFileName, soundDictionary.get("name"));
-        assertEquals(expectedCriticalValue, soundDictionary.get("critical"));
+        assertEquals(expectedCriticalValue, ((Number) soundDictionary.get("critical")).intValue());
         assertEquals(soundVolume, soundDictionary.get("volume"));
     }
 


### PR DESCRIPTION
This fixes #686 by representing the `critical` field of a `sound` dictionary in a push notification payload as a number instead of a boolean value.