### PR TITLE
Add new `apns-push-type` values and documentation

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/PushType.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/PushType.java
@@ -34,20 +34,86 @@ package com.turo.pushy.apns;
 public enum PushType {
 
     /**
-     * Indicates that a push notification is expected to display an alert, play a sound, or badges the receiving apps'
-     * icon.
+     * <p>Indicates that a push notification is expected to display an alert, play a sound, or badges the receiving
+     * apps' icon. According to Apple's documentation:</p>
+     *
+     * <blockquote>Use the {@code alert} push type for notifications that trigger a user interaction—for example, an
+     * alert, badge, or sound. If you set this push type, the {@code apns-topic} header field must use your app’s bundle
+     * ID as the topic… The {@code alert} push type is required on watchOS 6 and later. It is recommended on macOS, iOS,
+     * tvOS, and iPadOS.</blockquote>
+     *
+     * @since 0.13.9
      */
     ALERT("alert"),
 
     /**
-     * Indicates that a push notification is not expected to interact with the user on the receiving device.
+     * <p>Indicates that a push notification is not expected to interact with the user on the receiving device.
+     * According to Apple's documentation:</p>
+     *
+     * <blockquote>Use the background push type for notifications that deliver content in the background, and don’t
+     * trigger any user interactions. If you set this push type, the apns-topic header field must use your app’s bundle
+     * ID as the topic. The background push type is required on watchOS 6 and later. It is recommended on macOS, iOS,
+     * tvOS, and iPadOS.</blockquote>
+     *
+     * @since 0.13.9
      */
     BACKGROUND("background"),
 
     /**
-     * Indicates that a push notification is expected to activate the client for handling VoIP flow.
+     * <p>Indicates that a push notification is expected to activate the client for handling VoIP flow. According to
+     * Apple's documentation:</p>
+     *
+     * <blockquote>Use the {@code voip} push type for notifications that provide information about an incoming
+     * Voice-over-IP (VoIP) call… If you set this push type, the {@code apns-topic} header field must use your app’s
+     * bundle ID with {@code .voip} appended to the end. If you’re using certificate-based authentication, you must also
+     * register the certificate for VoIP services. The topic is then part of the 1.2.840.113635.100.6.3.4 or
+     * 1.2.840.113635.100.6.3.6 extension. The {@code voip} push type is not available on watchOS. It is recommended on
+     * macOS, iOS, tvOS, and iPadOS.</blockquote>
+     *
+     * @since 0.13.10
      */
-    VOIP("voip");
+    VOIP("voip"),
+
+    /**
+     * <p>Indicates that a push notification is intended to provide an update for a watchOS app complication. According
+     * to Apple's documentation:</p>
+     *
+     * <blockquote>Use the {@code complication} push type for notifications that contain update information for a
+     * watchOS app’s complications… If you set this push type, the {@code apns-topic} header field must use your app’s
+     * bundle ID with {@code .complication} appended to the end. If you’re using certificate-based authentication, you
+     * must also register the certificate for WatchKit services. The topic is then part of the 1.2.840.113635.100.6.3.6
+     * extension. The {@code complication} push type is recommended for watchOS and iOS. It is not available on macOS,
+     * tvOS, and iPadOS.</blockquote>
+     *
+     * @since 0.13.10
+     */
+    COMPLICATION("complication"),
+
+    /**
+     * <p>Indicates that a push notification is intended to update a File Provider extension. According to Apple's
+     * documentation:</p>
+     *
+     * <blockquote>Use the {@code fileprovider} push type to signal changes to a File Provider extension. If you set
+     * this push type, the apns-topic header field must use your app’s bundle ID with {@code .pushkit.fileprovider}
+     * appended to the end… The fileprovider push type is not available on watchOS. It is recommended on macOS, iOS,
+     * tvOS, and iPadOS.</blockquote>
+     *
+     * @since 0.13.10
+     */
+    FILEPROVIDER("fileprovider"),
+
+    /**
+     * <p>Indicates that a push notification is intended to cause the receiving device to contact its mobile device
+     * management (MDM) server. According to Apple's documentation:</p>
+     *
+     * <blockquote>Use the {@code mdm} push type for notifications that tell managed devices to contact the MDM server.
+     * If you set this push type, you must use the topic from the UID attribute in the subject of your MDM push
+     * certificate… The mdm push type is not available on watchOS. It is recommended on macOS, iOS, tvOS, and
+     * iPadOS.</blockquote>
+     *
+     * @since 0.13.10
+     */
+    MDM("mdm");
 
     private final String headerValue;
 

--- a/pushy/src/test/java/com/turo/pushy/apns/ApnsClientTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/ApnsClientTest.java
@@ -726,7 +726,11 @@ public class ApnsClientTest extends AbstractClientServerTest {
         return new Object[] {
                 null,
                 PushType.BACKGROUND,
-                PushType.ALERT
+                PushType.ALERT,
+                PushType.VOIP,
+                PushType.COMPLICATION,
+                PushType.FILEPROVIDER,
+                PushType.MDM
         };
     }
 }


### PR DESCRIPTION
As a follow-up to #720 (which covered #719), this pull request adds all known values for the `apns-push-type` header to the `PushType` enumeration.