### PR TITLE
Drop support for OIO

### DIFF
--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -106,7 +106,6 @@
                         <Import-Package>
                             <!-- Classes from the following packages are only loaded using Class.forName(), so BND can not detect they are required imports. -->
                             io.netty.channel.socket.nio,
-                            io.netty.channel.socket.oio,
                             <!-- This tells BND to add all other required imports that it does detect, as normal. -->
                             *,
                         </Import-Package>

--- a/pushy/src/main/java/com/turo/pushy/apns/ClientChannelClassUtil.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ClientChannelClassUtil.java
@@ -37,12 +37,10 @@ class ClientChannelClassUtil {
 
     static {
         SOCKET_CHANNEL_CLASSES.put("io.netty.channel.nio.NioEventLoopGroup", "io.netty.channel.socket.nio.NioSocketChannel");
-        SOCKET_CHANNEL_CLASSES.put("io.netty.channel.oio.OioEventLoopGroup", "io.netty.channel.socket.oio.OioSocketChannel");
         SOCKET_CHANNEL_CLASSES.put("io.netty.channel.epoll.EpollEventLoopGroup", "io.netty.channel.epoll.EpollSocketChannel");
         SOCKET_CHANNEL_CLASSES.put("io.netty.channel.kqueue.KQueueEventLoopGroup", "io.netty.channel.kqueue.KQueueSocketChannel");
 
         DATAGRAM_CHANNEL_CLASSES.put("io.netty.channel.nio.NioEventLoopGroup", "io.netty.channel.socket.nio.NioDatagramChannel");
-        DATAGRAM_CHANNEL_CLASSES.put("io.netty.channel.oio.OioEventLoopGroup", "io.netty.channel.socket.oio.OioDatagramChannel");
         DATAGRAM_CHANNEL_CLASSES.put("io.netty.channel.epoll.EpollEventLoopGroup", "io.netty.channel.epoll.EpollDatagramChannel");
         DATAGRAM_CHANNEL_CLASSES.put("io.netty.channel.kqueue.KQueueEventLoopGroup", "io.netty.channel.kqueue.KQueueDatagramChannel");
     }

--- a/pushy/src/main/java/com/turo/pushy/apns/server/ServerChannelClassUtil.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/server/ServerChannelClassUtil.java
@@ -35,7 +35,6 @@ class ServerChannelClassUtil {
 
     static {
         SERVER_SOCKET_CHANNEL_CLASSES.put("io.netty.channel.nio.NioEventLoopGroup", "io.netty.channel.socket.nio.NioServerSocketChannel");
-        SERVER_SOCKET_CHANNEL_CLASSES.put("io.netty.channel.oio.OioEventLoopGroup", "io.netty.channel.socket.oio.OioServerSocketChannel");
         SERVER_SOCKET_CHANNEL_CLASSES.put("io.netty.channel.epoll.EpollEventLoopGroup", "io.netty.channel.epoll.EpollServerSocketChannel");
         SERVER_SOCKET_CHANNEL_CLASSES.put("io.netty.channel.kqueue.KQueueEventLoopGroup", "io.netty.channel.kqueue.KQueueServerSocketChannel");
     }

--- a/pushy/src/test/java/com/turo/pushy/apns/ClientChannelClassUtilTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/ClientChannelClassUtilTest.java
@@ -9,11 +9,8 @@ import io.netty.channel.kqueue.KQueueDatagramChannel;
 import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.kqueue.KQueueSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.oio.OioEventLoopGroup;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.channel.socket.oio.OioDatagramChannel;
-import io.netty.channel.socket.oio.OioSocketChannel;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -24,14 +21,11 @@ public class ClientChannelClassUtilTest {
     @Test
     public void testGetCoreSocketChannelClass() {
         final NioEventLoopGroup nioEventLoopGroup = new NioEventLoopGroup(1);
-        final OioEventLoopGroup oioEventLoopGroup = new OioEventLoopGroup(1);
 
         try {
             assertEquals(NioSocketChannel.class, ClientChannelClassUtil.getSocketChannelClass(nioEventLoopGroup));
-            assertEquals(OioSocketChannel.class, ClientChannelClassUtil.getSocketChannelClass(oioEventLoopGroup));
         } finally {
             nioEventLoopGroup.shutdownGracefully();
-            oioEventLoopGroup.shutdownGracefully();
         }
     }
 
@@ -70,14 +64,11 @@ public class ClientChannelClassUtilTest {
     @Test
     public void testGetCoreDatagramChannelClass() {
         final NioEventLoopGroup nioEventLoopGroup = new NioEventLoopGroup(1);
-        final OioEventLoopGroup oioEventLoopGroup = new OioEventLoopGroup(1);
 
         try {
             assertEquals(NioDatagramChannel.class, ClientChannelClassUtil.getDatagramChannelClass(nioEventLoopGroup));
-            assertEquals(OioDatagramChannel.class, ClientChannelClassUtil.getDatagramChannelClass(oioEventLoopGroup));
         } finally {
             nioEventLoopGroup.shutdownGracefully();
-            oioEventLoopGroup.shutdownGracefully();
         }
     }
 

--- a/pushy/src/test/java/com/turo/pushy/apns/server/ServerChannelClassUtilTest.java
+++ b/pushy/src/test/java/com/turo/pushy/apns/server/ServerChannelClassUtilTest.java
@@ -7,9 +7,7 @@ import io.netty.channel.kqueue.KQueue;
 import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.kqueue.KQueueServerSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.oio.OioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.netty.channel.socket.oio.OioServerSocketChannel;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -20,14 +18,11 @@ public class ServerChannelClassUtilTest {
     @Test
     public void testGetCoreSocketChannelClass() {
         final NioEventLoopGroup nioEventLoopGroup = new NioEventLoopGroup(1);
-        final OioEventLoopGroup oioEventLoopGroup = new OioEventLoopGroup(1);
 
         try {
             assertEquals(NioServerSocketChannel.class, ServerChannelClassUtil.getServerSocketChannelClass(nioEventLoopGroup));
-            assertEquals(OioServerSocketChannel.class, ServerChannelClassUtil.getServerSocketChannelClass(oioEventLoopGroup));
         } finally {
             nioEventLoopGroup.shutdownGracefully();
-            oioEventLoopGroup.shutdownGracefully();
         }
     }
 


### PR DESCRIPTION
I can't imagine that anybody was actually using OIO for anything. It's also been deprecated upstream, so now seems like as good a time as any to drop it.