### PR TITLE
Use `jgitver` to manage versions

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>fr.brouillard.oss</groupId>
+    <artifactId>jgitver-maven-plugin</artifactId>
+    <version>1.9.0</version>
+  </extension>
+</extensions>

--- a/.mvn/jgitver.config.xml
+++ b/.mvn/jgitver.config.xml
@@ -1,0 +1,8 @@
+<configuration xmlns="http://jgitver.github.io/maven/configuration/1.1.0"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://jgitver.github.io/maven/configuration/1.1.0 https://jgitver.github.io/maven/configuration/jgitver-configuration-v1_1_0.xsd">
+
+    <useDirty>true</useDirty>
+    <nonQualifierBranches>main</nonQualifierBranches>
+    <regexVersionTag>pushy-(.+)</regexVersionTag>
+</configuration>

--- a/README.md
+++ b/README.md
@@ -235,6 +235,28 @@ To build a mock server, callers should use a [`MockApnsServerBuilder`](https://p
 
 Callers may also provide a [`MockApnsServerListener`](https://pushy-apns.org/apidocs/0.15/com/eatthepath/pushy/apns/server/MockApnsServerListener.html) when building a mock server; listeners are notified whenever the mock server accepts or rejects a notification from a client.
 
+## Building Pushy
+
+Pushy uses [Maven](https://maven.apache.org/) as its build system. To build Pushy from source:
+
+```shell
+./mvnw clean package
+```
+
+…or to run tests:
+
+```shell
+./mvnw clean test
+```
+
+### For IntelliJ IDEA users
+
+Note that IntelliJ IDEA struggles with multi-module projects that set their versions on the fly (like Pushy). Please see [IDEA-187928](https://youtrack.jetbrains.com/issue/IDEA-187928/Jgitver-not-working-at-all-for-a-multimodule-project) for background and discussion, but in short, IntelliJ users are likely to encounter an error something like:
+
+> Could not find artifact com.eatthepath:pushy:jar:tests:0.15.5-SNAPSHOT
+
+To work around the issue, IntelliJ users can navigate to Settings → Build, Execution, Deployment → Build Tools → Maven → Importing and add `-Djgitver.skip=true` to "VM options for importer."
+
 ## License and status
 
 Pushy is available under the [MIT License](https://github.com/jchambers/pushy/blob/master/LICENSE.md).

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <artifactId>pushy-parent</artifactId>
         <groupId>com.eatthepath</groupId>
-        <version>0.15.5-SNAPSHOT</version>
+        <version>JGITVER</version>
     </parent>
 
     <artifactId>pushy-benchmark</artifactId>

--- a/dropwizard-metrics-listener/pom.xml
+++ b/dropwizard-metrics-listener/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>com.eatthepath</groupId>
         <artifactId>pushy-parent</artifactId>
-        <version>0.15.5-SNAPSHOT</version>
+        <version>JGITVER</version>
     </parent>
 
     <dependencies>

--- a/micrometer-metrics-listener/pom.xml
+++ b/micrometer-metrics-listener/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <artifactId>pushy-parent</artifactId>
         <groupId>com.eatthepath</groupId>
-        <version>0.15.5-SNAPSHOT</version>
+        <version>JGITVER</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>com.eatthepath</groupId>
     <artifactId>pushy-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.15.5-SNAPSHOT</version>
+    <version>JGITVER</version>
 
     <name>Pushy parent</name>
     <description>A Java library for sending APNs (iOS/macOS/Safari) push notifications</description>

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -25,14 +25,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>pushy</artifactId>
-    <version>0.15.5-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>Pushy</name>
 
     <parent>
         <groupId>com.eatthepath</groupId>
         <artifactId>pushy-parent</artifactId>
-        <version>0.15.5-SNAPSHOT</version>
+        <version>JGITVER</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
In support of #617, this change introduces [jgitver](https://github.com/jgitver/jgitver) to set Maven versions based on git tags. This should make some parts of automated builds/releases much easier.