### PR TITLE
Update direct dependencies and plugins (including Netty 4.1.133)

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -31,14 +31,14 @@
     </parent>
 
     <artifactId>pushy-benchmark</artifactId>
-    <version>0.15.5-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Pushy benchmarks</name>
 
-    <prerequisites>
-        <maven>3.0</maven>
-    </prerequisites>
+    <properties>
+        <jmh.version>1.37</jmh.version>
+        <uberjar.name>benchmarks</uberjar.name>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -65,16 +65,9 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <version>3.20.0</version>
         </dependency>
     </dependencies>
-
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jmh.version>1.21</jmh.version>
-        <javac.target>1.8</javac.target>
-        <uberjar.name>benchmarks</uberjar.name>
-    </properties>
 
     <build>
         <plugins>

--- a/dropwizard-metrics-listener/pom.xml
+++ b/dropwizard-metrics-listener/pom.xml
@@ -25,7 +25,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>pushy-dropwizard-metrics-listener</artifactId>
-    <version>0.15.5-SNAPSHOT</version>
     <name>Dropwizard Metrics listener for Pushy</name>
     <description>A metrics listener for Pushy that uses the Dropwizard Metrics library for gathering and reporting metrics.</description>
 
@@ -44,7 +43,7 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>4.2.26</version>
+            <version>4.2.38</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -62,8 +61,8 @@
                     <overview>${basedir}/src/main/java/overview.html</overview>
                     <show>public</show>
                     <links>
-                        <link>https://pushy-apns.org/apidocs/0.14/</link>
-                        <link>https://metrics.dropwizard.io/3.1.0/apidocs/</link>
+                        <link>https://pushy-apns.org/apidocs/0.15/</link>
+                        <link>https://www.javadoc.io/doc/io.dropwizard.metrics/metrics-core/4.2.0/</link>
                     </links>
                 </configuration>
             </plugin>

--- a/gson-payload-builder/pom.xml
+++ b/gson-payload-builder/pom.xml
@@ -26,7 +26,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>pushy-gson-payload-builder</artifactId>
-    <version>0.15.5-SNAPSHOT</version>
     <name>Gson APNs payload builder for Pushy</name>
     <description>A payload builder for Pushy that uses Gson to serialize payloads.</description>
 
@@ -45,7 +44,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.9.0</version>
+            <version>2.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -71,8 +70,8 @@
                     <overview>${basedir}/src/main/java/overview.html</overview>
                     <show>public</show>
                     <links>
-                        <link>https://www.javadoc.io/doc/com.google.code.gson/gson/2.8.0/</link>
-                        <link>https://pushy-apns.org/apidocs/0.14/</link>
+                        <link>https://www.javadoc.io/doc/com.google.code.gson/gson/2.14.0/</link>
+                        <link>https://pushy-apns.org/apidocs/0.15/</link>
                     </links>
                 </configuration>
             </plugin>

--- a/jackson-payload-builder/pom.xml
+++ b/jackson-payload-builder/pom.xml
@@ -26,7 +26,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>pushy-jackson-payload-builder</artifactId>
-    <version>0.15.5-SNAPSHOT</version>
     <name>Jackson APNs payload builder for Pushy</name>
     <description>A payload builder for Pushy that uses Jackson to serialize payloads.</description>
 
@@ -45,7 +44,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.14.1</version>
+            <version>2.21.3</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -71,8 +70,8 @@
                     <overview>${basedir}/src/main/java/overview.html</overview>
                     <show>public</show>
                     <links>
-                        <link>https://fasterxml.github.io/jackson-databind/javadoc/2.12/</link>
-                        <link>https://pushy-apns.org/apidocs/0.14/</link>
+                        <link>https://fasterxml.github.io/jackson-databind/javadoc/2.14/</link>
+                        <link>https://pushy-apns.org/apidocs/0.15/</link>
                     </links>
                 </configuration>
             </plugin>

--- a/micrometer-metrics-listener/pom.xml
+++ b/micrometer-metrics-listener/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>1.13.1</version>
+            <version>1.16.5</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -61,17 +61,8 @@
                     <overview>${basedir}/src/main/java/overview.html</overview>
                     <show>public</show>
                     <links>
-                        <link>https://pushy-apns.org/apidocs/0.14/</link>
+                        <link>https://pushy-apns.org/apidocs/0.15/</link>
                     </links>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,23 +89,15 @@
         <dependencies>
             <dependency>
                 <groupId>io.netty</groupId>
-                <artifactId>netty-codec-http2</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-handler-proxy</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-resolver-dns</artifactId>
-                <version>${netty.version}</version>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.133.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>2.0.62.Final</version>
+                <version>2.0.77.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.eatthepath</groupId>
@@ -125,23 +117,10 @@
                 <artifactId>junit-jupiter</artifactId>
                 <version>${junit.version}</version>
             </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-kqueue</artifactId>
-                <version>${netty.version}</version>
-                <classifier>osx-x86_64</classifier>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-epoll</artifactId>
-                <version>${netty.version}</version>
-                <classifier>linux-x86_64</classifier>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <properties>
-        <netty.version>4.1.119.Final</netty.version>
         <junit.version>5.12.1</junit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -113,15 +113,16 @@
             </dependency>
             <!-- Test dependencies -->
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter</artifactId>
-                <version>${junit.version}</version>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.14.4</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <properties>
-        <junit.version>5.12.1</junit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -132,29 +132,30 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>4.2.1</version>
+                    <version>6.0.2</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.15.0</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>8</source>
+                        <target>8</target>
+                        <release>8</release>
                     </configuration>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.4</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.2.8</version>
 
                     <executions>
                         <execution>
@@ -170,7 +171,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.5.0</version>
                     <configuration>
                         <excludes>
                             <exclude>**/.gitignore</exclude>
@@ -181,7 +182,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.12.0</version>
                     <configuration>
                         <source>8</source>
                     </configuration>
@@ -198,13 +199,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.6.2</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.4.0</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>
@@ -218,13 +219,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.2</version>
+                    <version>3.5.5</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.13</version>
+                    <version>1.7.0</version>
 
                     <extensions>true</extensions>
 


### PR DESCRIPTION
This updates all direct dependencies and Maven plugins to their latest versions. This closes #1117.