### PR TITLE
Remove fast-uuid as a dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,11 +90,6 @@
                 <version>2.0.77.Final</version>
             </dependency>
             <dependency>
-                <groupId>com.eatthepath</groupId>
-                <artifactId>fast-uuid</artifactId>
-                <version>0.2.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-bom</artifactId>
                 <version>2.0.18</version>

--- a/pushy/pom.xml
+++ b/pushy/pom.xml
@@ -48,10 +48,6 @@
             <artifactId>netty-resolver-dns</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.eatthepath</groupId>
-            <artifactId>fast-uuid</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/ApnsClientHandler.java
@@ -24,7 +24,6 @@ package com.eatthepath.pushy.apns;
 
 import com.eatthepath.json.JsonParser;
 import com.eatthepath.pushy.apns.util.concurrent.PushNotificationFuture;
-import com.eatthepath.uuid.FastUUID;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -236,7 +235,7 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
         }
 
         if (pushNotification.getApnsId() != null) {
-            headers.add(APNS_ID_HEADER, FastUUID.toString(pushNotification.getApnsId()));
+            headers.add(APNS_ID_HEADER, pushNotification.getApnsId().toString());
         }
 
         return headers;
@@ -338,7 +337,7 @@ class ApnsClientHandler extends Http2ConnectionHandler implements Http2FrameList
         final CharSequence uuidSequence = headers.get(header);
 
         try {
-            return uuidSequence != null ? FastUUID.parseUUID(uuidSequence) : null;
+            return uuidSequence != null ? UUID.fromString(uuidSequence.toString()) : null;
         } catch (final IllegalArgumentException e) {
             log.error("Failed to parse `{}` header: {}", header, uuidSequence, e);
             return null;

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/SimplePushNotificationResponse.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/SimplePushNotificationResponse.java
@@ -22,8 +22,6 @@
 
 package com.eatthepath.pushy.apns;
 
-import com.eatthepath.uuid.FastUUID;
-
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -92,8 +90,8 @@ class SimplePushNotificationResponse<T extends ApnsPushNotification> implements 
         return "SimplePushNotificationResponse{" +
                 "pushNotification=" + pushNotification +
                 ", success=" + success +
-                ", apnsId=" + (apnsId != null ? FastUUID.toString(apnsId) : null) +
-                ", apnsUniqueId=" + getApnsUniqueId().map(FastUUID::toString).orElse(null) +
+                ", apnsId=" + apnsId +
+                ", apnsUniqueId=" + getApnsUniqueId() +
                 ", rejectionReason='" + rejectionReason + '\'' +
                 ", tokenExpirationTimestamp=" + tokenExpirationTimestamp +
                 '}';

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/server/MockApnsServerHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/server/MockApnsServerHandler.java
@@ -23,7 +23,6 @@
 package com.eatthepath.pushy.apns.server;
 
 import com.eatthepath.json.JsonSerializer;
-import com.eatthepath.uuid.FastUUID;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
@@ -277,7 +276,7 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
             UUID apnsIdFromHeaders;
 
             try {
-                apnsIdFromHeaders = apnsIdSequence != null ? FastUUID.parseUUID(apnsIdSequence) : UUID.randomUUID();
+                apnsIdFromHeaders = apnsIdSequence != null ? UUID.fromString(apnsIdSequence.toString()) : UUID.randomUUID();
             } catch (final IllegalArgumentException e) {
                 log.error("Failed to parse `apns-id` header: {}", apnsIdSequence, e);
                 apnsIdFromHeaders = UUID.randomUUID();
@@ -318,10 +317,10 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
 
             final Http2Headers headers = new DefaultHttp2Headers()
                     .status(HttpResponseStatus.OK.codeAsText())
-                    .add(APNS_ID_HEADER, FastUUID.toString(acceptNotificationResponse.getApnsId()));
+                    .add(APNS_ID_HEADER, acceptNotificationResponse.getApnsId().toString());
 
             acceptNotificationResponse.getApnsUniqueId()
-                    .ifPresent(apnsUniqueId -> headers.add(APNS_UNIQUE_ID_HEADER, FastUUID.toString(apnsUniqueId)));
+                    .ifPresent(apnsUniqueId -> headers.add(APNS_UNIQUE_ID_HEADER, apnsUniqueId.toString()));
 
             this.encoder().writeHeaders(context, acceptNotificationResponse.getStreamId(), headers, 0, true, writePromise);
 
@@ -332,10 +331,10 @@ class MockApnsServerHandler extends Http2ConnectionHandler implements Http2Frame
             final Http2Headers headers = new DefaultHttp2Headers()
                     .status(rejectNotificationResponse.getErrorReason().getHttpResponseStatus().codeAsText())
                     .add(HttpHeaderNames.CONTENT_TYPE, "application/json")
-                    .add(APNS_ID_HEADER, FastUUID.toString(rejectNotificationResponse.getApnsId()));
+                    .add(APNS_ID_HEADER, rejectNotificationResponse.getApnsId().toString());
 
             rejectNotificationResponse.getApnsUniqueId()
-                    .ifPresent(apnsUniqueId -> headers.add(APNS_UNIQUE_ID_HEADER, FastUUID.toString(apnsUniqueId)));
+                    .ifPresent(apnsUniqueId -> headers.add(APNS_UNIQUE_ID_HEADER, apnsUniqueId.toString()));
 
             final byte[] payloadBytes;
             {

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/server/ParsingMockApnsServerListenerAdapter.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/server/ParsingMockApnsServerListenerAdapter.java
@@ -25,7 +25,6 @@ package com.eatthepath.pushy.apns.server;
 import com.eatthepath.pushy.apns.ApnsPushNotification;
 import com.eatthepath.pushy.apns.DeliveryPriority;
 import com.eatthepath.pushy.apns.PushType;
-import com.eatthepath.uuid.FastUUID;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.util.AsciiString;
@@ -173,7 +172,7 @@ public abstract class ParsingMockApnsServerListenerAdapter implements MockApnsSe
             UUID apnsIdFromHeaders;
 
             try {
-                apnsIdFromHeaders = apnsIdSequence != null ? FastUUID.parseUUID(apnsIdSequence) : null;
+                apnsIdFromHeaders = apnsIdSequence != null ? UUID.fromString(apnsIdSequence.toString()) : null;
             } catch (final IllegalArgumentException e) {
                 log.error("Failed to parse `apns-id` header: {}", apnsIdSequence, e);
                 apnsIdFromHeaders = null;

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandler.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandler.java
@@ -24,7 +24,6 @@ package com.eatthepath.pushy.apns.server;
 
 import com.eatthepath.pushy.apns.DeliveryPriority;
 import com.eatthepath.pushy.apns.PushType;
-import com.eatthepath.uuid.FastUUID;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http2.Http2Headers;
@@ -34,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -66,7 +66,7 @@ abstract class ValidatingPushNotificationHandler implements PushNotificationHand
             final CharSequence apnsIdSequence = headers.get(APNS_ID_HEADER);
 
             if (apnsIdSequence != null) {
-                FastUUID.parseUUID(apnsIdSequence);
+                UUID.fromString(apnsIdSequence.toString());
             }
         } catch (final IllegalArgumentException e) {
             throw new RejectedNotificationException(RejectionReason.BAD_MESSAGE_ID);

--- a/pushy/src/main/java/com/eatthepath/pushy/apns/util/SimpleApnsPushNotification.java
+++ b/pushy/src/main/java/com/eatthepath/pushy/apns/util/SimpleApnsPushNotification.java
@@ -25,7 +25,6 @@ package com.eatthepath.pushy.apns.util;
 import com.eatthepath.pushy.apns.ApnsPushNotification;
 import com.eatthepath.pushy.apns.DeliveryPriority;
 import com.eatthepath.pushy.apns.PushType;
-import com.eatthepath.uuid.FastUUID;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -325,7 +324,7 @@ public class SimpleApnsPushNotification implements ApnsPushNotification {
                 ", pushType=" + pushType +
                 ", topic='" + topic + '\'' +
                 ", collapseId='" + collapseId + '\'' +
-                ", apnsId=" + (apnsId != null ? FastUUID.toString(apnsId) : null) +
+                ", apnsId=" + apnsId +
                 '}';
     }
 }

--- a/pushy/src/test/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerTest.java
+++ b/pushy/src/test/java/com/eatthepath/pushy/apns/server/ValidatingPushNotificationHandlerTest.java
@@ -23,7 +23,6 @@
 package com.eatthepath.pushy.apns.server;
 
 import com.eatthepath.pushy.apns.DeliveryPriority;
-import com.eatthepath.uuid.FastUUID;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.handler.codec.http.HttpMethod;
@@ -38,7 +37,8 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public abstract class ValidatingPushNotificationHandlerTest {
 


### PR DESCRIPTION
I think it's time to drop `fast-uuid` as a dependency. It's been integrated into the JDK (hooray!) for a while, and now the stock `UUID` serializers/parsers are _at least_ as fast as what `fast-uuid` could do. There's still some benefit to using `fast-uuid` for folks stuck on older JDK versions, but I think almost everybody has moved on at this point, and more people will benefit from removing `fast-uuid` than from keeping it.