### PR TITLE
Update to netty-tcnative 2.0.29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>2.0.26.Final</version>
+                <version>2.0.29.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.eatthepath</groupId>


### PR DESCRIPTION
This brings us up to netty-tcnative 2.0.29 as a follow-up to #738 (thanks, @DCKcode!). In #738, we discovered an upstream bug that led to a crash under macOS 10.13 and older. The upstream issue has been fixed in netty-tcnative 2.0.29, and it's now safe for us to update.