### PR TITLE
Switch from `nexus-staging-maven-plugin` to `central-publishing-maven-plugin`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,15 @@
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>3.2.8</version>
 
+                    <configuration>
+                        <!-- Prevent gpg from using pinentry programs;
+                        see https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#extra-setup-for-pomxml -->
+                        <gpgArguments>
+                            <arg>--pinentry-mode</arg>
+                            <arg>loopback</arg>
+                        </gpgArguments>
+                    </configuration>
+
                     <executions>
                         <execution>
                             <id>sign-artifacts</id>
@@ -224,16 +233,13 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.7.0</version>
-
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.10.0</version>
                     <extensions>true</extensions>
 
                     <configuration>
-                        <serverId>ossrh</serverId>
-                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        <publishingServerId>central</publishingServerId>
                     </configuration>
                 </plugin>
             </plugins>
@@ -261,8 +267,8 @@
             </plugin>
 
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The [process for releasing artifacts to Maven Central](https://central.sonatype.org/publish/publish-portal-maven/) has changed, and this updates our approach to match.