### PR TITLE
Remove manual dependency-management instructions from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,7 @@ If you use [Maven](http://maven.apache.org/), you can add Pushy to your project 
 </dependency>
 ```
 
-If you don't use Maven (or something else that understands Maven dependencies, like Gradle), you can [download Pushy as a `.jar` file](https://github.com/jchambers/pushy/releases/download/pushy-0.15.6/pushy-0.15.6.jar) and add it to your project directly. You'll also need to make sure you have Pushy's runtime dependencies on your classpath. They are:
-
-- [netty 4.1.133](http://netty.io/)
-- [slf4j 2.0.18](http://www.slf4j.org/) (and possibly an SLF4J binding, as described in the [logging](#logging) section below)
-- [fast-uuid 0.2](https://github.com/jchambers/fast-uuid)
-
-Pushy itself requires Java 8 or newer to build and run. While not required, users may choose to use [netty-native](http://netty.io/wiki/forked-tomcat-native.html) as an SSL provider for enhanced performance. To use a native provider, make sure netty-tcnative is on your classpath. Maven users may add a dependency to their project as follows:
+Pushy requires Java 8 or newer to build and run. While not required, users may choose to use [netty-tcnative](http://netty.io/wiki/forked-tomcat-native.html) as an SSL provider for enhanced performance. To use a native provider, make sure netty-tcnative is on your classpath. Maven users may add a dependency to their project as follows:
 
 ```xml
 <dependency>


### PR DESCRIPTION
I think manual dependency management is probably an _extremely_ niche use case at this point, and folks who really want to do it can find the relevant jar files on their own.