### PR TITLE
Simplify test matrix and add Java 25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,14 +7,41 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-latest]
-        java: [8, 17, 21]
-        transport: [native, JDK]
-        tls: [native, JDK]
-        # The macos-14 (and presumably newer) runners are using arm64, and Temurin doesn't support Java 8 on arm64
+        # Test JDK transport/TLS provider for all LTS versions of Java on the latest Ubuntu and macOS runners
+        os: [ubuntu-latest, macos-latest]
+        java: [8, 11, 17, 21, 25]
+        transport: [JDK]
+        tls: [JDK]
         exclude:
+          # The macos-14 (and presumably newer) runners are using arm64, and Temurin doesn't support Java 8 on arm64
           - os: macos-latest
             java: 8
+        include:
+          # …but test macOS/Java 8 on an old Intel runner instead
+          - os: macos-13
+            java: 8
+            transport: JDK
+            tls: JDK
+
+          # Test native transport/TLS provider the most and least recent version of Java on each platform to keep the
+          # test matrix manageable. Exhaustive coverage would be best, but ultimately, we're testing somebody else's
+          # stuff rather than our own, and we can aim for a representative sample instead.
+          - os: ubuntu-latest
+            java: 8
+            transport: native
+            tls: native
+          - os: macos-13
+            java: 8
+            transport: native
+            tls: native
+          - os: ubuntu-latest
+            java: 25
+            transport: native
+            tls: native
+          - os: macos-latest
+            java: 25
+            transport: native
+            tls: native
       fail-fast: false
     name: JDK ${{ matrix.java }}, ${{ matrix.os }}, ${{ matrix.transport }} transport, ${{ matrix.tls }} SSL provider
 

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -133,7 +133,6 @@
                     <overview>${basedir}/src/main/java/overview.html</overview>
                     <show>public</show>
                     <links>
-                        <link>https://docs.oracle.com/javase/8/docs/api/</link>
                         <link>https://netty.io/4.1/api/</link>
                     </links>
                 </configuration>


### PR DESCRIPTION
This change shrinks the test matrix significantly by just testing a representative sample of OS/JDK/transport combinations. It also adds Java 25 to the list of LTS releases we test against.

This closes #1118.