### PR TITLE
Proactively rotate authentication tokens before the server complains

### DIFF
--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsChannelFactory.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsChannelFactory.java
@@ -85,7 +85,7 @@ class ApnsChannelFactory implements PooledObjectFactory<Channel>, Closeable {
         }
     }
 
-    ApnsChannelFactory(final SslContext sslContext, final ApnsSigningKey signingKey,
+    ApnsChannelFactory(final SslContext sslContext, final ApnsSigningKey signingKey, final long tokenExpirationMillis,
                        final ProxyHandlerFactory proxyHandlerFactory, final int connectTimeoutMillis,
                        final long idlePingIntervalMillis, final long gracefulShutdownTimeoutMillis,
                        final Http2FrameLogger frameLogger, final InetSocketAddress apnsServerAddress,
@@ -134,6 +134,7 @@ class ApnsChannelFactory implements PooledObjectFactory<Channel>, Closeable {
                             if (signingKey != null) {
                                 clientHandlerBuilder = new TokenAuthenticationApnsClientHandler.TokenAuthenticationApnsClientHandlerBuilder()
                                         .signingKey(signingKey)
+                                        .tokenExpirationMillis(tokenExpirationMillis)
                                         .authority(authority)
                                         .idlePingIntervalMillis(idlePingIntervalMillis);
                             } else {

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClient.java
@@ -130,11 +130,11 @@ public class ApnsClient {
     }
 
     protected ApnsClient(final InetSocketAddress apnsServerAddress, final SslContext sslContext,
-                         final ApnsSigningKey signingKey, final ProxyHandlerFactory proxyHandlerFactory,
-                         final int connectTimeoutMillis, final long idlePingIntervalMillis,
-                         final long gracefulShutdownTimeoutMillis, final int concurrentConnections,
-                         final ApnsClientMetricsListener metricsListener, final Http2FrameLogger frameLogger,
-                         final EventLoopGroup eventLoopGroup) {
+                         final ApnsSigningKey signingKey, final long tokenExpirationMillis,
+                         final ProxyHandlerFactory proxyHandlerFactory,  final int connectTimeoutMillis,
+                         final long idlePingIntervalMillis, final long gracefulShutdownTimeoutMillis,
+                         final int concurrentConnections,  final ApnsClientMetricsListener metricsListener,
+                         final Http2FrameLogger frameLogger, final EventLoopGroup eventLoopGroup) {
 
         if (eventLoopGroup != null) {
             this.eventLoopGroup = eventLoopGroup;
@@ -146,9 +146,9 @@ public class ApnsClient {
 
         this.metricsListener = metricsListener != null ? metricsListener : new NoopApnsClientMetricsListener();
 
-        final ApnsChannelFactory channelFactory = new ApnsChannelFactory(sslContext, signingKey, proxyHandlerFactory,
-                connectTimeoutMillis, idlePingIntervalMillis, gracefulShutdownTimeoutMillis, frameLogger,
-                apnsServerAddress, this.eventLoopGroup);
+        final ApnsChannelFactory channelFactory = new ApnsChannelFactory(sslContext, signingKey, tokenExpirationMillis,
+                proxyHandlerFactory,  connectTimeoutMillis, idlePingIntervalMillis, gracefulShutdownTimeoutMillis,
+                frameLogger, apnsServerAddress, this.eventLoopGroup);
 
         final ApnsChannelPoolMetricsListener channelPoolMetricsListener = new ApnsChannelPoolMetricsListener() {
 

--- a/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/turo/pushy/apns/ApnsClientHandler.java
@@ -202,7 +202,7 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
                 this.unattachedResponsePromisesByStreamId.put(streamId, responsePromise);
                 final ApnsPushNotification pushNotification = responsePromise.getPushNotification();
 
-                final Http2Headers headers = getHeadersForPushNotification(pushNotification, streamId);
+                final Http2Headers headers = getHeadersForPushNotification(pushNotification, context, streamId);
 
                 final ChannelPromise headersPromise = context.newPromise();
                 this.encoder().writeHeaders(context, streamId, headers, 0, false, headersPromise);
@@ -230,7 +230,7 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
         }
     }
 
-    protected Http2Headers getHeadersForPushNotification(final ApnsPushNotification pushNotification, final int streamId) {
+    protected Http2Headers getHeadersForPushNotification(final ApnsPushNotification pushNotification, final ChannelHandlerContext context, final int streamId) {
         final Http2Headers headers = new DefaultHttp2Headers()
                 .method(HttpMethod.POST.asciiName())
                 .authority(this.authority)


### PR DESCRIPTION
This fixes #732 by proactively expiring authentication tokens before the server complains that the token has expired. We've learned that the server will throttle connections down to a single concurrent stream if the token expires, and the expectation is that clients should proactively rotate tokens.

@janzar @helle @extraSix does this look good to you folks?