### PR TITLE
Only use OpenJDK when testing with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,14 @@ language: java
 matrix:
     include:
         - os: linux
-          jdk: oraclejdk8
+          jdk: openjdk8
           env: PUSHY_SSL_PROVIDER=jdk
 
         - os: linux
-          jdk: oraclejdk8
+          jdk: openjdk8
 
         - os: linux
+          dist: trusty
           jdk: openjdk7
           install: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -pl '!micrometer-metrics-listener'
           script: mvn test -B -pl '!micrometer-metrics-listener'


### PR DESCRIPTION
Looks like things have changed upstream with Travis (again) and we need to adjust our build matrix to compensate.