### PR TITLE
Update to Netty 4.1.37

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you use [Maven](http://maven.apache.org/), you can add Pushy to your project 
 
 If you don't use Maven (or something else that understands Maven dependencies, like Gradle), you can [download Pushy as a `.jar` file](https://github.com/relayrides/pushy/releases/download/pushy-0.13.8/pushy-0.13.8.jar) and add it to your project directly. You'll also need to make sure you have Pushy's runtime dependencies on your classpath. They are:
 
-- [netty 4.1.32](http://netty.io/)
+- [netty 4.1.37](http://netty.io/)
 - [gson 2.6](https://github.com/google/gson)
 - [slf4j 1.7](http://www.slf4j.org/) (and possibly an SLF4J binding, as described in the [logging](#logging) section below)
 - [fast-uuid 0.1](https://github.com/jchambers/fast-uuid)

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     </dependencyManagement>
 
     <properties>
-        <netty.version>4.1.32.Final</netty.version>
+        <netty.version>4.1.37.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
As advertised, this updates to the latest version of Netty. Importantly, this contains a fix for https://github.com/netty/netty/issues/9212, which in turn fixes #675. ~The update to netty-tcnative also closes #699~ (EDIT: I merged that fix separately).