### PR TITLE
Implement factory methods to return HttpProxyHandlerFactory instances or not based on system default proxies

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/proxy/ProxyLocator.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/proxy/ProxyLocator.java
@@ -1,0 +1,42 @@
+package com.turo.pushy.apns.proxy;
+
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper class to look for proxy configurations.
+ *
+ * @see <a href="https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html#Proxies">The Java documentation on proxies.</a>
+ * @since 0.14
+ */
+class ProxyLocator {
+
+    private static final Logger log = LoggerFactory.getLogger(ProxyLocator.class);
+
+    /**
+     * Searches for any system-wide {@link Proxy} of a given {@link Proxy.Type} for a given {@link URI}.
+     *
+     * @param uri the URI to find any system proxy for.
+     * @param proxyType the types of proxy to find for the URI.
+     * @return any appropriate {@link Proxy} instance, or <code>null</code> if there were none.
+     * @since 0.14
+     */
+    static Proxy getProxyForUri(final URI uri, final Proxy.Type proxyType) {
+        ProxySelector defaultProxySelector = ProxySelector.getDefault();
+        List<Proxy> proxiesForUri = defaultProxySelector.select(uri);
+        log.debug("Proxies for URI \"{}\" were {}", uri, proxiesForUri);
+
+        for (java.net.Proxy proxy : proxiesForUri) {
+            if (proxy.type() == proxyType) {
+                return proxy;
+            }
+        }
+
+        return null;
+    }
+}

--- a/pushy/src/test/java/com/turo/pushy/apns/proxy/HttpProxyHandlerFactoryTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/proxy/HttpProxyHandlerFactoryTest.java
@@ -1,0 +1,150 @@
+package com.turo.pushy.apns.proxy;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.turo.pushy.apns.ApnsClientBuilder;
+
+public class HttpProxyHandlerFactoryTest {
+
+    private static class FixedProxiesSelector extends ProxySelector {
+
+        private final List<Proxy> availableProxies;
+
+        public FixedProxiesSelector(final Proxy... availableProxies) {
+            this.availableProxies = Arrays.asList(availableProxies);
+        }
+
+        @Override
+        public List<Proxy> select(URI uri) {
+            return availableProxies;
+        }
+
+        @Override
+        public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+            // Not needed for this test.
+        }
+    }
+
+    private static class SingleHostHttpProxySelector extends ProxySelector {
+
+        private final String proxiedHost;
+
+        public SingleHostHttpProxySelector(final String proxiedHost) {
+            this.proxiedHost = proxiedHost;
+        }
+
+        @Override
+        public List<Proxy> select(URI uri) {
+            Proxy proxy;
+
+            if (uri.getHost().equals(proxiedHost)) {
+                proxy = DUMMY_HTTP_PROXY;
+            } else {
+                proxy = Proxy.NO_PROXY;
+            }
+
+            return Arrays.asList(proxy);
+        }
+
+        @Override
+        public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {
+            // Not needed for this test.
+        }
+    }
+
+    private static final Proxy DUMMY_HTTP_PROXY = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("httpproxy", 123));
+    private static final Proxy DUMMY_SOCKS_PROXY = new Proxy(Proxy.Type.SOCKS, new InetSocketAddress("socksproxy", 456));
+
+    private static ProxySelector defaultProxySelector;
+
+    @BeforeClass
+    public static void setUpClass() {
+        defaultProxySelector = ProxySelector.getDefault();
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        ProxySelector.setDefault(defaultProxySelector);
+    }
+
+    @Test
+    public void testNoProxy()
+            throws URISyntaxException {
+
+        ProxySelector.setDefault(new FixedProxiesSelector(Proxy.NO_PROXY));
+
+        assertNull(HttpProxyHandlerFactory.fromSystemProxies());
+        assertNull(HttpProxyHandlerFactory.fromSystemProxies(ApnsClientBuilder.PRODUCTION_APNS_HOST));
+        assertNull(HttpProxyHandlerFactory.fromSystemProxies(ApnsClientBuilder.DEVELOPMENT_APNS_HOST));
+    }
+
+    @Test
+    public void testHasHttpProxy()
+            throws URISyntaxException {
+
+        ProxySelector.setDefault(new FixedProxiesSelector(DUMMY_HTTP_PROXY));
+
+        assertNotNull(HttpProxyHandlerFactory.fromSystemProxies());
+        assertNotNull(HttpProxyHandlerFactory.fromSystemProxies(ApnsClientBuilder.PRODUCTION_APNS_HOST));
+        assertNotNull(HttpProxyHandlerFactory.fromSystemProxies(ApnsClientBuilder.DEVELOPMENT_APNS_HOST));
+    }
+
+    @Test
+    public void testHasSocksProxy()
+            throws URISyntaxException {
+
+        ProxySelector.setDefault(new FixedProxiesSelector(DUMMY_SOCKS_PROXY));
+
+        assertNull(HttpProxyHandlerFactory.fromSystemProxies());
+        assertNull(HttpProxyHandlerFactory.fromSystemProxies(ApnsClientBuilder.PRODUCTION_APNS_HOST));
+        assertNull(HttpProxyHandlerFactory.fromSystemProxies(ApnsClientBuilder.DEVELOPMENT_APNS_HOST));
+    }
+
+    @Test
+    public void testHasSocksAndHttpProxies()
+            throws URISyntaxException {
+
+        ProxySelector.setDefault(new FixedProxiesSelector(DUMMY_HTTP_PROXY, DUMMY_SOCKS_PROXY));
+
+        assertNotNull(HttpProxyHandlerFactory.fromSystemProxies());
+        assertNotNull(HttpProxyHandlerFactory.fromSystemProxies(ApnsClientBuilder.PRODUCTION_APNS_HOST));
+        assertNotNull(HttpProxyHandlerFactory.fromSystemProxies(ApnsClientBuilder.DEVELOPMENT_APNS_HOST));
+    }
+
+    @Test
+    public void testHasHttpProxyForApnsProductionOnly()
+            throws URISyntaxException {
+
+        ProxySelector.setDefault(new SingleHostHttpProxySelector(ApnsClientBuilder.PRODUCTION_APNS_HOST));
+
+        assertNotNull(HttpProxyHandlerFactory.fromSystemProxies());
+        assertNotNull(HttpProxyHandlerFactory.fromSystemProxies(ApnsClientBuilder.PRODUCTION_APNS_HOST));
+        assertNull(HttpProxyHandlerFactory.fromSystemProxies(ApnsClientBuilder.DEVELOPMENT_APNS_HOST));
+    }
+
+    @Test
+    public void testHasHttpProxyForApnsDevelopmentOnly()
+            throws URISyntaxException {
+
+        ProxySelector.setDefault(new SingleHostHttpProxySelector(ApnsClientBuilder.DEVELOPMENT_APNS_HOST));
+
+        assertNull(HttpProxyHandlerFactory.fromSystemProxies());
+        assertNull(HttpProxyHandlerFactory.fromSystemProxies(ApnsClientBuilder.PRODUCTION_APNS_HOST));
+        assertNotNull(HttpProxyHandlerFactory.fromSystemProxies(ApnsClientBuilder.DEVELOPMENT_APNS_HOST));
+    }
+}


### PR DESCRIPTION
The code has been structured to allow doing the same for SOCKS proxies in the same way, hence the new package-protected helper class.