### PR TITLE
Update Netty to 4.1.45

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you use [Maven](http://maven.apache.org/), you can add Pushy to your project 
 
 If you don't use Maven (or something else that understands Maven dependencies, like Gradle), you can [download Pushy as a `.jar` file](https://github.com/relayrides/pushy/releases/download/pushy-0.13.10/pushy-0.13.10.jar) and add it to your project directly. You'll also need to make sure you have Pushy's runtime dependencies on your classpath. They are:
 
-- [netty 4.1.37](http://netty.io/)
+- [netty 4.1.45](http://netty.io/)
 - [gson 2.6](https://github.com/google/gson)
 - [slf4j 1.7](http://www.slf4j.org/) (and possibly an SLF4J binding, as described in the [logging](#logging) section below)
 - [fast-uuid 0.1](https://github.com/jchambers/fast-uuid)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you don't use Maven (or something else that understands Maven dependencies, l
 - [slf4j 1.7](http://www.slf4j.org/) (and possibly an SLF4J binding, as described in the [logging](#logging) section below)
 - [fast-uuid 0.1](https://github.com/jchambers/fast-uuid)
 
-Pushy itself requires Java 7 or newer to build and run. Under Java 7, Pushy has an additional dependency (included automatically by dependency management systems) on [netty-native 2.0.25.Final](http://netty.io/wiki/forked-tomcat-native.html), a native SSL provider that (among other benefits) includes ciphers required by APNs that are not included with Java 7 by default.
+Pushy itself requires Java 7 or newer to build and run. Under Java 7, Pushy has an additional dependency (included automatically by dependency management systems) on [netty-native 2.0.26.Final](http://netty.io/wiki/forked-tomcat-native.html), a native SSL provider that (among other benefits) includes ciphers required by APNs that are not included with Java 7 by default.
 
 Under Java 8 and newer, Pushy does not require a native SSL provider, but users may choose to use it regardless for enhanced performance. To use a native provider, make sure netty-tcnative is on your classpath. Maven users may add a dependency to their project as follows:
 
@@ -38,7 +38,7 @@ Under Java 8 and newer, Pushy does not require a native SSL provider, but users 
 <dependency>
     <groupId>io.netty</groupId>
     <artifactId>netty-tcnative-boringssl-static</artifactId>
-    <version>2.0.25.Final</version>
+    <version>2.0.26.Final</version>
     <scope>runtime</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>2.0.25.Final</version>
+                <version>2.0.28.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.eatthepath</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     </dependencyManagement>
 
     <properties>
-        <netty.version>4.1.37.Final</netty.version>
+        <netty.version>4.1.45.Final</netty.version>
         <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>2.0.28.Final</version>
+                <version>2.0.26.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.eatthepath</groupId>


### PR DESCRIPTION
Hi,

This is a quick PR to update Netty to the latest upstream version. Netty is affected by [CVE-2019-20444](https://nvd.nist.gov/vuln/detail/CVE-2019-20444) and [CVE-2019-20445](https://nvd.nist.gov/vuln/detail/CVE-2019-20445). Although these are of course bigger concerns when Netty is used for server purposes, these CVEs also affect Netty when using it as an HTTP client.

I mostly want to reduce the noise users get from any vulnerability scanners they have running for future versions of Pushy :)