### PR TITLE
Add support for the `apns-push-type` header

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
@@ -70,6 +70,7 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
     private static final AsciiString APNS_PRIORITY_HEADER = new AsciiString("apns-priority");
     private static final AsciiString APNS_COLLAPSE_ID_HEADER = new AsciiString("apns-collapse-id");
     private static final AsciiString APNS_ID_HEADER = new AsciiString("apns-id");
+    private static final AsciiString APNS_PUSH_TYPE_HEADER = new AsciiString("apns-push-type");
 
     private static final int INITIAL_PAYLOAD_BUFFER_CAPACITY = 4096;
 
@@ -242,6 +243,10 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
 
         if (pushNotification.getPriority() != null) {
             headers.addInt(APNS_PRIORITY_HEADER, pushNotification.getPriority().getCode());
+        }
+
+        if (pushNotification.getPushType() != null) {
+            headers.add(APNS_PUSH_TYPE_HEADER, pushNotification.getPushType().getHeaderValue());
         }
 
         if (pushNotification.getTopic() != null) {

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsPushNotification.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsPushNotification.java
@@ -86,6 +86,17 @@ public interface ApnsPushNotification {
     DeliveryPriority getPriority();
 
     /**
+     * Returns the display type this push notification. Note that push notification display types are required in iOS 13
+     * and later and watchOS 6 and later, but are ignored under earlier versions of either operating system. May be
+     * {@code null}.
+     *
+     * @return the display type this push notification
+     *
+     * @since 0.13.9
+     */
+    PushType getPushType();
+
+    /**
      * Returns the topic to which this notification should be sent. This is generally the bundle ID of the receiving
      * app. Topics must not be {@code null}.
      *

--- a/pushy/src/main/java/com/turo/pushy/apns/PushType.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/PushType.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2013-2019 Turo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.turo.pushy.apns;
+
+/**
+ * An enumeration of push notification display types. Note that push notification display types are required in iOS 13
+ * and later and watchOS 6 and later, but are ignored under earlier versions of either operating system.
+ *
+ * @see <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns">Sending
+ * Notification Requests to APNs</a>
+ *
+ * @since 0.13.9
+ */
+public enum PushType {
+
+    /**
+     * Indicates that a push notification is expected to display an alert, play a sound, or badges the receiving apps'
+     * icon.
+     */
+    ALERT("alert"),
+
+    /**
+     * Indicates that a push notification is not expected to interact with the user on the receiving device.
+     */
+    BACKGROUND("background");
+
+    private final String headerValue;
+
+    PushType(final String headerValue) {
+        this.headerValue = headerValue;
+    }
+
+    public String getHeaderValue() {
+        return this.headerValue;
+    }
+
+    public static PushType getFromHeaderValue(final CharSequence headerValue) {
+        for (final PushType pushType : PushType.values()) {
+            if (pushType.headerValue.contentEquals(headerValue)) {
+                return pushType;
+            }
+        }
+
+        throw new IllegalArgumentException("No push type found for header value: " + headerValue);
+    }
+}

--- a/pushy/src/main/java/com/turo/pushy/apns/server/RejectionReason.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/RejectionReason.java
@@ -38,6 +38,7 @@ public enum RejectionReason {
     DEVICE_TOKEN_NOT_FOR_TOPIC("DeviceTokenNotForTopic", HttpResponseStatus.BAD_REQUEST),
     DUPLICATE_HEADERS("DuplicateHeaders", HttpResponseStatus.BAD_REQUEST),
     IDLE_TIMEOUT("IdleTimeout", HttpResponseStatus.BAD_REQUEST),
+    INVALID_PUSH_TYPE("InvalidPushType", HttpResponseStatus.BAD_REQUEST),
     MISSING_DEVICE_TOKEN("MissingDeviceToken", HttpResponseStatus.BAD_REQUEST),
     MISSING_TOPIC("MissingTopic", HttpResponseStatus.BAD_REQUEST),
     PAYLOAD_EMPTY("PayloadEmpty", HttpResponseStatus.BAD_REQUEST),

--- a/pushy/src/main/java/com/turo/pushy/apns/server/ValidatingPushNotificationHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/ValidatingPushNotificationHandler.java
@@ -24,6 +24,7 @@ package com.turo.pushy.apns.server;
 
 import com.eatthepath.uuid.FastUUID;
 import com.turo.pushy.apns.DeliveryPriority;
+import com.turo.pushy.apns.PushType;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http2.Http2Headers;
@@ -46,6 +47,7 @@ abstract class ValidatingPushNotificationHandler implements PushNotificationHand
     private static final AsciiString APNS_PRIORITY_HEADER = new AsciiString("apns-priority");
     private static final AsciiString APNS_ID_HEADER = new AsciiString("apns-id");
     private static final AsciiString APNS_COLLAPSE_ID_HEADER = new AsciiString("apns-collapse-id");
+    private static final AsciiString APNS_PUSH_TYPE_HEADER = new AsciiString("apns-push-type");
 
     private static final Pattern DEVICE_TOKEN_PATTERN = Pattern.compile("[0-9a-fA-F]{64}");
 
@@ -101,6 +103,18 @@ abstract class ValidatingPushNotificationHandler implements PushNotificationHand
                     DeliveryPriority.getFromCode(priorityCode);
                 } catch (final IllegalArgumentException e) {
                     throw new RejectedNotificationException(RejectionReason.BAD_PRIORITY);
+                }
+            }
+        }
+
+        {
+            final CharSequence pushTypeSequence = headers.get(APNS_PUSH_TYPE_HEADER);
+
+            if (pushTypeSequence != null) {
+                try {
+                    PushType.getFromHeaderValue(pushTypeSequence);
+                } catch (final IllegalArgumentException e) {
+                    throw new RejectedNotificationException(RejectionReason.INVALID_PUSH_TYPE);
                 }
             }
         }

