### PR TITLE
Remove pending acquirePromise once chained responseFuture fails

### DIFF
--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsChannelPool.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsChannelPool.java
@@ -178,6 +178,14 @@ class ApnsChannelPool {
                         this.acquireWithinEventExecutor(acquirePromise);
                     }
                 } else {
+                    // If the deferred acquirePromise is cancelled, remove it from pendingAcquisitionPromises
+                    // to allow garbage collection.
+                    acquirePromise.addListener(future -> {
+                        if (future.isCancelled()) {
+                            pendingAcquisitionPromises.remove(acquirePromise);
+                        }
+                    });
+
                     // We don't have any connections ready to go, and don't have any more capacity to create new
                     // channels. Add this acquisition to the queue waiting for channels to become available.
                     pendingAcquisitionPromises.add(acquirePromise);

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClient.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClient.java
@@ -184,7 +184,8 @@ public class ApnsClient {
         if (!this.isClosed.get()) {
             final long start = System.nanoTime();
 
-            this.channelPool.acquire().addListener((GenericFutureListener<Future<Channel>>) acquireFuture -> {
+            Future<Channel> acquirePromise = this.channelPool.acquire();
+            acquirePromise.addListener((GenericFutureListener<Future<Channel>>) acquireFuture -> {
                 if (acquireFuture.isSuccess()) {
                     final Channel channel = acquireFuture.getNow();
 
@@ -207,6 +208,12 @@ public class ApnsClient {
                     ApnsClient.this.metricsListener.handleNotificationAcknowledged(response, end - start);
                 } else {
                     ApnsClient.this.metricsListener.handleWriteFailure(notification.getTopic());
+
+                    // Try cancel acquirePromise if responseFuture fails (e.g. TimeoutException)
+                    // before acquirePromise gets resolved.
+                    if (acquirePromise.isCancellable()) {
+                        acquirePromise.cancel(true);
+                    }
                 }
             });
         } else {


### PR DESCRIPTION
Closes #1094.

First, I have read #1095, and I understand why it was rejected. I agree having a limit on pending requests is out of scope.

---

This PR addresses the "memory leak" in a different way.

Despite that the "memory leak" is "accounted for" and "recoverable", there is still a risk of full service meltdown if the service has very high thoughput and the retained memory grows quickly towards HeapOutOfMemory. Although most likely this will be a user error like a bad certificate etc, the possibility of Apple Server having an outage cannot be entirely ruled out. Having the possibility of APNS server going down causing a client service to have HeapOutOfMemory and bring down that whole service is not acceptable.

In the failure path, if the chained `responseFuture` already fails (e.g. with TimeoutException), the retained `acquirePromise` effectively becomes useless. Even if it recovers and resolves later, the next chained `responseFuture` is already resolved as failure, and the listener on the `acquirePromise` effectively becomes a no-op when attempting to complete a `responseFuture` that already failed.

Holding the `acquirePromise` in memory also holds a `Listener` object, which hold the `responseFuture`, which holds an `Exception`, which holds a `StackTrace`, etc... The total retained memory foot print for just a single `acquirePromise` is about 1.27KB in a failure case.

With that said, as soon as `responseFuture` fails, there is no reason for keeping its `acquirePromise`, therefore we can get rid of it:

1. Listen on `responseFuture`'s failure, and attempt to cancel `acquirePromise` if it is cancellable (not resolved yet).
2. Listen on `acquirePromise`'s cancel event, and remove it from `pendingAcquisitionPromises` to allow GC to collect these unnecessary pending requests immediately.