### PR TITLE
Update to SLF4J 2.0.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,19 +114,16 @@
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
+                <artifactId>slf4j-bom</artifactId>
+                <version>2.0.18</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <!-- Test dependencies -->
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>
                 <version>${junit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-                <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
@@ -146,7 +143,6 @@
     <properties>
         <netty.version>4.1.119.Final</netty.version>
         <junit.version>5.12.1</junit.version>
-        <slf4j.version>1.7.21</slf4j.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
This updates to the latest stable version of SLF4J. It also switches to using a BOM for individual component version management.

This closes #1119.