### PR TITLE
added VoIP PushType for VoIP push notifications

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/PushType.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/PushType.java
@@ -42,7 +42,12 @@ public enum PushType {
     /**
      * Indicates that a push notification is not expected to interact with the user on the receiving device.
      */
-    BACKGROUND("background");
+    BACKGROUND("background"),
+
+    /**
+     * Indicates that a push notification is expected to activate the client for handling VoIP flow.
+     */
+    VOIP("voip");
 
     private final String headerValue;
 


### PR DESCRIPTION
On iOS 13, VoIP pushes are getting rejected by APNs servers with the reason `InvalidPushType`.  AS mentioned [here](https://forums.developer.apple.com/thread/121083), we require to send `"apns-push-type" : "voip"` for VoIP pushes. But, it's not documented in the [official docs](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns#2947610).

I've tested it locally by sending a push to my device on iOS 13 and found the case to be true. Hence, added `voip` in `PushType` so that we can start using it for `VoIP` pushes for iOS>=13.

This closes #719.