--- a/pushy/src/test/java/com/turo/pushy/apns/server/MockApnsServerTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/server/MockApnsServerTest.java
@@ -329,7 +329,7 @@ public class MockApnsServerTest extends AbstractClientServerTest {
                 final UUID apnsId = UUID.randomUUID();
 
                 final SimpleApnsPushNotification pushNotificationWithApnsId =
-                        new SimpleApnsPushNotification(DEVICE_TOKEN, TOPIC, PAYLOAD, null, DeliveryPriority.IMMEDIATE, null, apnsId);
+                        new SimpleApnsPushNotification(DEVICE_TOKEN, TOPIC, PAYLOAD, null, DeliveryPriority.IMMEDIATE, PushType.ALERT, null, apnsId);
 
                 final PushNotificationResponse<SimpleApnsPushNotification> response =
                         client.sendNotification(pushNotificationWithApnsId).get();
@@ -379,7 +379,7 @@ public class MockApnsServerTest extends AbstractClientServerTest {
                 final UUID apnsId = UUID.randomUUID();
 
                 final SimpleApnsPushNotification pushNotificationWithApnsId =
-                        new SimpleApnsPushNotification(DEVICE_TOKEN, TOPIC, PAYLOAD, null, DeliveryPriority.IMMEDIATE, null, apnsId);
+                        new SimpleApnsPushNotification(DEVICE_TOKEN, TOPIC, PAYLOAD, null, DeliveryPriority.IMMEDIATE, PushType.ALERT, null, apnsId);
 
                 final PushNotificationResponse<SimpleApnsPushNotification> response =
                         client.sendNotification(pushNotificationWithApnsId).get();

--- a/pushy/src/test/java/com/turo/pushy/apns/util/SimpleApnsPushNotificationTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/util/SimpleApnsPushNotificationTest.java
@@ -23,7 +23,7 @@
 package com.turo.pushy.apns.util;
 
 import com.turo.pushy.apns.DeliveryPriority;
-import org.junit.Assert;
+import com.turo.pushy.apns.PushType;
 import org.junit.Test;
 
 import java.util.Date;
@@ -48,7 +48,8 @@ public class SimpleApnsPushNotificationTest {
         assertEquals(topic, pushNotification.getTopic());
         assertEquals(payload, pushNotification.getPayload());
         assertTrue(pushNotification.getExpiration().after(now));
-        Assert.assertEquals(DeliveryPriority.IMMEDIATE, pushNotification.getPriority());
+        assertEquals(DeliveryPriority.IMMEDIATE, pushNotification.getPriority());
+        assertNull(pushNotification.getPushType());
         assertNull(pushNotification.getCollapseId());
     }
 
@@ -82,6 +83,7 @@ public class SimpleApnsPushNotificationTest {
         assertEquals(payload, pushNotification.getPayload());
         assertEquals(expiration, pushNotification.getExpiration());
         assertEquals(DeliveryPriority.IMMEDIATE, pushNotification.getPriority());
+        assertNull(pushNotification.getPushType());
         assertNull(pushNotification.getCollapseId());
         assertNull(pushNotification.getApnsId());
     }
@@ -102,6 +104,29 @@ public class SimpleApnsPushNotificationTest {
         assertEquals(payload, pushNotification.getPayload());
         assertEquals(expiration, pushNotification.getExpiration());
         assertEquals(priority, pushNotification.getPriority());
+        assertNull(pushNotification.getPushType());
+        assertNull(pushNotification.getCollapseId());
+        assertNull(pushNotification.getApnsId());
+    }
+
+    @Test
+    public void testSimpleApnsPushNotificationTokenTopicPayloadExpirationPriorityType() {
+        final String token = "test-token";
+        final String topic = "test-topic";
+        final String payload = "{\"test\": true}";
+        final Date expiration = new Date();
+        final DeliveryPriority priority = DeliveryPriority.CONSERVE_POWER;
+        final PushType pushType = PushType.BACKGROUND;
+
+        final SimpleApnsPushNotification pushNotification =
+                new SimpleApnsPushNotification(token, topic, payload, expiration, priority, pushType);
+
+        assertEquals(token, pushNotification.getToken());
+        assertEquals(topic, pushNotification.getTopic());
+        assertEquals(payload, pushNotification.getPayload());
+        assertEquals(expiration, pushNotification.getExpiration());
+        assertEquals(priority, pushNotification.getPriority());
+        assertEquals(pushType, pushNotification.getPushType());
         assertNull(pushNotification.getCollapseId());
         assertNull(pushNotification.getApnsId());
     }
@@ -123,28 +148,54 @@ public class SimpleApnsPushNotificationTest {
         assertEquals(payload, pushNotification.getPayload());
         assertEquals(expiration, pushNotification.getExpiration());
         assertEquals(priority, pushNotification.getPriority());
+        assertNull(pushNotification.getPushType());
         assertEquals(collapseId, pushNotification.getCollapseId());
         assertNull(pushNotification.getApnsId());
     }
 
     @Test
-    public void testSimpleApnsPushNotificationTokenTopicPayloadExpirationPriorityCollapseIdApnsId() {
+    public void testSimpleApnsPushNotificationTokenTopicPayloadExpirationPriorityTypeCollapseId() {
         final String token = "test-token";
         final String topic = "test-topic";
         final String payload = "{\"test\": true}";
         final Date expiration = new Date();
         final DeliveryPriority priority = DeliveryPriority.CONSERVE_POWER;
+        final PushType pushType = PushType.BACKGROUND;
         final String collapseId = "test-collapse-id";
-        final UUID apnsId = UUID.randomUUID();
 
         final SimpleApnsPushNotification pushNotification =
-                new SimpleApnsPushNotification(token, topic, payload, expiration, priority, collapseId, apnsId);
+                new SimpleApnsPushNotification(token, topic, payload, expiration, priority, pushType, collapseId);
 
         assertEquals(token, pushNotification.getToken());
         assertEquals(topic, pushNotification.getTopic());
         assertEquals(payload, pushNotification.getPayload());
         assertEquals(expiration, pushNotification.getExpiration());
         assertEquals(priority, pushNotification.getPriority());
+        assertEquals(pushType, pushNotification.getPushType());
+        assertEquals(collapseId, pushNotification.getCollapseId());
+        assertNull(pushNotification.getApnsId());
+    }
+
+    @Test
+    public void testSimpleApnsPushNotificationTokenTopicPayloadExpirationPriorityTypeCollapseIdApnsId() {
+        final String token = "test-token";
+        final String topic = "test-topic";
+        final String payload = "{\"test\": true}";
+        final Date expiration = new Date();
+        final DeliveryPriority priority = DeliveryPriority.CONSERVE_POWER;
+        final PushType pushType = PushType.BACKGROUND;
+        final String collapseId = "test-collapse-id";
+        final UUID apnsId = UUID.randomUUID();
+
+        final SimpleApnsPushNotification pushNotification =
+                new SimpleApnsPushNotification(token, topic, payload, expiration, priority, pushType, collapseId, apnsId);
+
+        assertEquals(token, pushNotification.getToken());
+        assertEquals(topic, pushNotification.getTopic());
+        assertEquals(payload, pushNotification.getPayload());
+        assertEquals(expiration, pushNotification.getExpiration());
+        assertEquals(priority, pushNotification.getPriority());
+        assertEquals(pushType, pushNotification.getPushType());
         assertEquals(collapseId, pushNotification.getCollapseId());
         assertEquals(apnsId, pushNotification.getApnsId());
     }


### PR DESCRIPTION
This is a first pass at adding support for the `apns-push-type` header introduced in iOS 13/watchOS 6. There are a couple points of tension I'm trying to resolve (or accept):

1. `SimpleApnsPushNotification` now has a _lot_ of constructors. Doing everything in constructors made sense early on when there were only a couple optional fields, but the constructor count will grow exponentially as the APNs API adds more and more fields over time. In a future, larger release (where there's more expectation of API breakage), it might make sense to move to a builder pattern.
2. I'm not sure that I like making `pushType` be possibly-`null`. As a header, it falls into a grey zone of "required for successful operation sometimes, but ignored at other times." Making it nullable means minimal disruption and surprise for existing use cases. Making it required reduces surprise for new use cases.

I'm also wondering about the interplay of delivery priority and `apns-push-type`. Are all combinations of priorities and push types legal? Can you have a "conserve power" priority for an "alert" push type, for example?

I'm very open to feedback on all of this.

If merged, this closes #701.

----

TODO:

- [x] Un-hose existing tests.
- [x] Add more robust tests to make sure the `apns-push-type` header is actually being sent as expected.